### PR TITLE
fix(ci): externalize msgpackr + cd before npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -141,12 +141,15 @@ jobs:
           chmod +x packages/fuse-helper-linux-arm64/bin/agent-fs-fuse
 
       - name: Publish linux-x64 sub-package
-        run: npm publish packages/fuse-helper-linux-x64 --provenance --access public
+        # `cd` into the package — npm 10+ parses a path like "packages/x" as a
+        # `<gh-user>/<repo>` short-spec and tries to git-clone it. Run from
+        # inside the dir so npm sees a local package.
+        run: cd packages/fuse-helper-linux-x64 && npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish linux-arm64 sub-package
-        run: npm publish packages/fuse-helper-linux-arm64 --provenance --access public
+        run: cd packages/fuse-helper-linux-arm64 && npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:npm": "bun build src/index.ts --outfile dist/cli.js --target bun --minify --external sqlite-vec --external node-llama-cpp --external @aws-sdk/client-s3 --external @google/genai --external openai --external commander --external diff --external drizzle-orm --external chonkie --external zod --external @modelcontextprotocol/sdk --external hono",
+    "build:npm": "bun build src/index.ts --outfile dist/cli.js --target bun --minify --external sqlite-vec --external node-llama-cpp --external @aws-sdk/client-s3 --external @google/genai --external openai --external commander --external diff --external drizzle-orm --external chonkie --external zod --external @modelcontextprotocol/sdk --external hono --external msgpackr",
     "prepublishOnly": "bun run build:npm"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary

After PR #13 fixed the obvious lockfile + binary-path issues, the v0.6.0 re-release surfaced two more failures:

- **Publish Docker Image** (arm64 stage): `bun run build` crashed with `File not found "/app/node_modules/.bun/msgpackr@1.11.12/node_modules/msgpackr-extract"`. Bun's bundler tries to follow `msgpackr → msgpackr-extract` (a native sibling that's supposed to be optional) and dies when the platform binary isn't materialized. Same family of issue we already worked around for `sqlite-vec`, `node-llama-cpp`, etc.
- **Release & Publish** (publish-fuse-subpackages): `npm publish packages/fuse-helper-linux-x64 --provenance --access public` failed with \`npm error command git --no-replace-objects ls-remote ssh://git@github.com/packages/fuse-helper-linux-x64.git\`. npm 10+ parses a path containing `/` as a `<gh-user>/<repo>` shortcut and tries to git-clone it. We need to invoke it from inside the package dir so the spec resolves as the local package.json.

Fly deploy went green on the previous push, so this PR doesn't touch it.

## Changes
- `packages/cli/package.json` — add `--external msgpackr` to `build:npm`
- `.github/workflows/npm-publish.yml` — `cd <pkg> && npm publish` for both linux-x64 and linux-arm64 sub-packages

## Test plan
- [x] `bun run build` locally succeeds with msgpackr externalized
- [ ] CI green
- [ ] Re-tag v0.6.0 after merge → both subpackages published, main package published, Docker image published