### PR TITLE
fix(ci): release + docker after FUSE workspace additions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,7 +81,8 @@ jobs:
 
       - name: Strip binary
         run: |
-          BIN=packages/fuse-helper/target/${{ matrix.target }}/release/agent-fs-fuse
+          # Cargo workspace at repo root -> target/ lives at workspace root, not the crate dir.
+          BIN=target/${{ matrix.target }}/release/agent-fs-fuse
           ls -lh "$BIN"
           # `strip` from binutils works for both x86_64 and aarch64 ELF on the runner.
           strip "$BIN" || true
@@ -90,7 +91,7 @@ jobs:
       - name: Stage binary into sub-package
         run: |
           mkdir -p ${{ matrix.pkg_dir }}/bin
-          cp packages/fuse-helper/target/${{ matrix.target }}/release/agent-fs-fuse \
+          cp target/${{ matrix.target }}/release/agent-fs-fuse \
              ${{ matrix.pkg_dir }}/bin/agent-fs-fuse
           chmod +x ${{ matrix.pkg_dir }}/bin/agent-fs-fuse
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,12 @@ COPY packages/core/package.json packages/core/
 COPY packages/cli/package.json packages/cli/
 COPY packages/mcp/package.json packages/mcp/
 COPY packages/server/package.json packages/server/
+# fuse-helper sub-packages are workspace members; bun needs their manifests to
+# resolve the lockfile cleanly (`--frozen-lockfile` fails otherwise). The
+# binaries themselves aren't needed inside this image — the daemon container
+# never mounts FUSE.
+COPY packages/fuse-helper-linux-x64/package.json packages/fuse-helper-linux-x64/
+COPY packages/fuse-helper-linux-arm64/package.json packages/fuse-helper-linux-arm64/
 RUN bun install --frozen-lockfile
 
 COPY . .
@@ -19,6 +25,8 @@ COPY --from=builder /app/packages/core/package.json packages/core/
 COPY --from=builder /app/packages/cli/package.json packages/cli/
 COPY --from=builder /app/packages/mcp/package.json packages/mcp/
 COPY --from=builder /app/packages/server/package.json packages/server/
+COPY --from=builder /app/packages/fuse-helper-linux-x64/package.json packages/fuse-helper-linux-x64/
+COPY --from=builder /app/packages/fuse-helper-linux-arm64/package.json packages/fuse-helper-linux-arm64/
 RUN bun install --frozen-lockfile --production
 COPY --from=builder /app/packages/cli/dist/ packages/cli/dist/
 


### PR DESCRIPTION
## Summary

The 0.6.0 release + Docker + Fly all failed after the FUSE mount PR landed. Two root causes:

1. **`npm-publish` build-fuse**: cross-built binary lives at workspace-root `target/`, not `packages/fuse-helper/target/`. The Cargo workspace at the repo root pulls outputs there regardless of where `cross build` is invoked. The Strip binary step couldn't find the file and crashed with exit 2. Both matrix entries fixed to use the workspace path.

2. **Docker / Fly `bun install --frozen-lockfile`**: The Dockerfile only `COPY`s the four legacy sub-package manifests. `bun.lock` now references two new workspace members (`fuse-helper-linux-x64`, `fuse-helper-linux-arm64`), so inside the build context those packages appear missing and the lockfile is considered stale. Added the two `COPY` lines to both stages. The daemon image never mounts FUSE — only the manifests are needed for lockfile consistency.

## Test plan

- [x] `bun install` locally (no lockfile changes — confirms the workspace state matches)
- [ ] Re-tag and push `v0.6.0` after merge → watch the release workflow build/publish cleanly
- [ ] Verify the next Docker + Fly runs pass on the new main