### PR TITLE
Multi-tenant RBAC safety: enforce explicit roles across HTTP, MCP, raw/FUSE, and comments

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "author": {
     "name": "desplega-ai"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-fs-fuse"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-fs-fuse"
-version = "0.7.2"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "bytes",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -80,6 +80,8 @@ curl -X POST http://localhost:7433/orgs/<orgId>/ops \
   -d '{"op": "write", "path": "/hello.md", "content": "# Hello"}'
 ```
 
+An optional `driveId` field targets a specific drive. The drive **must belong to `{orgId}`** — a `driveId` from another org returns `404 NOT_FOUND`, the same response as a nonexistent drive, so drive IDs cannot be probed across tenants. Each op requires a minimum drive role (see [Access control](#access-control)).
+
 See the [OpenAPI spec](./openapi.json) for the full schema of each operation, or browse it interactively:
 
 - **Live endpoint**: `GET /docs/openapi.json` (when server is running)
@@ -103,6 +105,22 @@ curl http://localhost:7433/orgs/<orgId>/drives/<driveId>/files/assets/logo.png/r
 ```
 
 The raw route preserves bytes exactly. Text indexing runs only for valid, indexable UTF-8 payloads.
+
+`PUT /raw` requires the **editor** role (or better) on the target drive — viewers get `403 PERMISSION_DENIED`, matching the JSON `write` op. `GET /raw` is viewer-accessible. As with the ops route, the `driveId` in the path must belong to the `orgId` in the path; mismatches return `404`.
+
+## Access control
+
+All routes authenticate via API key and authorize against explicit memberships:
+
+- **Strict drive membership** — a drive is only visible and accessible to users with an explicit drive membership row. Creating a drive grants the creator an admin membership automatically.
+- **Per-op role gates** — read ops (`ls`, `cat`, `search`, `signed-url`, ...) require `viewer`; write ops (`write`, `edit`, `append`, `rm`, `mv`, `cp`, `revert`, `comment-add`, ...) require `editor`; `reindex` requires `admin`.
+- **Member management is admin-only** — inviting, listing, updating, and removing org members requires org `admin`. Drive member routes require drive `admin` or admin of the owning org.
+- **No existence oracle** — requests that reference an org or drive you have no access to return `404`, identical to the response for IDs that don't exist.
+- **Scoped comment IDs** — comment IDs only resolve within the org/drive context they were created in; cross-tenant IDs return `404`.
+
+### Signed URLs are bearer secrets
+
+The `signed-url` op is viewer-accessible and RBAC is checked **only at generation time**. The returned URL is a presigned S3 URL: it requires no authentication and grants download access to **anyone who has it** until it expires (default 24h, max 7 days). Treat signed URLs like bearer tokens — don't log them, don't post them anywhere you wouldn't post a credential, and use the shortest expiry that works (`expiresIn`).
 
 ## Operations
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,6 +129,13 @@ Users have roles per-organization and per-drive:
 | `editor` | Read + write, edit, delete files |
 | `admin` | Full access + manage users, drives, orgs |
 
+Key rules:
+
+- **Drive membership is explicit.** A drive is only visible and usable for users with a drive membership row. New drives grant the creator admin membership automatically; invite other users per drive (or rely on org-invite's default-drive grant).
+- **Member management is admin-only.** Inviting, listing, updating, and removing org members requires org `admin`. Managing drive members requires drive `admin` or admin of the owning org. Creating drives in an org requires org `admin`.
+- **Write paths all enforce editor-or-better** — the JSON ops route, the binary `PUT /raw` route, and FUSE mounts share the same check. Viewers can read everywhere they're a member but cannot write through any surface.
+- **Org/drive IDs are bound.** A request that addresses a drive under the wrong org — or any org/drive the caller has no membership in — returns `404`, indistinguishable from a nonexistent ID.
+
 ## 4. Multi-Agent, Hosted
 
 Deploy agent-fs as shared infrastructure for autonomous agents.
@@ -155,6 +162,16 @@ curl -X POST http://agent-fs:7433/auth/register -d '{"email": "agent-b@agents.lo
 ```
 
 Each agent gets its own identity, so file operations are attributed to the agent that performed them. Use `log` to see who wrote what.
+
+### Multi-tenant isolation model
+
+When mutually distrustful users or agents share one server, understand what the boundary is — and is not:
+
+- **Isolation is enforced at the application layer** by RBAC: every HTTP, MCP, raw, and FUSE operation proves the caller has an explicit role on the target org/drive before touching data. Cross-tenant org/drive/comment IDs resolve to `404`, so tenants can't probe each other's resources.
+- **Storage is a single shared S3 bucket**, namespaced by `<orgId>/drives/<driveId>/...` key prefixes. There is no per-tenant bucket, credential, or encryption key — anyone holding the *server's* S3 credentials (or the server's SQLite DB) can read all tenants' data. Tenant isolation holds only as long as the server host and its credentials are trusted.
+- **Signed URLs are an intentional escape hatch.** Generation is RBAC-checked (viewer-or-better on the drive), but the resulting presigned S3 URL is an unauthenticated bearer secret until it expires. A tenant who shares a signed URL is sharing read access to that file with anyone who has the URL.
+
+If you need isolation that survives a server-credential leak, run separate agent-fs instances (or buckets) per tenant.
 
 ## Embedding Providers
 

--- a/docs/fuse-mount.md
+++ b/docs/fuse-mount.md
@@ -135,10 +135,15 @@ agent-fs exposes operational signal at well-known paths so agents can self-diagn
 | `cp` (within mount) | Yes | Two ops: read + write |
 | `mkdir`, `rmdir` (inside a drive) | Yes | Versions still tracked per file |
 | `mkdir` at mount root | No (`EROFS`) | Use `agent-fs drive create` |
+| Writes on a drive where you're a `viewer` | No (`EACCES`) | All FUSE writes require the `editor` role or better — see below |
 | `chmod`, `chown` | No (`ENOSYS` / no-op) | agent-fs has no POSIX permissions model |
 | `flock`, `fcntl` locks | No (`ENOSYS`) | Use `--expected-version` for optimistic concurrency |
 | Streaming large files (>50 MB) | Partial | The 50 MB Hono body limit caps a single PUT; streaming-into-S3 is v1.x |
 | Extended attributes (`xattr`) | No | Read-only xattr window is v1.1 (`user.agent-fs.{version, content-hash, ...}`) |
+
+### Write permissions
+
+FUSE writes enforce the same RBAC as the JSON `write` op and `PUT /raw`: opening a file for write, creating a file, or truncating requires the **editor** role (or better) on the drive. On a drive where you're a `viewer`, the mount is effectively **read-only for file writes** — write attempts fail with `EACCES`, and the denial is recorded in `<mount>/.agent-fs/errors.ndjson` with `http_status: 403` and `error: "PERMISSION_DENIED"`. Reads (`cat`, `grep`, `find`, ...) work with any role.
 
 ## See also
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -119,6 +119,18 @@ The server advertises tools via the standard MCP `tools/list` method.
 | `comment-delete` | Soft-delete a comment (author only). |
 | `comment-resolve` | Resolve or reopen a root comment. |
 
+### Identity & Member Management
+
+| Tool | Description |
+|------|-------------|
+| `whoami` | Get current user identity, org memberships, and drive roles. Lists only drives you're an explicit member of. |
+| `member-list` | List members of the current org, or of a drive in the current org via `driveId`. |
+| `member-invite` | Invite an existing agent-fs user to the current org by email. |
+| `member-update-role` | Update a member's org role, or drive role via `driveId`. |
+| `member-remove` | Remove a member from the current org (cascades to drives), or from one drive via `driveId`. |
+
+Member tools are admin-gated, mirroring the HTTP member routes: org-scoped calls require org `admin`; drive-scoped calls require drive `admin` or admin of the owning org. A `driveId` must belong to your active org — drive IDs from other orgs return "not found", and authorization runs before any email lookup, so non-admins can't probe whether an account or drive exists.
+
 ## Which Search Tool Should I Use?
 
 agent-fs has three search tools for different use cases:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.7.5",
+    "version": "0.8.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/landing/public/docs/api-reference.md
+++ b/landing/public/docs/api-reference.md
@@ -80,12 +80,47 @@ curl -X POST http://localhost:7433/orgs/<orgId>/ops \
   -d '{"op": "write", "path": "/hello.md", "content": "# Hello"}'
 ```
 
+An optional `driveId` field targets a specific drive. The drive **must belong to `{orgId}`** — a `driveId` from another org returns `404 NOT_FOUND`, the same response as a nonexistent drive, so drive IDs cannot be probed across tenants. Each op requires a minimum drive role (see [Access control](#access-control)).
+
 See the [OpenAPI spec](./openapi.json) for the full schema of each operation, or browse it interactively:
 
 - **Live endpoint**: `GET /docs/openapi.json` (when server is running)
 - **Static file**: [`docs/openapi.json`](./openapi.json) (committed to repo)
 
 Import either into [Swagger Editor](https://editor.swagger.io) or [Scalar](https://scalar.com) for interactive exploration.
+
+### Raw file bytes
+
+Use the raw file route for binary-safe uploads and downloads:
+
+```bash
+curl -X PUT http://localhost:7433/orgs/<orgId>/drives/<driveId>/files/assets/logo.png/raw \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/octet-stream" \
+  --data-binary @logo.png
+
+curl http://localhost:7433/orgs/<orgId>/drives/<driveId>/files/assets/logo.png/raw \
+  -H "Authorization: Bearer <api-key>" \
+  -o logo.png
+```
+
+The raw route preserves bytes exactly. Text indexing runs only for valid, indexable UTF-8 payloads.
+
+`PUT /raw` requires the **editor** role (or better) on the target drive — viewers get `403 PERMISSION_DENIED`, matching the JSON `write` op. `GET /raw` is viewer-accessible. As with the ops route, the `driveId` in the path must belong to the `orgId` in the path; mismatches return `404`.
+
+## Access control
+
+All routes authenticate via API key and authorize against explicit memberships:
+
+- **Strict drive membership** — a drive is only visible and accessible to users with an explicit drive membership row. Creating a drive grants the creator an admin membership automatically.
+- **Per-op role gates** — read ops (`ls`, `cat`, `search`, `signed-url`, ...) require `viewer`; write ops (`write`, `edit`, `append`, `rm`, `mv`, `cp`, `revert`, `comment-add`, ...) require `editor`; `reindex` requires `admin`.
+- **Member management is admin-only** — inviting, listing, updating, and removing org members requires org `admin`. Drive member routes require drive `admin` or admin of the owning org.
+- **No existence oracle** — requests that reference an org or drive you have no access to return `404`, identical to the response for IDs that don't exist.
+- **Scoped comment IDs** — comment IDs only resolve within the org/drive context they were created in; cross-tenant IDs return `404`.
+
+### Signed URLs are bearer secrets
+
+The `signed-url` op is viewer-accessible and RBAC is checked **only at generation time**. The returned URL is a presigned S3 URL: it requires no authentication and grants download access to **anyone who has it** until it expires (default 24h, max 7 days). Treat signed URLs like bearer tokens — don't log them, don't post them anywhere you wouldn't post a credential, and use the shortest expiry that works (`expiresIn`).
 
 ## Operations
 

--- a/landing/public/docs/deployment.md
+++ b/landing/public/docs/deployment.md
@@ -129,6 +129,13 @@ Users have roles per-organization and per-drive:
 | `editor` | Read + write, edit, delete files |
 | `admin` | Full access + manage users, drives, orgs |
 
+Key rules:
+
+- **Drive membership is explicit.** A drive is only visible and usable for users with a drive membership row. New drives grant the creator admin membership automatically; invite other users per drive (or rely on org-invite's default-drive grant).
+- **Member management is admin-only.** Inviting, listing, updating, and removing org members requires org `admin`. Managing drive members requires drive `admin` or admin of the owning org. Creating drives in an org requires org `admin`.
+- **Write paths all enforce editor-or-better** — the JSON ops route, the binary `PUT /raw` route, and FUSE mounts share the same check. Viewers can read everywhere they're a member but cannot write through any surface.
+- **Org/drive IDs are bound.** A request that addresses a drive under the wrong org — or any org/drive the caller has no membership in — returns `404`, indistinguishable from a nonexistent ID.
+
 ## 4. Multi-Agent, Hosted
 
 Deploy agent-fs as shared infrastructure for autonomous agents.
@@ -155,6 +162,16 @@ curl -X POST http://agent-fs:7433/auth/register -d '{"email": "agent-b@agents.lo
 ```
 
 Each agent gets its own identity, so file operations are attributed to the agent that performed them. Use `log` to see who wrote what.
+
+### Multi-tenant isolation model
+
+When mutually distrustful users or agents share one server, understand what the boundary is — and is not:
+
+- **Isolation is enforced at the application layer** by RBAC: every HTTP, MCP, raw, and FUSE operation proves the caller has an explicit role on the target org/drive before touching data. Cross-tenant org/drive/comment IDs resolve to `404`, so tenants can't probe each other's resources.
+- **Storage is a single shared S3 bucket**, namespaced by `<orgId>/drives/<driveId>/...` key prefixes. There is no per-tenant bucket, credential, or encryption key — anyone holding the *server's* S3 credentials (or the server's SQLite DB) can read all tenants' data. Tenant isolation holds only as long as the server host and its credentials are trusted.
+- **Signed URLs are an intentional escape hatch.** Generation is RBAC-checked (viewer-or-better on the drive), but the resulting presigned S3 URL is an unauthenticated bearer secret until it expires. A tenant who shares a signed URL is sharing read access to that file with anyone who has the URL.
+
+If you need isolation that survives a server-credential leak, run separate agent-fs instances (or buckets) per tenant.
 
 ## Embedding Providers
 

--- a/landing/public/docs/fuse-mount.md
+++ b/landing/public/docs/fuse-mount.md
@@ -135,10 +135,15 @@ agent-fs exposes operational signal at well-known paths so agents can self-diagn
 | `cp` (within mount) | Yes | Two ops: read + write |
 | `mkdir`, `rmdir` (inside a drive) | Yes | Versions still tracked per file |
 | `mkdir` at mount root | No (`EROFS`) | Use `agent-fs drive create` |
+| Writes on a drive where you're a `viewer` | No (`EACCES`) | All FUSE writes require the `editor` role or better — see below |
 | `chmod`, `chown` | No (`ENOSYS` / no-op) | agent-fs has no POSIX permissions model |
 | `flock`, `fcntl` locks | No (`ENOSYS`) | Use `--expected-version` for optimistic concurrency |
 | Streaming large files (>50 MB) | Partial | The 50 MB Hono body limit caps a single PUT; streaming-into-S3 is v1.x |
 | Extended attributes (`xattr`) | No | Read-only xattr window is v1.1 (`user.agent-fs.{version, content-hash, ...}`) |
+
+### Write permissions
+
+FUSE writes enforce the same RBAC as the JSON `write` op and `PUT /raw`: opening a file for write, creating a file, or truncating requires the **editor** role (or better) on the drive. On a drive where you're a `viewer`, the mount is effectively **read-only for file writes** — write attempts fail with `EACCES`, and the denial is recorded in `<mount>/.agent-fs/errors.ndjson` with `http_status: 403` and `error: "PERMISSION_DENIED"`. Reads (`cat`, `grep`, `find`, ...) work with any role.
 
 ## See also
 

--- a/landing/public/docs/mcp-setup.md
+++ b/landing/public/docs/mcp-setup.md
@@ -119,6 +119,18 @@ The server advertises tools via the standard MCP `tools/list` method.
 | `comment-delete` | Soft-delete a comment (author only). |
 | `comment-resolve` | Resolve or reopen a root comment. |
 
+### Identity & Member Management
+
+| Tool | Description |
+|------|-------------|
+| `whoami` | Get current user identity, org memberships, and drive roles. Lists only drives you're an explicit member of. |
+| `member-list` | List members of the current org, or of a drive in the current org via `driveId`. |
+| `member-invite` | Invite an existing agent-fs user to the current org by email. |
+| `member-update-role` | Update a member's org role, or drive role via `driveId`. |
+| `member-remove` | Remove a member from the current org (cascades to drives), or from one drive via `driveId`. |
+
+Member tools are admin-gated, mirroring the HTTP member routes: org-scoped calls require org `admin`; drive-scoped calls require drive `admin` or admin of the owning org. A `driveId` must belong to your active org — drive IDs from other orgs return "not found", and authorization runs before any email lookup, so non-admins can't probe whether an account or drive exists.
+
 ## Which Search Tool Should I Use?
 
 agent-fs has three search tools for different use cases:

--- a/landing/public/docs/openapi.json
+++ b/landing/public/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.7.0",
+    "version": "0.8.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.7.5",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.7.5"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.0",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.0"
   },
   "dependencies": {
     "commander": "^14.0.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/src/db/migrate.ts
+++ b/packages/core/src/db/migrate.ts
@@ -31,4 +31,22 @@ export function runMigrations(sqlite: Database): void {
     "CREATE UNIQUE INDEX IF NOT EXISTS file_versions_path_drive_version_uq " +
       "ON file_versions(path, drive_id, version)"
   );
+
+  // Migration 3: backfill explicit drive memberships (multi-tenant RBAC).
+  //
+  // Drive visibility is strict explicit membership: drives with zero
+  // `drive_members` rows are visible to no one. Older DBs may contain
+  // zero-member drives that used to be treated as "public" within the org.
+  // Grant every org admin an explicit 'admin' membership on those drives so
+  // they stay reachable; org admins can then share them explicitly.
+  //
+  // Idempotent: only matches drives that still have zero member rows, and
+  // INSERT OR IGNORE tolerates the (drive_id, user_id) primary key.
+  sqlite.exec(
+    "INSERT OR IGNORE INTO drive_members (drive_id, user_id, role) " +
+      "SELECT d.id, om.user_id, 'admin' " +
+      "FROM drives d " +
+      "JOIN org_members om ON om.org_id = d.org_id AND om.role = 'admin' " +
+      "WHERE NOT EXISTS (SELECT 1 FROM drive_members dm WHERE dm.drive_id = d.id)"
+  );
 }

--- a/packages/core/src/identity/__tests__/identity.test.ts
+++ b/packages/core/src/identity/__tests__/identity.test.ts
@@ -5,11 +5,27 @@ import { tmpdir } from "node:os";
 import { createDatabase, schema } from "../../db/index.js";
 import type { DB } from "../../db/index.js";
 import { createUser, getUserByApiKey, getUserByEmail } from "../users.js";
-import { listUserOrgs, getOrg, inviteToOrg } from "../orgs.js";
-import { listDrives, getDrive, setDriveMember } from "../drives.js";
-import { checkPermission, getRequiredRole, getUserDriveRole } from "../rbac.js";
+import { createOrg, listUserOrgs, getOrg, inviteToOrg } from "../orgs.js";
+import {
+  createDrive,
+  listDrives,
+  listDrivesForUser,
+  getDrive,
+  setDriveMember,
+} from "../drives.js";
+import {
+  checkPermission,
+  getRequiredRole,
+  getUserDriveRole,
+  getUserOrgRole,
+  roleAtLeast,
+  requireDriveRole,
+  requireOrgRole,
+  requireDriveAdmin,
+  assertDriveInOrg,
+} from "../rbac.js";
 import { resolveContext } from "../context.js";
-import { PermissionDeniedError } from "../../errors.js";
+import { NotFoundError, PermissionDeniedError } from "../../errors.js";
 
 const TEST_DB = join(tmpdir(), `agent-fs-identity-test-${Date.now()}.db`);
 let db: DB;
@@ -185,5 +201,267 @@ describe("Drive context resolution", () => {
 
     const ctx = resolveContext(db, { userId, driveId: drives[0].id });
     expect(ctx.driveId).toBe(drives[0].id);
+  });
+});
+
+describe("Context org/drive binding", () => {
+  let ownerId: string;
+  let personalOrgId: string;
+  let secondOrgId: string;
+  let secondOrgDriveId: string;
+
+  beforeAll(() => {
+    // Self-sufficient: works standalone under --test-name-pattern.
+    ownerId = createUser(db, { email: "ctx-owner@example.com" }).user.id;
+    personalOrgId = listUserOrgs(db, ownerId).find((o) => o.isPersonal)!.id;
+
+    const secondOrg = createOrg(db, { name: "ctx-second", userId: ownerId });
+    secondOrgId = secondOrg.id;
+    secondOrgDriveId = listDrives(db, secondOrgId)[0].id;
+  });
+
+  test("resolveContext accepts driveId belonging to the given orgId", () => {
+    const ctx = resolveContext(db, {
+      userId: ownerId,
+      orgId: secondOrgId,
+      driveId: secondOrgDriveId,
+    });
+
+    expect(ctx.orgId).toBe(secondOrgId);
+    expect(ctx.driveId).toBe(secondOrgDriveId);
+  });
+
+  test("resolveContext rejects driveId from another org", () => {
+    expect(() =>
+      resolveContext(db, {
+        userId: ownerId,
+        orgId: personalOrgId,
+        driveId: secondOrgDriveId,
+      })
+    ).toThrow(NotFoundError);
+  });
+
+  test("resolveContext rejects unknown driveId", () => {
+    expect(() =>
+      resolveContext(db, { userId: ownerId, driveId: "no-such-drive" })
+    ).toThrow(NotFoundError);
+  });
+});
+
+describe("Strict drive membership", () => {
+  let aliceId: string;
+  let bobId: string;
+  let orgId: string;
+
+  beforeAll(() => {
+    // Self-sufficient: works standalone under --test-name-pattern.
+    aliceId = createUser(db, { email: "strict-owner@example.com" }).user.id;
+    bobId = createUser(db, { email: "strict-peer@example.com" }).user.id;
+    orgId = listUserOrgs(db, aliceId).find((o) => o.isPersonal)!.id;
+    // Peer joins the org (and its default drive) as viewer.
+    inviteToOrg(db, { orgId, email: "strict-peer@example.com", role: "viewer" });
+  });
+
+  test("newly-created drive has explicit creator membership", () => {
+    const drive = createDrive(db, {
+      orgId,
+      name: "with-creator",
+      creatorUserId: aliceId,
+    });
+
+    expect(getUserDriveRole(db, aliceId, drive.id)).toBe("admin");
+
+    const visible = listDrivesForUser(db, orgId, aliceId);
+    expect(visible.some((d) => d.id === drive.id)).toBe(true);
+  });
+
+  test("drive without any membership rows is visible to no one", () => {
+    const drive = createDrive(db, { orgId, name: "zero-members" });
+
+    // Not even the org admin can see it via listDrivesForUser — the old
+    // "zero members means public" fallback is gone.
+    const aliceVisible = listDrivesForUser(db, orgId, aliceId);
+    expect(aliceVisible.some((d) => d.id === drive.id)).toBe(false);
+
+    const bobVisible = listDrivesForUser(db, orgId, bobId);
+    expect(bobVisible.some((d) => d.id === drive.id)).toBe(false);
+
+    // It still exists in the unfiltered org listing.
+    const all = listDrives(db, orgId);
+    expect(all.some((d) => d.id === drive.id)).toBe(true);
+  });
+
+  test("listDrivesForUser excludes drives where user is not a member", () => {
+    const drive = createDrive(db, {
+      orgId,
+      name: "alice-only",
+      creatorUserId: aliceId,
+    });
+
+    const bobVisible = listDrivesForUser(db, orgId, bobId);
+    expect(bobVisible.some((d) => d.id === drive.id)).toBe(false);
+
+    // Explicit membership makes it visible.
+    setDriveMember(db, { driveId: drive.id, userId: bobId, role: "viewer" });
+    const bobVisibleAfter = listDrivesForUser(db, orgId, bobId);
+    expect(bobVisibleAfter.some((d) => d.id === drive.id)).toBe(true);
+  });
+});
+
+describe("Org and drive authorization helpers", () => {
+  let aliceId: string;
+  let bobId: string;
+  let strangerId: string;
+  let orgId: string;
+  let driveId: string;
+
+  beforeAll(() => {
+    // Self-sufficient: works standalone under --test-name-pattern.
+    aliceId = createUser(db, { email: "authz-admin@example.com" }).user.id;
+    bobId = createUser(db, { email: "authz-viewer@example.com" }).user.id;
+    strangerId = createUser(db, { email: "authz-stranger@example.com" }).user.id;
+    orgId = listUserOrgs(db, aliceId).find((o) => o.isPersonal)!.id;
+    driveId = listDrives(db, orgId).find((d) => d.isDefault)!.id;
+    // Bob joins the org (and its default drive) as viewer.
+    inviteToOrg(db, { orgId, email: "authz-viewer@example.com", role: "viewer" });
+  });
+
+  test("roleAtLeast compares role levels", () => {
+    expect(roleAtLeast("admin", "viewer")).toBe(true);
+    expect(roleAtLeast("editor", "editor")).toBe(true);
+    expect(roleAtLeast("viewer", "editor")).toBe(false);
+    expect(roleAtLeast(null, "viewer")).toBe(false);
+    expect(roleAtLeast(undefined, "viewer")).toBe(false);
+  });
+
+  test("getUserOrgRole returns explicit org role or null", () => {
+    expect(getUserOrgRole(db, aliceId, orgId)).toBe("admin");
+    expect(getUserOrgRole(db, bobId, orgId)).toBe("viewer");
+    expect(getUserOrgRole(db, strangerId, orgId)).toBeNull();
+  });
+
+  test("requireOrgRole passes for sufficient role and returns it", () => {
+    expect(requireOrgRole(db, { userId: aliceId, orgId, requiredRole: "admin" })).toBe("admin");
+    expect(requireOrgRole(db, { userId: bobId, orgId, requiredRole: "viewer" })).toBe("viewer");
+  });
+
+  test("requireOrgRole throws for insufficient role or non-member", () => {
+    expect(() =>
+      requireOrgRole(db, { userId: bobId, orgId, requiredRole: "admin" })
+    ).toThrow(PermissionDeniedError);
+
+    expect(() =>
+      requireOrgRole(db, { userId: strangerId, orgId, requiredRole: "viewer" })
+    ).toThrow(PermissionDeniedError);
+  });
+
+  test("requireDriveRole returns the actual role on success", () => {
+    expect(
+      requireDriveRole(db, { userId: aliceId, driveId, requiredRole: "editor" })
+    ).toBe("admin");
+    expect(() =>
+      requireDriveRole(db, { userId: bobId, driveId, requiredRole: "admin" })
+    ).toThrow(PermissionDeniedError);
+  });
+
+  test("requireDriveAdmin passes for explicit drive admin", () => {
+    expect(requireDriveAdmin(db, { userId: aliceId, driveId })).toBe("admin");
+  });
+
+  test("requireDriveAdmin falls back to org admin without drive row", () => {
+    // Alice is org admin; create a drive she has no membership row on.
+    const drive = createDrive(db, { orgId, name: "org-admin-fallback" });
+    expect(getUserDriveRole(db, aliceId, drive.id)).toBeNull();
+
+    expect(requireDriveAdmin(db, { userId: aliceId, driveId: drive.id })).toBe("admin");
+  });
+
+  test("requireDriveAdmin rejects non-admins and unknown drives", () => {
+    // Bob is org viewer and drive viewer — neither satisfies admin.
+    expect(() => requireDriveAdmin(db, { userId: bobId, driveId })).toThrow(
+      PermissionDeniedError
+    );
+    expect(() =>
+      requireDriveAdmin(db, { userId: aliceId, driveId: "no-such-drive" })
+    ).toThrow(NotFoundError);
+  });
+
+  test("assertDriveInOrg binds drive to org", () => {
+    const drive = assertDriveInOrg(db, { driveId, orgId });
+    expect(drive.id).toBe(driveId);
+    expect(drive.orgId).toBe(orgId);
+
+    const otherOrg = createOrg(db, { name: "other-org", userId: aliceId });
+    expect(() =>
+      assertDriveInOrg(db, { driveId, orgId: otherOrg.id })
+    ).toThrow(NotFoundError);
+    expect(() =>
+      assertDriveInOrg(db, { driveId: "no-such-drive", orgId })
+    ).toThrow(NotFoundError);
+  });
+});
+
+describe("Drive membership backfill migration", () => {
+  let carolId: string;
+  let daveId: string;
+  let teamOrgId: string;
+  let teamDefaultDriveId: string;
+  let legacyDriveId: string;
+
+  beforeAll(() => {
+    carolId = createUser(db, { email: "carol@example.com" }).user.id;
+    daveId = createUser(db, { email: "dave@example.com" }).user.id;
+
+    const teamOrg = createOrg(db, { name: "carol-team", userId: carolId });
+    teamOrgId = teamOrg.id;
+    teamDefaultDriveId = listDrives(db, teamOrgId).find((d) => d.isDefault)!.id;
+
+    // Dave joins as org editor (also gets editor on the default drive).
+    inviteToOrg(db, { orgId: teamOrgId, email: "dave@example.com", role: "editor" });
+
+    // Simulate a pre-strict-membership drive: zero member rows.
+    legacyDriveId = createDrive(db, { orgId: teamOrgId, name: "legacy" }).id;
+  });
+
+  test("backfills empty drive members for org admins", () => {
+    // Before backfill: invisible to everyone under strict membership.
+    expect(
+      listDrivesForUser(db, teamOrgId, carolId).some((d) => d.id === legacyDriveId)
+    ).toBe(false);
+    expect(getUserDriveRole(db, carolId, legacyDriveId)).toBeNull();
+
+    // Re-running createDatabase on the same file re-runs migrations.
+    createDatabase(TEST_DB);
+
+    // Org admin carol got an explicit admin row; org editor dave did not.
+    expect(getUserDriveRole(db, carolId, legacyDriveId)).toBe("admin");
+    expect(getUserDriveRole(db, daveId, legacyDriveId)).toBeNull();
+
+    expect(
+      listDrivesForUser(db, teamOrgId, carolId).some((d) => d.id === legacyDriveId)
+    ).toBe(true);
+    expect(
+      listDrivesForUser(db, teamOrgId, daveId).some((d) => d.id === legacyDriveId)
+    ).toBe(false);
+  });
+
+  test("backfill does not touch drives that already have members", () => {
+    // Default drive memberships are unchanged: carol admin, dave editor.
+    expect(getUserDriveRole(db, carolId, teamDefaultDriveId)).toBe("admin");
+    expect(getUserDriveRole(db, daveId, teamDefaultDriveId)).toBe("editor");
+  });
+
+  test("backfill is idempotent", () => {
+    createDatabase(TEST_DB);
+
+    const rows = db
+      .select()
+      .from(schema.driveMembers)
+      .where(require("drizzle-orm").eq(schema.driveMembers.driveId, legacyDriveId))
+      .all();
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].userId).toBe(carolId);
+    expect(rows[0].role).toBe("admin");
   });
 });

--- a/packages/core/src/identity/__tests__/identity.test.ts
+++ b/packages/core/src/identity/__tests__/identity.test.ts
@@ -116,6 +116,41 @@ describe("Org & invite flow", () => {
     const bobOrgs = listUserOrgs(db, bobId);
     expect(bobOrgs.some((o) => o.id === orgId && o.role === "viewer")).toBe(true);
   });
+
+  test("inviteToOrg grants membership on the isDefault drive even when a non-default drive sorts first", () => {
+    // Self-sufficient: fresh org whose FIRST drives row (by insertion order)
+    // is non-default. Demote the auto-created default drive, then create a
+    // new default one — the old unfiltered "first row" query picks the wrong
+    // drive here.
+    const ownerId = createUser(db, { email: "invite-default-owner@example.com" })
+      .user.id;
+    const org = createOrg(db, { name: "invite-default-org", userId: ownerId });
+    const firstDriveId = listDrives(db, org.id)[0].id;
+
+    db.update(schema.drives)
+      .set({ isDefault: false })
+      .where(require("drizzle-orm").eq(schema.drives.id, firstDriveId))
+      .run();
+    const realDefault = createDrive(db, {
+      orgId: org.id,
+      name: "real-default",
+      isDefault: true,
+      creatorUserId: ownerId,
+    });
+
+    const inviteeId = createUser(db, {
+      email: "invite-default-peer@example.com",
+    }).user.id;
+    inviteToOrg(db, {
+      orgId: org.id,
+      email: "invite-default-peer@example.com",
+      role: "editor",
+    });
+
+    // Granted on the isDefault drive — not whichever row happens to come first.
+    expect(getUserDriveRole(db, inviteeId, realDefault.id)).toBe("editor");
+    expect(getUserDriveRole(db, inviteeId, firstDriveId)).toBeNull();
+  });
 });
 
 describe("RBAC enforcement", () => {
@@ -305,6 +340,75 @@ describe("Strict drive membership", () => {
     setDriveMember(db, { driveId: drive.id, userId: bobId, role: "viewer" });
     const bobVisibleAfter = listDrivesForUser(db, orgId, bobId);
     expect(bobVisibleAfter.some((d) => d.id === drive.id)).toBe(true);
+  });
+
+  test("resolveContext for an inaccessible drive is indistinguishable from a missing drive", () => {
+    // Alice-only drive: bob (org viewer) has no membership row on it.
+    const hidden = createDrive(db, {
+      orgId,
+      name: "bob-cannot-see",
+      creatorUserId: aliceId,
+    });
+
+    const capture = (fn: () => unknown): NotFoundError => {
+      try {
+        fn();
+      } catch (err) {
+        expect(err).toBeInstanceOf(NotFoundError);
+        return err as NotFoundError;
+      }
+      throw new Error("expected resolveContext to throw");
+    };
+
+    const missingId = "00000000-0000-4000-8000-000000000000";
+    const missingErr = capture(() =>
+      resolveContext(db, { userId: bobId, driveId: missingId })
+    );
+    const hiddenErr = capture(() =>
+      resolveContext(db, { userId: bobId, driveId: hidden.id })
+    );
+
+    // Byte-identical modulo the caller-supplied driveId (no existence oracle).
+    expect(hiddenErr.message).toBe(
+      missingErr.message.replaceAll(missingId, hidden.id)
+    );
+    expect(JSON.stringify(hiddenErr.toJSON())).toBe(
+      JSON.stringify(missingErr.toJSON()).replaceAll(missingId, hidden.id)
+    );
+
+    // Same holds when the org is pinned (the /orgs/:orgId/ops shape).
+    const missingOrgErr = capture(() =>
+      resolveContext(db, { userId: bobId, orgId, driveId: missingId })
+    );
+    const hiddenOrgErr = capture(() =>
+      resolveContext(db, { userId: bobId, orgId, driveId: hidden.id })
+    );
+    expect(JSON.stringify(hiddenOrgErr.toJSON())).toBe(
+      JSON.stringify(missingOrgErr.toJSON()).replaceAll(missingId, hidden.id)
+    );
+  });
+
+  test("resolveContext via orgId hides an inaccessible default drive", () => {
+    // Org member with no membership row on the org's default drive: joins via
+    // a raw org_members insert (inviteToOrg would grant the drive role).
+    const orgOnlyId = createUser(db, {
+      email: "strict-org-only@example.com",
+    }).user.id;
+    db.insert(schema.orgMembers)
+      .values({ orgId, userId: orgOnlyId, role: "viewer" })
+      .run();
+
+    try {
+      resolveContext(db, { userId: orgOnlyId, orgId });
+      expect(true).toBe(false); // Should not reach here
+    } catch (err) {
+      // NotFound (404), with the same message as an org without a default
+      // drive — neither the drive's existence nor its id leaks.
+      expect(err).toBeInstanceOf(NotFoundError);
+      expect((err as NotFoundError).message).toBe(
+        `No default drive for org: ${orgId}`
+      );
+    }
   });
 });
 

--- a/packages/core/src/identity/context.ts
+++ b/packages/core/src/identity/context.ts
@@ -34,8 +34,17 @@ export function resolveContext(
       });
     }
 
+    // No role on an existing drive must be indistinguishable from a drive
+    // that does not exist — same error type and byte-identical message as
+    // the missing/cross-org branch above (no intra-org existence oracle).
     const role = getUserDriveRole(db, params.userId, params.driveId);
-    if (!role) throw new Error("You do not have access to this drive");
+    if (!role) {
+      throw new NotFoundError(`Drive not found: ${params.driveId}`, {
+        suggestion: params.orgId
+          ? "Check the driveId belongs to the org you are addressing"
+          : undefined,
+      });
+    }
 
     return { orgId: drive.orgId, driveId: params.driveId, role };
   }
@@ -53,10 +62,15 @@ export function resolveContext(
       )
       .get();
 
-    if (!drive) throw new Error(`No default drive for org: ${params.orgId}`);
+    if (!drive)
+      throw new NotFoundError(`No default drive for org: ${params.orgId}`);
 
+    // A default drive the user has no role on must be indistinguishable from
+    // the org having no default drive at all — same error, and no leak of the
+    // drive's id to non-members.
     const role = getUserDriveRole(db, params.userId, drive.id);
-    if (!role) throw new Error("You do not have access to this drive");
+    if (!role)
+      throw new NotFoundError(`No default drive for org: ${params.orgId}`);
 
     return { orgId: params.orgId, driveId: drive.id, role };
   }

--- a/packages/core/src/identity/context.ts
+++ b/packages/core/src/identity/context.ts
@@ -1,6 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { schema } from "../db/index.js";
 import type { DB } from "../db/index.js";
+import { NotFoundError } from "../errors.js";
 import type { Role } from "./rbac.js";
 import { getUserDriveRole } from "./rbac.js";
 
@@ -22,7 +23,16 @@ export function resolveContext(
       .where(eq(schema.drives.id, params.driveId))
       .get();
 
-    if (!drive) throw new Error(`Drive not found: ${params.driveId}`);
+    // When the caller also pinned an org (e.g. route /orgs/:orgId/ops),
+    // the drive MUST belong to that org. Reject mismatches with the same
+    // error as "missing" so cross-tenant callers cannot probe existence.
+    if (!drive || (params.orgId && drive.orgId !== params.orgId)) {
+      throw new NotFoundError(`Drive not found: ${params.driveId}`, {
+        suggestion: params.orgId
+          ? "Check the driveId belongs to the org you are addressing"
+          : undefined,
+      });
+    }
 
     const role = getUserDriveRole(db, params.userId, params.driveId);
     if (!role) throw new Error("You do not have access to this drive");

--- a/packages/core/src/identity/drives.ts
+++ b/packages/core/src/identity/drives.ts
@@ -4,7 +4,17 @@ import type { DB } from "../db/index.js";
 
 export function createDrive(
   db: DB,
-  params: { orgId: string; name: string; isDefault?: boolean }
+  params: {
+    orgId: string;
+    name: string;
+    isDefault?: boolean;
+    /**
+     * When provided, the creator gets an explicit 'admin' drive membership
+     * row. Under strict membership (drives are only visible to explicit
+     * members) every user-facing creation path should pass this.
+     */
+    creatorUserId?: string;
+  }
 ): { id: string; name: string } {
   const id = crypto.randomUUID();
   const now = new Date();
@@ -18,6 +28,12 @@ export function createDrive(
       createdAt: now,
     })
     .run();
+
+  if (params.creatorUserId) {
+    db.insert(schema.driveMembers)
+      .values({ driveId: id, userId: params.creatorUserId, role: "admin" })
+      .run();
+  }
 
   return { id, name: params.name };
 }
@@ -37,12 +53,11 @@ export function listDrives(
 /**
  * List drives in an org that the user can see.
  *
- * A drive is visible to the user iff one of:
- *   1. The drive has at least one row in `drive_members` and one of those
- *      rows references this user, OR
- *   2. The drive has NO rows in `drive_members` (treated as "public" to
- *      anyone in the org — preserves the existing default-drive bootstrap
- *      where the org is created without an explicit member row).
+ * Strict explicit membership: a drive is visible to the user iff the user
+ * has a row in `drive_members` for that drive. Drives with zero member
+ * rows are visible to NO ONE (the old "public drive" fallback is gone —
+ * creation paths add an explicit creator membership, and `runMigrations()`
+ * backfills org admins onto pre-existing zero-member drives).
  *
  * The FUSE mount uses this to populate its root readdir without seeing
  * drives it can't access.
@@ -52,28 +67,24 @@ export function listDrivesForUser(
   orgId: string,
   userId: string
 ): Array<{ id: string; name: string; isDefault: boolean }> {
-  // Pull all drives in the org first; partition them client-side. Tiny
-  // tables, no need to fold this into one query.
-  const drives = db
-    .select()
-    .from(schema.drives)
-    .where(eq(schema.drives.orgId, orgId))
-    .all();
-
-  // For each drive, decide visibility.
-  return drives
-    .filter((d) => {
-      const memberRows = db
-        .select({ userId: schema.driveMembers.userId })
-        .from(schema.driveMembers)
-        .where(eq(schema.driveMembers.driveId, d.id))
-        .all();
-
-      if (memberRows.length === 0) {
-        return true; // public drive
-      }
-      return memberRows.some((m) => m.userId === userId);
+  return db
+    .select({
+      id: schema.drives.id,
+      name: schema.drives.name,
+      isDefault: schema.drives.isDefault,
     })
+    .from(schema.drives)
+    .innerJoin(
+      schema.driveMembers,
+      eq(schema.driveMembers.driveId, schema.drives.id)
+    )
+    .where(
+      and(
+        eq(schema.drives.orgId, orgId),
+        eq(schema.driveMembers.userId, userId)
+      )
+    )
+    .all()
     .map((d) => ({ id: d.id, name: d.name, isDefault: d.isDefault }));
 }
 

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -1,7 +1,17 @@
 export { createUser, getUserByApiKey, getUserByEmail } from "./users.js";
 export { createOrg, listUserOrgs, getOrg, inviteToOrg, listOrgMembers, updateOrgMemberRole, removeOrgMember } from "./orgs.js";
 export { createDrive, listDrives, listDrivesForUser, getDrive, setDriveMember, listDriveMembers, updateDriveMemberRole, removeDriveMember } from "./drives.js";
-export { checkPermission, getRequiredRole, getUserDriveRole } from "./rbac.js";
+export {
+  checkPermission,
+  getRequiredRole,
+  getUserDriveRole,
+  getUserOrgRole,
+  roleAtLeast,
+  requireDriveRole,
+  requireOrgRole,
+  requireDriveAdmin,
+  assertDriveInOrg,
+} from "./rbac.js";
 export type { Role } from "./rbac.js";
 export { resolveContext } from "./context.js";
 export type { ResolvedContext } from "./context.js";

--- a/packages/core/src/identity/orgs.ts
+++ b/packages/core/src/identity/orgs.ts
@@ -24,12 +24,13 @@ export function createOrg(
     .values({ orgId: id, userId: params.userId, role: "admin" })
     .run();
 
-  // Create default drive and add creator as admin
-  const drive = createDrive(db, { orgId: id, name: "default", isDefault: true });
-
-  db.insert(schema.driveMembers)
-    .values({ driveId: drive.id, userId: params.userId, role: "admin" })
-    .run();
+  // Create default drive with explicit creator admin membership
+  createDrive(db, {
+    orgId: id,
+    name: "default",
+    isDefault: true,
+    creatorUserId: params.userId,
+  });
 
   return { id, name: params.name };
 }

--- a/packages/core/src/identity/orgs.ts
+++ b/packages/core/src/identity/orgs.ts
@@ -241,7 +241,12 @@ export function inviteToOrg(
   const defaultDrive = db
     .select()
     .from(schema.drives)
-    .where(eq(schema.drives.orgId, params.orgId))
+    .where(
+      and(
+        eq(schema.drives.orgId, params.orgId),
+        eq(schema.drives.isDefault, true)
+      )
+    )
     .get();
 
   if (defaultDrive) {

--- a/packages/core/src/identity/rbac.ts
+++ b/packages/core/src/identity/rbac.ts
@@ -1,7 +1,7 @@
 import { eq, and } from "drizzle-orm";
 import { schema } from "../db/index.js";
 import type { DB } from "../db/index.js";
-import { PermissionDeniedError } from "../errors.js";
+import { NotFoundError, PermissionDeniedError } from "../errors.js";
 
 export type Role = "viewer" | "editor" | "admin";
 
@@ -47,6 +47,34 @@ export function getRequiredRole(opName: string): Role {
   return OP_ROLES[opName] ?? "admin";
 }
 
+/** True when `role` is present and at least as privileged as `required`. */
+export function roleAtLeast(
+  role: Role | null | undefined,
+  required: Role
+): boolean {
+  if (!role) return false;
+  return ROLE_LEVELS[role] >= ROLE_LEVELS[required];
+}
+
+export function getUserOrgRole(
+  db: DB,
+  userId: string,
+  orgId: string
+): Role | null {
+  const member = db
+    .select()
+    .from(schema.orgMembers)
+    .where(
+      and(
+        eq(schema.orgMembers.orgId, orgId),
+        eq(schema.orgMembers.userId, userId)
+      )
+    )
+    .get();
+
+  return (member?.role as Role) ?? null;
+}
+
 export function getUserDriveRole(
   db: DB,
   userId: string,
@@ -66,10 +94,14 @@ export function getUserDriveRole(
   return (member?.role as Role) ?? null;
 }
 
-export function checkPermission(
+/**
+ * Require an explicit drive membership with at least `requiredRole`.
+ * Returns the user's actual drive role on success.
+ */
+export function requireDriveRole(
   db: DB,
   params: { userId: string; driveId: string; requiredRole: Role }
-): void {
+): Role {
   const userRole = getUserDriveRole(db, params.userId, params.driveId);
 
   if (!userRole) {
@@ -93,4 +125,113 @@ export function checkPermission(
       }
     );
   }
+
+  return userRole;
+}
+
+export function checkPermission(
+  db: DB,
+  params: { userId: string; driveId: string; requiredRole: Role }
+): void {
+  requireDriveRole(db, params);
+}
+
+/**
+ * Require an explicit org membership with at least `requiredRole`.
+ * Returns the user's actual org role on success.
+ */
+export function requireOrgRole(
+  db: DB,
+  params: { userId: string; orgId: string; requiredRole: Role }
+): Role {
+  const userRole = getUserOrgRole(db, params.userId, params.orgId);
+
+  if (!userRole) {
+    throw new PermissionDeniedError(
+      "You do not have access to this organization",
+      {
+        requiredRole: params.requiredRole,
+        yourRole: "none",
+        suggestion: "Request access from an org admin",
+      }
+    );
+  }
+
+  if (ROLE_LEVELS[userRole] < ROLE_LEVELS[params.requiredRole]) {
+    throw new PermissionDeniedError(
+      `This operation requires '${params.requiredRole}' role in the org, but you have '${userRole}'`,
+      {
+        requiredRole: params.requiredRole,
+        yourRole: userRole,
+        suggestion: "Ask an org admin to upgrade your role",
+      }
+    );
+  }
+
+  return userRole;
+}
+
+/**
+ * Require drive administration rights: an explicit drive 'admin' membership,
+ * or 'admin' membership in the drive's owning org.
+ * Returns the role that satisfied the check.
+ */
+export function requireDriveAdmin(
+  db: DB,
+  params: { userId: string; driveId: string }
+): Role {
+  const drive = db
+    .select()
+    .from(schema.drives)
+    .where(eq(schema.drives.id, params.driveId))
+    .get();
+
+  if (!drive) {
+    throw new NotFoundError(`Drive not found: ${params.driveId}`);
+  }
+
+  const driveRole = getUserDriveRole(db, params.userId, params.driveId);
+  if (driveRole === "admin") return driveRole;
+
+  const orgRole = getUserOrgRole(db, params.userId, drive.orgId);
+  if (orgRole === "admin") return orgRole;
+
+  throw new PermissionDeniedError(
+    "This operation requires drive admin or org admin role",
+    {
+      requiredRole: "admin",
+      yourRole: driveRole ?? orgRole ?? "none",
+      suggestion: "Ask a drive or org admin to perform this operation",
+    }
+  );
+}
+
+/**
+ * Assert that `driveId` exists and belongs to `orgId`.
+ * Throws NotFoundError otherwise (same error for "missing" and "wrong org"
+ * so cross-tenant callers cannot probe drive existence).
+ * Returns the drive on success.
+ */
+export function assertDriveInOrg(
+  db: DB,
+  params: { driveId: string; orgId: string }
+): { id: string; orgId: string; name: string; isDefault: boolean } {
+  const drive = db
+    .select()
+    .from(schema.drives)
+    .where(eq(schema.drives.id, params.driveId))
+    .get();
+
+  if (!drive || drive.orgId !== params.orgId) {
+    throw new NotFoundError(`Drive not found in org: ${params.driveId}`, {
+      suggestion: "Check the driveId belongs to the org you are addressing",
+    });
+  }
+
+  return {
+    id: drive.id,
+    orgId: drive.orgId,
+    name: drive.name,
+    isDefault: drive.isDefault,
+  };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,6 +86,12 @@ export {
   checkPermission,
   getRequiredRole,
   getUserDriveRole,
+  getUserOrgRole,
+  roleAtLeast,
+  requireDriveRole,
+  requireOrgRole,
+  requireDriveAdmin,
+  assertDriveInOrg,
   resolveContext,
   ensureLocalUser,
 } from "./identity/index.js";

--- a/packages/core/src/ops/__tests__/comment.test.ts
+++ b/packages/core/src/ops/__tests__/comment.test.ts
@@ -18,11 +18,17 @@ import { NotFoundError, ValidationError, PermissionDeniedError } from "../../err
 const TEST_DB = join(tmpdir(), `agent-fs-comment-test-${Date.now()}.db`);
 const ORG_ID = "test-org";
 const DRIVE_ID = "test-drive";
+const OTHER_DRIVE_ID = "test-drive-2";
+const OTHER_ORG_ID = "other-org";
+const OTHER_ORG_DRIVE_ID = "other-org-drive";
 const USER_A = "user-a";
 const USER_B = "user-b";
+const USER_C = "user-c";
 
 let ctx: OpContext;
 let ctxB: OpContext;
+let ctxOtherDrive: OpContext;
+let ctxOtherOrg: OpContext;
 
 beforeAll(() => {
   const db = createDatabase(TEST_DB);
@@ -31,17 +37,28 @@ beforeAll(() => {
   // Seed FK data
   db.insert(schema.users).values({ id: USER_A, email: "a@test.com", apiKeyHash: "a", createdAt: now }).run();
   db.insert(schema.users).values({ id: USER_B, email: "b@test.com", apiKeyHash: "b", createdAt: now }).run();
+  db.insert(schema.users).values({ id: USER_C, email: "c@test.com", apiKeyHash: "c", createdAt: now }).run();
   db.insert(schema.orgs).values({ id: ORG_ID, name: "Test Org", createdAt: now }).run();
+  db.insert(schema.orgs).values({ id: OTHER_ORG_ID, name: "Other Org", createdAt: now }).run();
   db.insert(schema.drives).values({ id: DRIVE_ID, orgId: ORG_ID, name: "default", isDefault: true, createdAt: now }).run();
+  db.insert(schema.drives).values({ id: OTHER_DRIVE_ID, orgId: ORG_ID, name: "second", isDefault: false, createdAt: now }).run();
+  db.insert(schema.drives).values({ id: OTHER_ORG_DRIVE_ID, orgId: OTHER_ORG_ID, name: "default", isDefault: true, createdAt: now }).run();
   db.insert(schema.orgMembers).values({ orgId: ORG_ID, userId: USER_A, role: "admin" }).run();
   db.insert(schema.orgMembers).values({ orgId: ORG_ID, userId: USER_B, role: "editor" }).run();
+  db.insert(schema.orgMembers).values({ orgId: OTHER_ORG_ID, userId: USER_C, role: "admin" }).run();
   db.insert(schema.driveMembers).values({ driveId: DRIVE_ID, userId: USER_A, role: "admin" }).run();
   db.insert(schema.driveMembers).values({ driveId: DRIVE_ID, userId: USER_B, role: "editor" }).run();
+  db.insert(schema.driveMembers).values({ driveId: OTHER_DRIVE_ID, userId: USER_A, role: "admin" }).run();
+  db.insert(schema.driveMembers).values({ driveId: OTHER_ORG_DRIVE_ID, userId: USER_C, role: "admin" }).run();
 
   // S3 client is not used by comment ops — pass null cast
   const nullS3 = null as any;
   ctx = { db, s3: nullS3, orgId: ORG_ID, driveId: DRIVE_ID, userId: USER_A };
   ctxB = { db, s3: nullS3, orgId: ORG_ID, driveId: DRIVE_ID, userId: USER_B };
+  // Same user/org, different drive — must not see DRIVE_ID comments
+  ctxOtherDrive = { db, s3: nullS3, orgId: ORG_ID, driveId: OTHER_DRIVE_ID, userId: USER_A };
+  // Different org entirely — must not see ORG_ID comments
+  ctxOtherOrg = { db, s3: nullS3, orgId: OTHER_ORG_ID, driveId: OTHER_ORG_DRIVE_ID, userId: USER_C };
 }, 30_000);
 
 afterAll(() => {
@@ -307,5 +324,109 @@ describe("events", () => {
     expect(types).toContain("comment_created");
     expect(types).toContain("comment_resolved");
     expect(types).toContain("comment_deleted");
+  });
+});
+
+describe("cross-tenant comment scoping", () => {
+  test("cross-tenant comment IDs are not found", async () => {
+    const root = await commentAdd(ctx, {
+      path: "/docs/tenant.md",
+      body: "Drive A comment",
+    });
+
+    // Same org, different drive — every ID-based op must behave as if the
+    // comment does not exist (NotFoundError, never PermissionDeniedError,
+    // even though USER_A is the author).
+    expect(commentGet(ctxOtherDrive, { id: root.id })).rejects.toThrow(NotFoundError);
+    expect(commentUpdate(ctxOtherDrive, { id: root.id, body: "hijack" })).rejects.toThrow(NotFoundError);
+    expect(commentDelete(ctxOtherDrive, { id: root.id })).rejects.toThrow(NotFoundError);
+    expect(commentResolve(ctxOtherDrive, { id: root.id, resolved: true })).rejects.toThrow(NotFoundError);
+    expect(commentAdd(ctxOtherDrive, { parentId: root.id, body: "cross-drive reply" })).rejects.toThrow(NotFoundError);
+
+    // Different org — same behavior
+    expect(commentGet(ctxOtherOrg, { id: root.id })).rejects.toThrow(NotFoundError);
+    expect(commentUpdate(ctxOtherOrg, { id: root.id, body: "hijack" })).rejects.toThrow(NotFoundError);
+    expect(commentDelete(ctxOtherOrg, { id: root.id })).rejects.toThrow(NotFoundError);
+    expect(commentResolve(ctxOtherOrg, { id: root.id, resolved: true })).rejects.toThrow(NotFoundError);
+    expect(commentAdd(ctxOtherOrg, { parentId: root.id, body: "cross-org reply" })).rejects.toThrow(NotFoundError);
+
+    // The comment is untouched in its own drive
+    const stillThere = await commentGet(ctx, { id: root.id });
+    expect(stillThere.comment.body).toBe("Drive A comment");
+    expect(stillThere.comment.resolved).toBe(false);
+  });
+
+  test("cross-drive comments do not appear in list or inline replies", async () => {
+    const root = await commentAdd(ctx, {
+      path: "/docs/tenant-list.md",
+      body: "Drive A root",
+    });
+    const legitReply = await commentAdd(ctxB, {
+      parentId: root.id,
+      body: "Legit same-drive reply",
+    });
+
+    // Forge a reply row pointing at the drive-A root but living in another
+    // drive (simulates tampered or legacy data) — scoped reply queries must
+    // exclude it.
+    const now = new Date();
+    ctx.db
+      .insert(schema.comments)
+      .values({
+        id: "forged-cross-drive-reply",
+        parentId: root.id,
+        orgId: ORG_ID,
+        driveId: OTHER_DRIVE_ID,
+        path: "/docs/tenant-list.md",
+        body: "Forged cross-drive reply",
+        author: USER_A,
+        resolved: false,
+        createdAt: now,
+        updatedAt: now,
+        isDeleted: false,
+      })
+      .run();
+
+    // commentList from another drive at the same path sees nothing
+    const otherDriveList = await commentList(ctxOtherDrive, { path: "/docs/tenant-list.md" });
+    expect(otherDriveList.comments.map((c) => c.id)).not.toContain(root.id);
+
+    // commentGet excludes the forged reply from replies and replyCount
+    const got = await commentGet(ctx, { id: root.id });
+    expect(got.comment.replyCount).toBe(1);
+    expect(got.replies.map((r) => r.id)).toEqual([legitReply.id]);
+
+    // commentList inline replies exclude the forged reply too
+    const list = await commentList(ctx, { path: "/docs/tenant-list.md" });
+    const rootEntry = list.comments.find((c) => c.id === root.id);
+    expect(rootEntry).toBeDefined();
+    expect(rootEntry!.replies.map((r) => r.id)).toEqual([legitReply.id]);
+
+    // Deleting the root cascades only within the drive — forged row untouched
+    await commentDelete(ctx, { id: root.id });
+    const forged = ctx.db
+      .select()
+      .from(schema.comments)
+      .where(eq(schema.comments.id, "forged-cross-drive-reply"))
+      .get();
+    expect(forged!.isDeleted).toBe(false);
+  });
+
+  test("author-only comment mutations still apply", async () => {
+    const added = await commentAdd(ctx, {
+      path: "/docs/tenant-author.md",
+      body: "By user A",
+    });
+
+    // Same drive, non-author: still PermissionDeniedError (not NotFound)
+    expect(commentUpdate(ctxB, { id: added.id, body: "By user B" })).rejects.toThrow(PermissionDeniedError);
+    expect(commentDelete(ctxB, { id: added.id })).rejects.toThrow(PermissionDeniedError);
+
+    // Author can still update and delete within the same drive
+    const updated = await commentUpdate(ctx, { id: added.id, body: "Edited by author" });
+    expect(updated.body).toBe("Edited by author");
+
+    const deleted = await commentDelete(ctx, { id: added.id });
+    expect(deleted.deleted).toBe(true);
   });
 });

--- a/packages/core/src/ops/comment.ts
+++ b/packages/core/src/ops/comment.ts
@@ -50,6 +50,27 @@ function emitEvent(
 
 // --- Helpers ---
 
+/**
+ * Fetch a live (non-deleted) comment by ID, scoped to the active org and
+ * drive. Out-of-scope comment IDs behave exactly like missing IDs (callers
+ * throw NotFoundError), so comment IDs never act as a cross-tenant
+ * existence oracle.
+ */
+function getScopedComment(ctx: OpContext, id: string) {
+  return ctx.db
+    .select()
+    .from(schema.comments)
+    .where(
+      and(
+        eq(schema.comments.id, id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId),
+        eq(schema.comments.isDeleted, false)
+      )
+    )
+    .get();
+}
+
 function toCommentEntry(row: any): CommentEntry {
   return {
     id: row.id,
@@ -81,17 +102,8 @@ export async function commentAdd(
   let path = params.path;
 
   if (params.parentId) {
-    // Resolve parent
-    const parent = ctx.db
-      .select()
-      .from(schema.comments)
-      .where(
-        and(
-          eq(schema.comments.id, params.parentId),
-          eq(schema.comments.isDeleted, false)
-        )
-      )
-      .get();
+    // Resolve parent (scoped to the active org/drive)
+    const parent = getScopedComment(ctx, params.parentId);
 
     if (!parent) {
       throw new NotFoundError("Parent comment not found", {
@@ -177,6 +189,7 @@ export async function commentList(
   params: CommentListParams
 ): Promise<CommentListResult> {
   const conditions = [
+    eq(schema.comments.orgId, ctx.orgId),
     eq(schema.comments.driveId, ctx.driveId),
     eq(schema.comments.isDeleted, false),
   ];
@@ -212,7 +225,7 @@ export async function commentList(
     .offset(offset)
     .all();
 
-  // Fetch replies inline for each root comment
+  // Fetch replies inline for each root comment (scoped to the active org/drive)
   const comments: CommentListEntry[] = rows.map((row) => {
     const replyRows = ctx.db
       .select()
@@ -220,6 +233,8 @@ export async function commentList(
       .where(
         and(
           eq(schema.comments.parentId, row.id),
+          eq(schema.comments.orgId, ctx.orgId),
+          eq(schema.comments.driveId, ctx.driveId),
           eq(schema.comments.isDeleted, false)
         )
       )
@@ -241,16 +256,7 @@ export async function commentGet(
   ctx: OpContext,
   params: CommentGetParams
 ): Promise<CommentGetResult> {
-  const row = ctx.db
-    .select()
-    .from(schema.comments)
-    .where(
-      and(
-        eq(schema.comments.id, params.id),
-        eq(schema.comments.isDeleted, false)
-      )
-    )
-    .get();
+  const row = getScopedComment(ctx, params.id);
 
   if (!row) {
     throw new NotFoundError("Comment not found", {
@@ -258,13 +264,15 @@ export async function commentGet(
     });
   }
 
-  // Count replies for the main comment
+  // Count replies for the main comment (scoped to the active org/drive)
   const replyCount = ctx.db
     .select({ count: sql<number>`count(*)` })
     .from(schema.comments)
     .where(
       and(
         eq(schema.comments.parentId, row.id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId),
         eq(schema.comments.isDeleted, false)
       )
     )
@@ -275,13 +283,15 @@ export async function commentGet(
     replyCount: replyCount?.count ?? 0,
   });
 
-  // Fetch replies
+  // Fetch replies (scoped to the active org/drive)
   const replyRows = ctx.db
     .select()
     .from(schema.comments)
     .where(
       and(
         eq(schema.comments.parentId, params.id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId),
         eq(schema.comments.isDeleted, false)
       )
     )
@@ -297,16 +307,7 @@ export async function commentUpdate(
   ctx: OpContext,
   params: CommentUpdateParams
 ): Promise<CommentUpdateResult> {
-  const row = ctx.db
-    .select()
-    .from(schema.comments)
-    .where(
-      and(
-        eq(schema.comments.id, params.id),
-        eq(schema.comments.isDeleted, false)
-      )
-    )
-    .get();
+  const row = getScopedComment(ctx, params.id);
 
   if (!row) {
     throw new NotFoundError("Comment not found", {
@@ -324,7 +325,13 @@ export async function commentUpdate(
   ctx.db
     .update(schema.comments)
     .set({ body: params.body, updatedAt: now })
-    .where(eq(schema.comments.id, params.id))
+    .where(
+      and(
+        eq(schema.comments.id, params.id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId)
+      )
+    )
     .run();
 
   return { id: params.id, body: params.body, updatedAt: now };
@@ -334,16 +341,7 @@ export async function commentDelete(
   ctx: OpContext,
   params: CommentDeleteParams
 ): Promise<CommentDeleteResult> {
-  const row = ctx.db
-    .select()
-    .from(schema.comments)
-    .where(
-      and(
-        eq(schema.comments.id, params.id),
-        eq(schema.comments.isDeleted, false)
-      )
-    )
-    .get();
+  const row = getScopedComment(ctx, params.id);
 
   if (!row) {
     throw new NotFoundError("Comment not found", {
@@ -359,19 +357,31 @@ export async function commentDelete(
 
   const now = new Date();
 
-  // Soft-delete the comment
+  // Soft-delete the comment (scoped to the active org/drive)
   ctx.db
     .update(schema.comments)
     .set({ isDeleted: true, updatedAt: now })
-    .where(eq(schema.comments.id, params.id))
+    .where(
+      and(
+        eq(schema.comments.id, params.id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId)
+      )
+    )
     .run();
 
-  // If root comment, also soft-delete all replies
+  // If root comment, also soft-delete all replies (scoped to the active org/drive)
   if (!row.parentId) {
     ctx.db
       .update(schema.comments)
       .set({ isDeleted: true, updatedAt: now })
-      .where(eq(schema.comments.parentId, params.id))
+      .where(
+        and(
+          eq(schema.comments.parentId, params.id),
+          eq(schema.comments.orgId, ctx.orgId),
+          eq(schema.comments.driveId, ctx.driveId)
+        )
+      )
       .run();
   }
 
@@ -388,16 +398,7 @@ export async function commentResolve(
   ctx: OpContext,
   params: CommentResolveParams
 ): Promise<CommentResolveResult> {
-  const row = ctx.db
-    .select()
-    .from(schema.comments)
-    .where(
-      and(
-        eq(schema.comments.id, params.id),
-        eq(schema.comments.isDeleted, false)
-      )
-    )
-    .get();
+  const row = getScopedComment(ctx, params.id);
 
   if (!row) {
     throw new NotFoundError("Comment not found", {
@@ -423,7 +424,13 @@ export async function commentResolve(
       resolvedAt,
       updatedAt: now,
     })
-    .where(eq(schema.comments.id, params.id))
+    .where(
+      and(
+        eq(schema.comments.id, params.id),
+        eq(schema.comments.orgId, ctx.orgId),
+        eq(schema.comments.driveId, ctx.driveId)
+      )
+    )
     .run();
 
   emitEvent(ctx, {

--- a/packages/core/src/ops/write.ts
+++ b/packages/core/src/ops/write.ts
@@ -8,6 +8,7 @@ import {
 } from "./versioning.js";
 import { detectMimeType } from "./mime.js";
 import { ValidationError } from "../errors.js";
+import { requireDriveRole } from "../identity/rbac.js";
 import { indexBytesForSearch, indexTextForSearch } from "./search-index.js";
 
 /** Max file size: 10 MB. Protects SQLite FTS indexing and embedding costs. */
@@ -33,11 +34,21 @@ export async function write(
  * up to 50 MB (Hono's body limit) instead of the JSON-path 10 MB cap. Bytes
  * are stored unchanged; search indexing runs only when the payload is valid,
  * indexable UTF-8 text.
+ *
+ * RBAC: callers reach this directly (not via `dispatchOp`), so the
+ * editor-or-better requirement that `dispatchOp` enforces for the JSON
+ * `write` op is enforced here instead. The JSON path calls `write()` /
+ * `writeInternal()` and is checked once by the dispatcher — no double check.
  */
 export async function writeRaw(
   ctx: OpContext,
   params: WriteRawParams
 ): Promise<WriteResult> {
+  requireDriveRole(ctx.db, {
+    userId: ctx.userId,
+    driveId: ctx.driveId,
+    requiredRole: "editor",
+  });
   return writeInternal(ctx, params, { maxSize: MAX_RAW_FILE_SIZE });
 }
 

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.7.5"
+version = "0.8.0"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/mcp/src/__tests__/mcp.test.ts
+++ b/packages/mcp/src/__tests__/mcp.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { getRegisteredOps, getOpDefinition } from "@/core";
+import type { OpContext } from "@/core";
+import { registerIdentityTools } from "../server.js";
+import { createTestDb } from "../../../core/src/test-utils.js";
 
 describe("MCP tool registration", () => {
   test("all ops from registry are available as tools", () => {
@@ -25,5 +28,25 @@ describe("MCP tool registration", () => {
     for (const op of expected) {
       expect(ops).toContain(op);
     }
+  });
+
+  test("registerIdentityTools registers whoami and member management tools", () => {
+    const names: string[] = [];
+    const mockServer = {
+      tool: (name: string, _desc: string, _schema: any, _handler: any) => {
+        names.push(name);
+      },
+    };
+
+    const db = createTestDb();
+    const getContext = (): OpContext => {
+      throw new Error("getContext should not be called during registration");
+    };
+
+    registerIdentityTools(mockServer as any, { db, getContext });
+
+    expect(names.sort()).toEqual(
+      ["member-invite", "member-list", "member-remove", "member-update-role", "whoami"].sort()
+    );
   });
 });

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -1,8 +1,21 @@
 import { describe, test, expect } from "bun:test";
 import { z } from "zod";
-import { getRegisteredOps, getOpDefinition } from "@/core";
+import {
+  getRegisteredOps,
+  getOpDefinition,
+  createUser,
+  createOrg,
+  inviteToOrg,
+  createDrive,
+  listDrives,
+  setDriveMember,
+  getUserOrgRole,
+  getUserDriveRole,
+} from "@/core";
+import type { OpContext } from "@/core";
 import { registerTools } from "../tools.js";
-import { createTestContext } from "../../../core/src/test-utils.js";
+import { registerIdentityTools } from "../server.js";
+import { createTestContext, createTestDb, MockS3Client } from "../../../core/src/test-utils.js";
 
 describe("registerTools", () => {
   test("registers all ops as MCP tools", () => {
@@ -73,6 +86,305 @@ describe("registerTools", () => {
     const parsed = JSON.parse(result.content[0].text);
     expect(parsed.version).toBe(1);
     expect(parsed.path).toBe("/mcp-test.txt");
+  });
+});
+
+// --- Identity tool harness ---
+
+type ToolHandler = (params: any, extra: any) => Promise<any>;
+type TestUser = { id: string; email: string };
+
+/**
+ * Build a multi-user world for exercising the identity tool handlers:
+ * - `sharedOrg` owned by `admin` (org admin + default-drive admin)
+ * - `editor` / `viewer` invited with matching org + default-drive roles
+ * - `outsider` with no membership in `sharedOrg`, but admin of `foreignOrg`
+ *
+ * All handlers run with the active org pinned to `sharedOrg` (mirrors the
+ * production `getContext`, which binds member tools to the resolved org).
+ */
+function createIdentityHarness() {
+  const db = createTestDb();
+  const s3 = new MockS3Client();
+
+  const { user: admin } = createUser(db, { email: "admin@example.com" });
+  const { user: editor } = createUser(db, { email: "editor@example.com" });
+  const { user: viewer } = createUser(db, { email: "viewer@example.com" });
+  const { user: outsider } = createUser(db, { email: "outsider@example.com" });
+
+  const sharedOrg = createOrg(db, { name: "shared", userId: admin.id });
+  inviteToOrg(db, { orgId: sharedOrg.id, email: editor.email, role: "editor" });
+  inviteToOrg(db, { orgId: sharedOrg.id, email: viewer.email, role: "viewer" });
+  const sharedDriveId = listDrives(db, sharedOrg.id).find((d) => d.isDefault)!.id;
+
+  const foreignOrg = createOrg(db, { name: "foreign", userId: outsider.id });
+  const foreignDriveId = listDrives(db, foreignOrg.id).find((d) => d.isDefault)!.id;
+
+  const handlers = new Map<string, ToolHandler>();
+  const mockServer = {
+    tool: (name: string, _desc: string, _schema: any, handler: ToolHandler) => {
+      handlers.set(name, handler);
+    },
+  };
+
+  const getContext = (extra: any): OpContext => {
+    const user = extra.authInfo.extra.user as TestUser;
+    return {
+      db,
+      s3: s3 as any,
+      orgId: sharedOrg.id,
+      driveId: sharedDriveId,
+      userId: user.id,
+      embeddingProvider: null,
+    };
+  };
+
+  registerIdentityTools(mockServer as any, { db, getContext });
+
+  const call = async (tool: string, params: any, user: TestUser) => {
+    const handler = handlers.get(tool);
+    if (!handler) throw new Error(`Tool not registered: ${tool}`);
+    const result = await handler(params, {
+      authInfo: { extra: { user } },
+    });
+    return { result, body: JSON.parse(result.content[0].text) };
+  };
+
+  return {
+    db,
+    sharedOrg,
+    sharedDriveId,
+    foreignOrg,
+    foreignDriveId,
+    admin,
+    editor,
+    viewer,
+    outsider,
+    handlers,
+    call,
+  };
+}
+
+describe("member tool RBAC", () => {
+  test("registers whoami and all member tools", () => {
+    const h = createIdentityHarness();
+    expect([...h.handlers.keys()].sort()).toEqual(
+      ["member-invite", "member-list", "member-remove", "member-update-role", "whoami"].sort()
+    );
+  });
+
+  test("org member list requires org admin", async () => {
+    const h = createIdentityHarness();
+
+    for (const user of [h.viewer, h.editor]) {
+      const { result, body } = await h.call("member-list", {}, user);
+      expect(result.isError).toBe(true);
+      expect(body.error).toContain("requires 'admin' role");
+    }
+
+    const { result, body } = await h.call("member-list", {}, h.admin);
+    expect(result.isError).toBeUndefined();
+    const emails = body.members.map((m: any) => m.email).sort();
+    expect(emails).toEqual(["admin@example.com", "editor@example.com", "viewer@example.com"]);
+  });
+
+  test("org member list rejects non-members of the org", async () => {
+    const h = createIdentityHarness();
+    const { result, body } = await h.call("member-list", {}, h.outsider);
+    expect(result.isError).toBe(true);
+    expect(body.error).toContain("do not have access");
+  });
+
+  test("member-invite requires org admin", async () => {
+    const h = createIdentityHarness();
+
+    const denied = await h.call(
+      "member-invite",
+      { email: h.outsider.email, role: "viewer" },
+      h.editor
+    );
+    expect(denied.result.isError).toBe(true);
+    expect(getUserOrgRole(h.db, h.outsider.id, h.sharedOrg.id)).toBeNull();
+
+    const allowed = await h.call(
+      "member-invite",
+      { email: h.outsider.email, role: "viewer" },
+      h.admin
+    );
+    expect(allowed.result.isError).toBeUndefined();
+    expect(allowed.body.ok).toBe(true);
+    expect(getUserOrgRole(h.db, h.outsider.id, h.sharedOrg.id)).toBe("viewer");
+  });
+
+  test("org member-update-role requires org admin", async () => {
+    const h = createIdentityHarness();
+
+    const denied = await h.call(
+      "member-update-role",
+      { email: h.viewer.email, role: "editor" },
+      h.editor
+    );
+    expect(denied.result.isError).toBe(true);
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBe("viewer");
+
+    const allowed = await h.call(
+      "member-update-role",
+      { email: h.viewer.email, role: "editor" },
+      h.admin
+    );
+    expect(allowed.result.isError).toBeUndefined();
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBe("editor");
+  });
+
+  test("org member-remove requires org admin", async () => {
+    const h = createIdentityHarness();
+
+    const denied = await h.call("member-remove", { email: h.viewer.email }, h.editor);
+    expect(denied.result.isError).toBe(true);
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBe("viewer");
+
+    const allowed = await h.call("member-remove", { email: h.viewer.email }, h.admin);
+    expect(allowed.result.isError).toBeUndefined();
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBeNull();
+    expect(getUserDriveRole(h.db, h.viewer.id, h.sharedDriveId)).toBeNull();
+  });
+
+  test("non-admins cannot probe account existence via member tools", async () => {
+    const h = createIdentityHarness();
+    const { result, body } = await h.call(
+      "member-remove",
+      { email: "ghost@example.com" },
+      h.viewer
+    );
+    expect(result.isError).toBe(true);
+    // Permission error, not "user not found" — the email lookup must not run.
+    expect(body.error).toContain("requires 'admin' role");
+    expect(body.error).not.toContain("not found");
+  });
+
+  test("drive member list requires drive admin or org admin", async () => {
+    const h = createIdentityHarness();
+
+    // Drive editor is not enough.
+    const denied = await h.call("member-list", { driveId: h.sharedDriveId }, h.editor);
+    expect(denied.result.isError).toBe(true);
+    expect(denied.body.error).toContain("drive admin or org admin");
+
+    // Explicit drive admin works, even though org role is still 'editor'.
+    setDriveMember(h.db, { driveId: h.sharedDriveId, userId: h.editor.id, role: "admin" });
+    const asDriveAdmin = await h.call("member-list", { driveId: h.sharedDriveId }, h.editor);
+    expect(asDriveAdmin.result.isError).toBeUndefined();
+    expect(asDriveAdmin.body.members.length).toBeGreaterThan(0);
+  });
+
+  test("org admin can manage drives without an explicit drive membership", async () => {
+    const h = createIdentityHarness();
+
+    // Drive created by editor — admin has no drive_members row for it.
+    const drive = createDrive(h.db, {
+      orgId: h.sharedOrg.id,
+      name: "editor-drive",
+      creatorUserId: h.editor.id,
+    });
+    expect(getUserDriveRole(h.db, h.admin.id, drive.id)).toBeNull();
+
+    const { result, body } = await h.call("member-list", { driveId: drive.id }, h.admin);
+    expect(result.isError).toBeUndefined();
+    expect(body.members.map((m: any) => m.email)).toEqual([h.editor.email]);
+  });
+
+  test("drive admin can update and remove drive members", async () => {
+    const h = createIdentityHarness();
+    setDriveMember(h.db, { driveId: h.sharedDriveId, userId: h.editor.id, role: "admin" });
+
+    const updated = await h.call(
+      "member-update-role",
+      { email: h.viewer.email, role: "editor", driveId: h.sharedDriveId },
+      h.editor
+    );
+    expect(updated.result.isError).toBeUndefined();
+    expect(getUserDriveRole(h.db, h.viewer.id, h.sharedDriveId)).toBe("editor");
+    // Org role untouched — drive-scoped update only.
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBe("viewer");
+
+    const removed = await h.call(
+      "member-remove",
+      { email: h.viewer.email, driveId: h.sharedDriveId },
+      h.editor
+    );
+    expect(removed.result.isError).toBeUndefined();
+    expect(getUserDriveRole(h.db, h.viewer.id, h.sharedDriveId)).toBeNull();
+    expect(getUserOrgRole(h.db, h.viewer.id, h.sharedOrg.id)).toBe("viewer");
+  });
+
+  test("drive-scoped tools reject driveIds outside the active org", async () => {
+    const h = createIdentityHarness();
+
+    // Even the org admin of the active org cannot reach a foreign drive...
+    for (const [tool, params] of [
+      ["member-list", { driveId: h.foreignDriveId }],
+      ["member-update-role", { email: h.viewer.email, role: "viewer", driveId: h.foreignDriveId }],
+      ["member-remove", { email: h.viewer.email, driveId: h.foreignDriveId }],
+    ] as const) {
+      const { result, body } = await h.call(tool, params, h.admin);
+      expect(result.isError).toBe(true);
+      expect(body.error).toContain("Drive not found in org");
+    }
+
+    // ...and neither can the foreign drive's own admin via this org's context.
+    const { result, body } = await h.call(
+      "member-list",
+      { driveId: h.foreignDriveId },
+      h.outsider
+    );
+    expect(result.isError).toBe(true);
+    expect(body.error).toContain("Drive not found in org");
+  });
+});
+
+describe("whoami hides inaccessible drives", () => {
+  test("only drives with explicit membership are listed", async () => {
+    const h = createIdentityHarness();
+
+    // Drive in the shared org that viewer is NOT a member of.
+    const secret = createDrive(h.db, {
+      orgId: h.sharedOrg.id,
+      name: "secret",
+      creatorUserId: h.admin.id,
+    });
+
+    const viewerWhoami = await h.call("whoami", {}, h.viewer);
+    const viewerOrg = viewerWhoami.body.memberships.find(
+      (m: any) => m.orgId === h.sharedOrg.id
+    );
+    expect(viewerOrg).toBeDefined();
+    expect(viewerOrg.drives.map((d: any) => d.driveId)).toEqual([h.sharedDriveId]);
+    expect(viewerOrg.drives[0].role).toBe("viewer");
+
+    const adminWhoami = await h.call("whoami", {}, h.admin);
+    const adminOrg = adminWhoami.body.memberships.find(
+      (m: any) => m.orgId === h.sharedOrg.id
+    );
+    expect(adminOrg.drives.map((d: any) => d.driveId).sort()).toEqual(
+      [h.sharedDriveId, secret.id].sort()
+    );
+    // No null roles leak through under strict membership.
+    for (const membership of adminWhoami.body.memberships) {
+      for (const drive of membership.drives) {
+        expect(drive.role).not.toBeNull();
+      }
+    }
+  });
+
+  test("foreign orgs and their drives never appear", async () => {
+    const h = createIdentityHarness();
+    const { body } = await h.call("whoami", {}, h.viewer);
+    const orgIds = body.memberships.map((m: any) => m.orgId);
+    expect(orgIds).not.toContain(h.foreignOrg.id);
+    const allDriveIds = body.memberships.flatMap((m: any) =>
+      m.drives.map((d: any) => d.driveId)
+    );
+    expect(allDriveIds).not.toContain(h.foreignDriveId);
   });
 });
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,7 +6,7 @@ import {
   resolveContext,
   dispatchOp,
   listUserOrgs,
-  listDrives,
+  listDrivesForUser,
   getUserDriveRole,
   getUserByEmail,
   listOrgMembers,
@@ -16,6 +16,9 @@ import {
   removeOrgMember,
   updateDriveMemberRole,
   removeDriveMember,
+  requireOrgRole,
+  requireDriveAdmin,
+  assertDriveInOrg,
   VERSION,
 } from "@/core";
 import type { OpContext, DB, EmbeddingProvider, AgentS3Client } from "@/core";
@@ -81,6 +84,44 @@ export function createMcpServer(options: McpServerOptions) {
     };
   });
 
+  registerIdentityTools(server, { db, getContext });
+
+  return server;
+}
+
+/**
+ * Register identity-related tools (whoami + member management).
+ *
+ * Exported separately from `createMcpServer` so tests can register the tools
+ * on a mock server and invoke the captured handlers with synthetic auth
+ * contexts (same pattern as `registerTools`).
+ *
+ * RBAC policy (mirrors HTTP member management):
+ * - Org member list/invite/update/remove require org 'admin'.
+ * - Drive member list/update/remove require drive 'admin' or org 'admin',
+ *   and the drive must belong to the caller's active org.
+ */
+export function registerIdentityTools(
+  server: McpServer,
+  deps: { db: DB; getContext: (extra: Extra) => OpContext }
+) {
+  const { db, getContext } = deps;
+
+  /**
+   * Authorize a member-management call. Drive-scoped requests are bound to
+   * the active org first (NotFound for unknown AND cross-org drives, so
+   * other tenants' drive IDs are unprobeable), then require drive admin or
+   * org admin. Org-scoped requests require org admin.
+   */
+  const requireMemberAdmin = (ctx: OpContext, driveId?: string) => {
+    if (driveId) {
+      assertDriveInOrg(db, { driveId, orgId: ctx.orgId });
+      requireDriveAdmin(db, { userId: ctx.userId, driveId });
+    } else {
+      requireOrgRole(db, { userId: ctx.userId, orgId: ctx.orgId, requiredRole: "admin" });
+    }
+  };
+
   // whoami tool — lets agents check their identity and permissions
   server.tool("whoami", "Get current user identity, org memberships, and drive roles.", {}, async (_params, extra) => {
     const ctx = getContext(extra);
@@ -88,7 +129,8 @@ export function createMcpServer(options: McpServerOptions) {
 
     const orgs = listUserOrgs(db, userId);
     const orgDetails = orgs.map((org) => {
-      const drives = listDrives(db, org.id);
+      // Strict membership: only drives the user is an explicit member of.
+      const drives = listDrivesForUser(db, org.id, userId);
       return {
         orgId: org.id,
         orgName: org.name,
@@ -119,22 +161,30 @@ export function createMcpServer(options: McpServerOptions) {
 
   server.tool(
     "member-list",
-    "List members of the current org, or a specific drive if driveId is provided.",
+    "List members of the current org (requires org admin), or a specific drive in the current org (requires drive admin or org admin) if driveId is provided.",
     { driveId: z.string().optional().describe("Drive ID to list members for. Omit for org members.") },
     async (params: { driveId?: string }, extra) => {
       const ctx = getContext(extra);
-      const members = params.driveId
-        ? listDriveMembers(db, params.driveId)
-        : listOrgMembers(db, ctx.orgId);
-      return {
-        content: [{ type: "text" as const, text: JSON.stringify({ members }, null, 2) }],
-      };
+      try {
+        requireMemberAdmin(ctx, params.driveId);
+        const members = params.driveId
+          ? listDriveMembers(db, params.driveId)
+          : listOrgMembers(db, ctx.orgId);
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ members }, null, 2) }],
+        };
+      } catch (err: any) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: err.message }, null, 2) }],
+          isError: true,
+        };
+      }
     }
   );
 
   server.tool(
     "member-invite",
-    "Invite a user to the current org by email. The user must already have an agent-fs account.",
+    "Invite a user to the current org by email (requires org admin). The user must already have an agent-fs account.",
     {
       email: z.string().describe("Email of the user to invite"),
       role: z.enum(["viewer", "editor", "admin"]).describe("Role to assign"),
@@ -142,6 +192,7 @@ export function createMcpServer(options: McpServerOptions) {
     async (params: { email: string; role: "viewer" | "editor" | "admin" }, extra) => {
       const ctx = getContext(extra);
       try {
+        requireMemberAdmin(ctx);
         inviteToOrg(db, { orgId: ctx.orgId, email: params.email, role: params.role });
         return {
           content: [{ type: "text" as const, text: JSON.stringify({ ok: true, invited: params.email, role: params.role }, null, 2) }],
@@ -157,7 +208,7 @@ export function createMcpServer(options: McpServerOptions) {
 
   server.tool(
     "member-update-role",
-    "Update a member's role in the current org or a specific drive.",
+    "Update a member's role in the current org (requires org admin) or a specific drive in the current org (requires drive admin or org admin).",
     {
       email: z.string().describe("Email of the member"),
       role: z.enum(["viewer", "editor", "admin"]).describe("New role"),
@@ -166,6 +217,9 @@ export function createMcpServer(options: McpServerOptions) {
     async (params: { email: string; role: "viewer" | "editor" | "admin"; driveId?: string }, extra) => {
       const ctx = getContext(extra);
       try {
+        // Authorize before the email lookup so non-admins can't probe
+        // whether an account exists.
+        requireMemberAdmin(ctx, params.driveId);
         const user = getUserByEmail(db, params.email);
         if (!user) throw new Error(`User with email ${params.email} not found`);
         if (params.driveId) {
@@ -187,7 +241,7 @@ export function createMcpServer(options: McpServerOptions) {
 
   server.tool(
     "member-remove",
-    "Remove a member from the current org (cascades to all drives) or from a specific drive only.",
+    "Remove a member from the current org (cascades to all drives; requires org admin) or from a specific drive in the current org only (requires drive admin or org admin).",
     {
       email: z.string().describe("Email of the member to remove"),
       driveId: z.string().optional().describe("Drive ID to remove from. Omit to remove from org."),
@@ -195,6 +249,9 @@ export function createMcpServer(options: McpServerOptions) {
     async (params: { email: string; driveId?: string }, extra) => {
       const ctx = getContext(extra);
       try {
+        // Authorize before the email lookup so non-admins can't probe
+        // whether an account exists.
+        requireMemberAdmin(ctx, params.driveId);
         const user = getUserByEmail(db, params.email);
         if (!user) throw new Error(`User with email ${params.email} not found`);
         if (params.driveId) {
@@ -213,6 +270,4 @@ export function createMcpServer(options: McpServerOptions) {
       }
     }
   );
-
-  return server;
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/src/__tests__/files-raw.test.ts
+++ b/packages/server/src/__tests__/files-raw.test.ts
@@ -1,19 +1,23 @@
 import { describe, test, expect, beforeAll } from "bun:test";
 import { createHash } from "node:crypto";
 import { createTestDb, MockS3Client } from "../../../core/src/test-utils.js";
+import { createUser, setDriveMember } from "../../../core/src/index.js";
 import { createApp } from "../app.js";
 
 let app: ReturnType<typeof createApp>;
 let apiKey: string;
 let orgId: string;
 let driveId: string;
+let viewerKey: string;
+let editorKey: string;
 
 beforeAll(async () => {
   const db = createTestDb();
   const s3 = new MockS3Client();
   app = createApp(db, s3 as any);
 
-  // Register a user (auth is shared across these tests).
+  // Register a user (auth is shared across these tests). Registration makes
+  // this user the drive's admin (creator gets an explicit admin member row).
   const reg = await app.request("/auth/register", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -30,11 +34,26 @@ beforeAll(async () => {
   });
   const meBody = await me.json();
   driveId = meBody.defaultDriveId;
+
+  // Secondary users with explicit drive roles for the RBAC tests below.
+  const viewer = createUser(db, { email: "raw-viewer@example.com" });
+  viewerKey = viewer.apiKey;
+  setDriveMember(db, { driveId, userId: viewer.user.id, role: "viewer" });
+
+  const editor = createUser(db, { email: "raw-editor@example.com" });
+  editorKey = editor.apiKey;
+  setDriveMember(db, { driveId, userId: editor.user.id, role: "editor" });
 });
 
 function authedFetch(path: string, opts?: RequestInit) {
   const headers = new Headers(opts?.headers);
   headers.set("Authorization", `Bearer ${apiKey}`);
+  return app.request(path, { ...opts, headers });
+}
+
+function fetchAs(key: string, path: string, opts?: RequestInit) {
+  const headers = new Headers(opts?.headers);
+  headers.set("Authorization", `Bearer ${key}`);
   return app.request(path, { ...opts, headers });
 }
 
@@ -278,5 +297,92 @@ describe("PUT /raw — binary write path", () => {
       }
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("raw RBAC — viewer vs editor vs admin", () => {
+  test("viewer raw read but not raw write", async () => {
+    // Seed the file as the drive admin (registered owner).
+    const seed = await authedFetch(
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac.txt/raw`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: "rbac body",
+      }
+    );
+    expect(seed.status).toBe(200);
+
+    // Viewer can read the raw bytes.
+    const read = await fetchAs(
+      viewerKey,
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac.txt/raw`
+    );
+    expect(read.status).toBe(200);
+    expect(await read.text()).toBe("rbac body");
+
+    // Viewer cannot overwrite an existing file.
+    const overwrite = await fetchAs(
+      viewerKey,
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac.txt/raw`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: "viewer overwrite",
+      }
+    );
+    expect(overwrite.status).toBe(403);
+    const overwriteBody = await overwrite.json();
+    expect(overwriteBody.error).toBe("PERMISSION_DENIED");
+
+    // Viewer cannot create a new file either.
+    const create = await fetchAs(
+      viewerKey,
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac-new.txt/raw`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: "viewer create",
+      }
+    );
+    expect(create.status).toBe(403);
+
+    // The denied writes must not have changed the file.
+    const after = await authedFetch(
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac.txt/raw`
+    );
+    expect(after.headers.get("X-Agent-FS-Version")).toBe("1");
+    expect(await after.text()).toBe("rbac body");
+  });
+
+  test("editor and admin PUT /raw succeed", async () => {
+    const v1 = await fetchAs(
+      editorKey,
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac-editor.txt/raw`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/octet-stream" },
+        body: "editor v1",
+      }
+    );
+    expect(v1.status).toBe(200);
+    const v1Body = await v1.json();
+    expect(v1Body.version).toBe(1);
+
+    // Admin (registered owner) bumps it with optimistic concurrency intact.
+    const v2 = await authedFetch(
+      `/orgs/${orgId}/drives/${driveId}/files/raw-rbac-editor.txt/raw`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "If-Match": "1",
+        },
+        body: "admin v2",
+      }
+    );
+    expect(v2.status).toBe(200);
+    const v2Body = await v2.json();
+    expect(v2Body.version).toBe(2);
   });
 });

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -248,3 +248,288 @@ describe("Error handling", () => {
     expect(body.error).toBe("PERMISSION_DENIED");
   });
 });
+
+// --- Multi-tenant RBAC on org/member/drive routes ---
+
+describe("Multi-tenant RBAC", () => {
+  let ownerKey: string;
+  let viewerKey: string;
+  let editorKey: string;
+  let outsiderKey: string;
+  let ownerUserId: string;
+  let viewerUserId: string;
+  let editorUserId: string;
+  let removableUserId: string;
+  let tenantOrgId: string;
+  let tenantDriveId: string; // tenant org default drive
+  let outsiderOrgId: string;
+  let outsiderDriveId: string; // outsider's personal default drive
+
+  function keyReq(key: string, path: string, opts?: RequestInit) {
+    const headers = new Headers(opts?.headers);
+    headers.set("Authorization", `Bearer ${key}`);
+    if (opts?.body) headers.set("Content-Type", "application/json");
+    return app.request(path, { ...opts, headers });
+  }
+
+  async function register(email: string) {
+    const res = await jsonPost("/auth/register", { email });
+    expect(res.status).toBe(200);
+    return res.json() as Promise<{ apiKey: string; userId: string; orgId: string }>;
+  }
+
+  beforeAll(async () => {
+    const owner = await register("rbac-owner@example.com");
+    ownerKey = owner.apiKey;
+    ownerUserId = owner.userId;
+
+    const viewer = await register("rbac-viewer@example.com");
+    viewerKey = viewer.apiKey;
+    viewerUserId = viewer.userId;
+
+    const editor = await register("rbac-editor@example.com");
+    editorKey = editor.apiKey;
+    editorUserId = editor.userId;
+
+    const outsider = await register("rbac-outsider@example.com");
+    outsiderKey = outsider.apiKey;
+    outsiderOrgId = outsider.orgId;
+
+    const removable = await register("rbac-removable@example.com");
+    removableUserId = removable.userId;
+
+    // Owner creates a shared (non-personal) tenant org
+    const orgRes = await keyReq(ownerKey, "/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: "rbac-tenant" }),
+    });
+    expect(orgRes.status).toBe(201);
+    tenantOrgId = (await orgRes.json()).id;
+
+    // Owner (org admin) invites members
+    for (const [email, role] of [
+      ["rbac-viewer@example.com", "viewer"],
+      ["rbac-editor@example.com", "editor"],
+      ["rbac-removable@example.com", "viewer"],
+    ] as const) {
+      const res = await keyReq(ownerKey, `/orgs/${tenantOrgId}/members/invite`, {
+        method: "POST",
+        body: JSON.stringify({ email, role }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    // Resolve drive ids
+    const tenantDrives = await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives`);
+    tenantDriveId = (await tenantDrives.json()).drives.find((d: any) => d.isDefault).id;
+
+    const outsiderDrives = await keyReq(outsiderKey, `/orgs/${outsiderOrgId}/drives`);
+    outsiderDriveId = (await outsiderDrives.json()).drives[0].id;
+  });
+
+  test("cross-tenant org and drive routes are invisible to non-members", async () => {
+    // Org details / drive listing: same 404 as a missing org (no existence oracle)
+    expect((await keyReq(outsiderKey, `/orgs/${tenantOrgId}`)).status).toBe(404);
+    expect((await keyReq(outsiderKey, `/orgs/${tenantOrgId}/drives`)).status).toBe(404);
+
+    // Drive creation in a foreign org is rejected (previously returned 201)
+    const createRes = await keyReq(outsiderKey, `/orgs/${tenantOrgId}/drives`, {
+      method: "POST",
+      body: JSON.stringify({ name: "intruder-drive" }),
+    });
+    expect(createRes.status).toBe(404);
+
+    // Org member surfaces
+    expect((await keyReq(outsiderKey, `/orgs/${tenantOrgId}/members`)).status).toBe(404);
+    expect(
+      (
+        await keyReq(outsiderKey, `/orgs/${tenantOrgId}/members/invite`, {
+          method: "POST",
+          body: JSON.stringify({ email: "rbac-outsider@example.com", role: "admin" }),
+        })
+      ).status
+    ).toBe(404);
+    expect(
+      (
+        await keyReq(outsiderKey, `/orgs/${tenantOrgId}/members/${ownerUserId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ role: "viewer" }),
+        })
+      ).status
+    ).toBe(404);
+    expect(
+      (
+        await keyReq(outsiderKey, `/orgs/${tenantOrgId}/members/${ownerUserId}`, {
+          method: "DELETE",
+        })
+      ).status
+    ).toBe(404);
+
+    // Drive member surface: driveId is bound to the route orgId, so a
+    // foreign drive under the outsider's own org is a 404...
+    expect(
+      (await keyReq(outsiderKey, `/orgs/${outsiderOrgId}/drives/${tenantDriveId}/members`)).status
+    ).toBe(404);
+    // ...and with the real org+drive pair, the outsider has no drive/org
+    // admin role, so the request is denied.
+    expect(
+      (await keyReq(outsiderKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members`)).status
+    ).toBe(403);
+
+    // Ops route binding: a body driveId from another org is rejected before dispatch
+    const opsRes = await keyReq(outsiderKey, `/orgs/${outsiderOrgId}/ops`, {
+      method: "POST",
+      body: JSON.stringify({ op: "ls", path: "/", driveId: tenantDriveId }),
+    });
+    expect(opsRes.status).toBe(404);
+
+    // Raw route binding: foreign driveId under the caller's org is rejected
+    const rawRes = await keyReq(
+      outsiderKey,
+      `/orgs/${outsiderOrgId}/drives/${tenantDriveId}/files/secret.txt/raw`
+    );
+    expect(rawRes.status).toBe(404);
+
+    // Verify the intruder drive was never created
+    const drives = await (await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives`)).json();
+    expect(drives.drives.some((d: any) => d.name === "intruder-drive")).toBe(false);
+  });
+
+  test("viewer and editor org members cannot administer org or drives", async () => {
+    // Members can see org details and their drives
+    expect((await keyReq(viewerKey, `/orgs/${tenantOrgId}`)).status).toBe(200);
+    expect((await keyReq(viewerKey, `/orgs/${tenantOrgId}/drives`)).status).toBe(200);
+
+    // Drive creation requires org admin
+    for (const key of [viewerKey, editorKey]) {
+      const res = await keyReq(key, `/orgs/${tenantOrgId}/drives`, {
+        method: "POST",
+        body: JSON.stringify({ name: "nope" }),
+      });
+      expect(res.status).toBe(403);
+    }
+
+    // Org member list/invite/update/remove require org admin
+    expect((await keyReq(viewerKey, `/orgs/${tenantOrgId}/members`)).status).toBe(403);
+    expect((await keyReq(editorKey, `/orgs/${tenantOrgId}/members`)).status).toBe(403);
+    expect(
+      (
+        await keyReq(editorKey, `/orgs/${tenantOrgId}/members/invite`, {
+          method: "POST",
+          body: JSON.stringify({ email: "rbac-outsider@example.com", role: "viewer" }),
+        })
+      ).status
+    ).toBe(403);
+    expect(
+      (
+        await keyReq(viewerKey, `/orgs/${tenantOrgId}/members/${editorUserId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ role: "admin" }),
+        })
+      ).status
+    ).toBe(403);
+    expect(
+      (
+        await keyReq(editorKey, `/orgs/${tenantOrgId}/members/${viewerUserId}`, {
+          method: "DELETE",
+        })
+      ).status
+    ).toBe(403);
+
+    // Drive member management requires drive admin or org admin — viewer and
+    // editor hold non-admin roles on the default drive (granted by invite)
+    expect(
+      (await keyReq(viewerKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members`)).status
+    ).toBe(403);
+    expect(
+      (
+        await keyReq(editorKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members/${viewerUserId}`, {
+          method: "PATCH",
+          body: JSON.stringify({ role: "admin" }),
+        })
+      ).status
+    ).toBe(403);
+    expect(
+      (
+        await keyReq(viewerKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members/${editorUserId}`, {
+          method: "DELETE",
+        })
+      ).status
+    ).toBe(403);
+  });
+
+  test("org admin can create list and manage drive members", async () => {
+    // Create a drive — creator gets an explicit admin membership row
+    const createRes = await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives`, {
+      method: "POST",
+      body: JSON.stringify({ name: "team-docs" }),
+    });
+    expect(createRes.status).toBe(201);
+    const newDriveId = (await createRes.json()).id;
+
+    // The freshly created drive is visible to its creator (strict membership)
+    const drives = await (await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives`)).json();
+    expect(drives.drives.some((d: any) => d.id === newDriveId)).toBe(true);
+
+    // Creator shows up as the drive admin
+    const newMembers = await (
+      await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives/${newDriveId}/members`)
+    ).json();
+    expect(newMembers.members).toEqual([
+      expect.objectContaining({ userId: ownerUserId, role: "admin" }),
+    ]);
+
+    // Org admin manages default-drive members (granted by invite)
+    const patchRes = await keyReq(
+      ownerKey,
+      `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members/${viewerUserId}`,
+      { method: "PATCH", body: JSON.stringify({ role: "editor" }) }
+    );
+    expect(patchRes.status).toBe(200);
+
+    const afterPatch = await (
+      await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members`)
+    ).json();
+    expect(
+      afterPatch.members.find((m: any) => m.userId === viewerUserId).role
+    ).toBe("editor");
+
+    const deleteRes = await keyReq(
+      ownerKey,
+      `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members/${editorUserId}`,
+      { method: "DELETE" }
+    );
+    expect(deleteRes.status).toBe(200);
+
+    const afterDelete = await (
+      await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives/${tenantDriveId}/members`)
+    ).json();
+    expect(afterDelete.members.some((m: any) => m.userId === editorUserId)).toBe(false);
+
+    // Org/drive mismatch is still a 404 even for an org admin
+    expect(
+      (await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives/${outsiderDriveId}/members`)).status
+    ).toBe(404);
+  });
+
+  test("org admin can manage org members", async () => {
+    const listRes = await keyReq(ownerKey, `/orgs/${tenantOrgId}/members`);
+    expect(listRes.status).toBe(200);
+    const members = (await listRes.json()).members;
+    expect(members.some((m: any) => m.userId === removableUserId)).toBe(true);
+
+    const patchRes = await keyReq(ownerKey, `/orgs/${tenantOrgId}/members/${removableUserId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ role: "editor" }),
+    });
+    expect(patchRes.status).toBe(200);
+
+    const deleteRes = await keyReq(ownerKey, `/orgs/${tenantOrgId}/members/${removableUserId}`, {
+      method: "DELETE",
+    });
+    expect(deleteRes.status).toBe(200);
+
+    const after = await (await keyReq(ownerKey, `/orgs/${tenantOrgId}/members`)).json();
+    expect(after.members.some((m: any) => m.userId === removableUserId)).toBe(false);
+  });
+});

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -532,4 +532,32 @@ describe("Multi-tenant RBAC", () => {
     const after = await (await keyReq(ownerKey, `/orgs/${tenantOrgId}/members`)).json();
     expect(after.members.some((m: any) => m.userId === removableUserId)).toBe(false);
   });
+
+  test("inaccessible drive is indistinguishable from a missing drive on ops (404)", async () => {
+    // Owner creates a drive the viewer has no membership row on
+    const createRes = await keyReq(ownerKey, `/orgs/${tenantOrgId}/drives`, {
+      method: "POST",
+      body: JSON.stringify({ name: "viewer-blind" }),
+    });
+    expect(createRes.status).toBe(201);
+    const hiddenDriveId = (await createRes.json()).id;
+
+    const probe = (driveId: string) =>
+      keyReq(viewerKey, `/orgs/${tenantOrgId}/ops`, {
+        method: "POST",
+        body: JSON.stringify({ op: "ls", path: "/", driveId }),
+      });
+
+    const missingId = "00000000-0000-4000-8000-000000000000";
+    const missingRes = await probe(missingId);
+    const hiddenRes = await probe(hiddenDriveId);
+
+    expect(missingRes.status).toBe(404);
+    expect(hiddenRes.status).toBe(404); // was a 500 INTERNAL_ERROR oracle
+
+    // Bodies are byte-identical modulo the caller-supplied driveId
+    const missingBody = (await missingRes.text()).replaceAll(missingId, "DRIVE_ID");
+    const hiddenBody = (await hiddenRes.text()).replaceAll(hiddenDriveId, "DRIVE_ID");
+    expect(hiddenBody).toBe(missingBody);
+  });
 });

--- a/packages/server/src/ipc/__tests__/server.test.ts
+++ b/packages/server/src/ipc/__tests__/server.test.ts
@@ -11,7 +11,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Packr, Unpackr } from "msgpackr";
 import { createTestDb, MockS3Client } from "../../../../core/src/test-utils.js";
-import { createUser, listUserOrgs, listDrives } from "../../../../core/src/index.js";
+import {
+  createUser,
+  listUserOrgs,
+  listDrives,
+  setDriveMember,
+} from "../../../../core/src/index.js";
 import { startIpcServer } from "../server.js";
 
 const packr = new Packr({ useRecords: false });
@@ -23,6 +28,9 @@ interface TestHarness {
   userId: string;
   driveId: string;
   driveSlug: string;
+  db: ReturnType<typeof createTestDb>;
+  /** Swap the API key the daemon resolves — lets tests act as other users. */
+  setApiKey: (key: string) => void;
   stop: () => void;
 }
 
@@ -36,11 +44,12 @@ function setup(): TestHarness {
   const orgs = listUserOrgs(db, user.id);
   const drives = listDrives(db, orgs[0].id);
 
+  let currentApiKey = apiKey;
   const server = startIpcServer(socketPath, {
     db,
     s3: s3 as any,
     embeddingProvider: null,
-    resolveApiKey: () => apiKey,
+    resolveApiKey: () => currentApiKey,
   });
 
   return {
@@ -49,6 +58,10 @@ function setup(): TestHarness {
     userId: user.id,
     driveId: drives[0].id,
     driveSlug: drives[0].name,
+    db,
+    setApiKey: (key: string) => {
+      currentApiKey = key;
+    },
     stop: () => {
       server.stop();
       try {
@@ -243,6 +256,91 @@ describe("IPC server — round-trip", () => {
     const resp: any = await roundTrip(harness.socketPath, { op: "nope" });
     expect(resp.error).toBeDefined();
     expect(resp.error.http_status).toBe(400);
+  });
+
+  test("viewer cannot open_write but editor can", async () => {
+    // Add a viewer and an editor as explicit members of the owner's drive.
+    // The drive is referenced by id (not slug) so the lookup can't collide
+    // with the secondary users' own personal default drives.
+    const viewer = createUser(harness.db, { email: "ipc-viewer@example.com" });
+    setDriveMember(harness.db, {
+      driveId: harness.driveId,
+      userId: viewer.user.id,
+      role: "viewer",
+    });
+    const editor = createUser(harness.db, { email: "ipc-editor@example.com" });
+    setDriveMember(harness.db, {
+      driveId: harness.driveId,
+      userId: editor.user.id,
+      role: "editor",
+    });
+
+    // Seed a file as the owner (drive admin).
+    const seed: any = await roundTrip(harness.socketPath, {
+      op: "open_write",
+      drive: harness.driveId,
+      path: "/rbac.md",
+      base_version: null,
+      content_hash: "",
+      bytes: new TextEncoder().encode("seeded by admin"),
+    });
+    expect(seed.open_write).toBeDefined();
+    expect(seed.open_write.version).toBe(1);
+
+    // Viewer: reads succeed, every write-shaped op is denied with 403.
+    harness.setApiKey(viewer.apiKey);
+
+    const read: any = await roundTrip(harness.socketPath, {
+      op: "open_read",
+      drive: harness.driveId,
+      path: "/rbac.md",
+    });
+    expect(read.open_read).toBeDefined();
+    expect(new TextDecoder().decode(new Uint8Array(read.open_read.bytes))).toBe(
+      "seeded by admin"
+    );
+
+    const write: any = await roundTrip(harness.socketPath, {
+      op: "open_write",
+      drive: harness.driveId,
+      path: "/rbac.md",
+      base_version: null,
+      content_hash: "",
+      bytes: new TextEncoder().encode("viewer write"),
+    });
+    expect(write.error).toBeDefined();
+    expect(write.error.http_status).toBe(403);
+    expect(write.error.code).toBe("PERMISSION_DENIED");
+
+    const create: any = await roundTrip(harness.socketPath, {
+      op: "create_file",
+      drive: harness.driveId,
+      path: "/rbac-new.md",
+    });
+    expect(create.error).toBeDefined();
+    expect(create.error.http_status).toBe(403);
+
+    const truncate: any = await roundTrip(harness.socketPath, {
+      op: "truncate",
+      drive: harness.driveId,
+      path: "/rbac.md",
+      size: 0,
+    });
+    expect(truncate.error).toBeDefined();
+    expect(truncate.error.http_status).toBe(403);
+
+    // Editor: open_write succeeds and bumps the version.
+    harness.setApiKey(editor.apiKey);
+    const editorWrite: any = await roundTrip(harness.socketPath, {
+      op: "open_write",
+      drive: harness.driveId,
+      path: "/rbac.md",
+      base_version: 1,
+      content_hash: "",
+      bytes: new TextEncoder().encode("editor write"),
+    });
+    expect(editorWrite.open_write).toBeDefined();
+    expect(editorWrite.open_write.version).toBe(2);
   });
 });
 

--- a/packages/server/src/ipc/handlers.ts
+++ b/packages/server/src/ipc/handlers.ts
@@ -3,7 +3,11 @@
 // One handler per FUSE op, dispatched by the request's `op` field. Each runs
 // in-process via `dispatchOp` / `writeRaw` so the daemon never round-trips
 // through HTTP loopback. RBAC + versioning + indexing flow through the same
-// path as the JSON op route.
+// path as the JSON op route:
+//   - write paths (`open_write`, `create_file`, `truncate`) require
+//     editor-or-better — enforced inside `writeRaw` itself;
+//   - `unlink` / `rename` go through `dispatchOp` ("rm" / "mv", editor ops);
+//   - read/list/getattr paths stay viewer-accessible.
 //
 // Wire encoding mirrors the Rust helper's `serde` enums (see
 // `packages/fuse-helper/src/ipc.rs` — `#[serde(rename_all = "snake_case")]`):

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -91,10 +91,11 @@ export function fileRoutes(
   //   - If-None-Match: *               → expectedVersion: 0 (create only)
   //   - X-Agent-FS-Message: <message>  → version message
   //
-  // Reuses the in-process `writeRaw` helper (which fronts the `write` op)
-  // so RBAC, versioning, FTS5 indexing and embedding scheduling all flow
-  // through the existing pipeline. The body is buffered up to Hono's
-  // 50 MB body limit — no true streaming in v1.
+  // Reuses the in-process `writeRaw` helper, which enforces editor-or-better
+  // drive RBAC (viewers get 403 PERMISSION_DENIED, matching the JSON `write`
+  // op) and drives versioning, FTS5 indexing and embedding scheduling through
+  // the existing pipeline. GET /raw above stays viewer-accessible. The body
+  // is buffered up to Hono's 50 MB body limit — no true streaming in v1.
   router.put("/:orgId/drives/:driveId/files/:filePath{.+}/raw", async (c) => {
     const user = c.get("user");
     const orgId = c.req.param("orgId");

--- a/packages/server/src/routes/orgs.ts
+++ b/packages/server/src/routes/orgs.ts
@@ -12,9 +12,49 @@ import {
   listDriveMembers,
   updateDriveMemberRole,
   removeDriveMember,
+  getUserOrgRole,
+  roleAtLeast,
+  requireDriveAdmin,
+  assertDriveInOrg,
+  NotFoundError,
+  PermissionDeniedError,
 } from "@/core";
-import type { DB } from "@/core";
+import type { DB, Role } from "@/core";
 import type { AppEnv } from "../types.js";
+
+/**
+ * Resolve the caller's role in `orgId`, throwing NotFoundError (404) when
+ * the caller has no membership. Missing orgs and foreign orgs produce the
+ * same 404 so cross-tenant callers cannot probe org existence.
+ */
+function requireOrgMember(db: DB, userId: string, orgId: string): Role {
+  const role = getUserOrgRole(db, userId, orgId);
+  if (!role) {
+    throw new NotFoundError(`Org not found: ${orgId}`, {
+      suggestion: "Check the org id or ask an org admin for access",
+    });
+  }
+  return role;
+}
+
+/**
+ * Like requireOrgMember, but additionally requires the 'admin' role.
+ * Non-members get 404 (no existence oracle); members below admin get 403.
+ */
+function requireOrgAdmin(db: DB, userId: string, orgId: string): Role {
+  const role = requireOrgMember(db, userId, orgId);
+  if (!roleAtLeast(role, "admin")) {
+    throw new PermissionDeniedError(
+      "This operation requires 'admin' role in the org",
+      {
+        requiredRole: "admin",
+        yourRole: role,
+        suggestion: "Ask an org admin to perform this operation",
+      }
+    );
+  }
+  return role;
+}
 
 export function orgRoutes(db: DB) {
   const router = new Hono<AppEnv>();
@@ -33,7 +73,9 @@ export function orgRoutes(db: DB) {
   });
 
   router.get("/:orgId", (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
+    requireOrgMember(db, user.id, orgId);
     const org = getOrg(db, orgId);
     if (!org) return c.json({ error: "NOT_FOUND", message: "Org not found" }, 404);
     return c.json(org);
@@ -42,35 +84,46 @@ export function orgRoutes(db: DB) {
   router.get("/:orgId/drives", (c) => {
     const user = c.get("user");
     const orgId = c.req.param("orgId");
+    requireOrgMember(db, user.id, orgId);
     const drives = listDrivesForUser(db, orgId, user.id);
     return c.json({ drives });
   });
 
   router.post("/:orgId/drives", async (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
+    requireOrgAdmin(db, user.id, orgId);
     const { name } = await c.req.json();
-    const drive = createDrive(db, { orgId, name });
+    // creatorUserId grants the creator an explicit admin drive membership so
+    // the new drive stays visible under strict explicit-membership rules.
+    const drive = createDrive(db, { orgId, name, creatorUserId: user.id });
     return c.json(drive, 201);
   });
 
   router.post("/:orgId/members/invite", async (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
+    requireOrgAdmin(db, user.id, orgId);
     const { email, role } = await c.req.json();
     inviteToOrg(db, { orgId, email, role });
     return c.json({ ok: true });
   });
 
-  // --- Org member management ---
+  // --- Org member management (org admin only) ---
 
   router.get("/:orgId/members", (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
+    requireOrgAdmin(db, user.id, orgId);
     const members = listOrgMembers(db, orgId);
     return c.json({ members });
   });
 
   router.patch("/:orgId/members/:userId", async (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
     const userId = c.req.param("userId");
+    requireOrgAdmin(db, user.id, orgId);
     const { role } = await c.req.json();
     try {
       updateOrgMemberRole(db, { orgId, userId, role });
@@ -81,8 +134,10 @@ export function orgRoutes(db: DB) {
   });
 
   router.delete("/:orgId/members/:userId", (c) => {
+    const user = c.get("user");
     const orgId = c.req.param("orgId");
     const userId = c.req.param("userId");
+    requireOrgAdmin(db, user.id, orgId);
     try {
       removeOrgMember(db, { orgId, userId });
       return c.json({ ok: true });
@@ -91,17 +146,29 @@ export function orgRoutes(db: DB) {
     }
   });
 
-  // --- Drive member management ---
+  // --- Drive member management (drive admin or org admin) ---
+  //
+  // Every route binds :driveId to :orgId first (assertDriveInOrg throws the
+  // same 404 for "missing" and "wrong org"), then requires drive-admin
+  // rights (explicit drive admin OR admin of the owning org).
 
   router.get("/:orgId/drives/:driveId/members", (c) => {
+    const user = c.get("user");
+    const orgId = c.req.param("orgId");
     const driveId = c.req.param("driveId");
+    assertDriveInOrg(db, { driveId, orgId });
+    requireDriveAdmin(db, { userId: user.id, driveId });
     const members = listDriveMembers(db, driveId);
     return c.json({ members });
   });
 
   router.patch("/:orgId/drives/:driveId/members/:userId", async (c) => {
+    const user = c.get("user");
+    const orgId = c.req.param("orgId");
     const driveId = c.req.param("driveId");
     const userId = c.req.param("userId");
+    assertDriveInOrg(db, { driveId, orgId });
+    requireDriveAdmin(db, { userId: user.id, driveId });
     const { role } = await c.req.json();
     try {
       updateDriveMemberRole(db, { driveId, userId, role });
@@ -112,8 +179,12 @@ export function orgRoutes(db: DB) {
   });
 
   router.delete("/:orgId/drives/:driveId/members/:userId", (c) => {
+    const user = c.get("user");
+    const orgId = c.req.param("orgId");
     const driveId = c.req.param("driveId");
     const userId = c.req.param("userId");
+    assertDriveInOrg(db, { driveId, orgId });
+    requireDriveAdmin(db, { userId: user.id, driveId });
     try {
       removeDriveMember(db, { driveId, userId });
       return c.json({ ok: true });

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1358,6 +1358,268 @@ async function runStandardTests(daemonUrl: string) {
     });
     assert(res.status, 401, `Expected 401, got ${res.status}`);
   });
+
+  // -- Multi-tenant RBAC hardening --
+  //
+  // Cross-surface checks for the hosted multi-tenant safety model:
+  // strict explicit drive membership, admin-gated management routes,
+  // org/drive binding (no cross-tenant existence oracle), editor-or-better
+  // raw writes, MCP member-tool gating, and org/drive-scoped comment IDs.
+
+  const authed = (key: string): Record<string, string> => ({
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${key}`,
+  });
+
+  let user3ApiKey = "";
+  await test("rbac: register third user", async () => {
+    const res = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "user3@e2e.local" }),
+    });
+    assert(res.ok, true, `Expected 200, got ${res.status}`);
+    const data = await res.json() as any;
+    user3ApiKey = data.apiKey;
+    assert(!!user3ApiKey, true, "Expected API key for user3");
+  });
+
+  await test("rbac: invite user3 to second org as viewer", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${secondOrgId}/members/invite`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ email: "user3@e2e.local", role: "viewer" }),
+    });
+    assert(res.ok, true, `Expected 200, got ${res.status}`);
+  });
+
+  let rbacDriveId = "";
+  await test("rbac: strict membership — new drive visible to creator only", async () => {
+    // Created AFTER user3's invite, so user3 has no membership row on it.
+    const createRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/drives`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ name: "rbac-extra" }),
+    });
+    assert(createRes.status, 201, `Expected 201, got ${createRes.status}`);
+    rbacDriveId = ((await createRes.json()) as any).id;
+    assert(!!rbacDriveId, true, "Expected drive id");
+
+    // Creator got an explicit admin membership row → drive is visible.
+    const mineRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/drives`, {
+      headers: authed(apiKey),
+    });
+    const mine = ((await mineRes.json()) as any).drives.map((d: any) => d.id);
+    assert(mine.includes(rbacDriveId), true, "Expected creator to see new drive");
+
+    // user3 is an org member but not a drive member → drive is invisible.
+    const theirsRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/drives`, {
+      headers: authed(user3ApiKey),
+    });
+    assert(theirsRes.status, 200, `Expected 200, got ${theirsRes.status}`);
+    const theirs = ((await theirsRes.json()) as any).drives.map((d: any) => d.id);
+    assert(theirs.includes(rbacDriveId), false, "Expected non-member to NOT see new drive");
+  });
+
+  await test("rbac: viewer cannot create drives (403)", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${secondOrgId}/drives`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({ name: "should-fail" }),
+    });
+    assert(res.status, 403, `Expected 403, got ${res.status}`);
+    assert(((await res.json()) as any).error, "PERMISSION_DENIED");
+  });
+
+  await test("rbac: viewer cannot invite or list org members (403)", async () => {
+    const inviteRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/members/invite`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({ email: "test@e2e.local", role: "admin" }),
+    });
+    assert(inviteRes.status, 403, `Expected 403, got ${inviteRes.status}`);
+    assert(((await inviteRes.json()) as any).error, "PERMISSION_DENIED");
+
+    const listRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/members`, {
+      headers: authed(user3ApiKey),
+    });
+    assert(listRes.status, 403, `Expected 403, got ${listRes.status}`);
+  });
+
+  await test("rbac: non-member org access returns 404 (no existence oracle)", async () => {
+    // user3 is not a member of user1's personal org — drive and member
+    // lookups 404 instead of 403, so org IDs can't be probed.
+    const drivesRes = await fetch(`${daemonUrl}/orgs/${personalOrgId}/drives`, {
+      headers: authed(user3ApiKey),
+    });
+    assert(drivesRes.status, 404, `Expected 404, got ${drivesRes.status}`);
+    const membersRes = await fetch(`${daemonUrl}/orgs/${personalOrgId}/members`, {
+      headers: authed(user3ApiKey),
+    });
+    assert(membersRes.status, 404, `Expected 404, got ${membersRes.status}`);
+  });
+
+  await test("rbac: drive member list requires drive admin (403)", async () => {
+    // user3 is a viewer on the second org's default drive — listing its
+    // members requires drive admin (or org admin).
+    const res = await fetch(
+      `${daemonUrl}/orgs/${secondOrgId}/drives/${secondDriveId}/members`,
+      { headers: authed(user3ApiKey) },
+    );
+    assert(res.status, 403, `Expected 403, got ${res.status}`);
+    assert(((await res.json()) as any).error, "PERMISSION_DENIED");
+  });
+
+  await test("rbac: org/drive mismatch rejected with 404", async () => {
+    // Drive member route under the wrong org → same 404 as "missing".
+    const memberRes = await fetch(
+      `${daemonUrl}/orgs/${personalOrgId}/drives/${secondDriveId}/members`,
+      { headers: authed(apiKey) },
+    );
+    assert(memberRes.status, 404, `Expected 404, got ${memberRes.status}`);
+
+    // Ops route with an explicit driveId from another org → 404 too.
+    const opsRes = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "ls", driveId: secondDriveId }),
+    });
+    assert(opsRes.status, 404, `Expected 404, got ${opsRes.status}`);
+    assert(((await opsRes.json()) as any).error, "NOT_FOUND");
+  });
+
+  await test("rbac: raw write requires editor — viewer PUT 403, GET 200", async () => {
+    // Seed a file in the second org's default drive as user1 (admin).
+    const writeRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "write", path: "/rbac-probe.txt", content: "rbac probe" }),
+    });
+    assert(writeRes.ok, true, `Seed write failed: ${writeRes.status}`);
+
+    const rawUrl = `${daemonUrl}/orgs/${secondOrgId}/drives/${secondDriveId}/files/rbac-probe.txt/raw`;
+
+    // GET /raw stays viewer-accessible.
+    const getRes = await fetch(rawUrl, { headers: { "Authorization": `Bearer ${user3ApiKey}` } });
+    assert(getRes.status, 200, `Expected 200, got ${getRes.status}`);
+    assert(await getRes.text(), "rbac probe");
+
+    // PUT /raw is editor-or-better — viewers get 403 PERMISSION_DENIED.
+    const putRes = await fetch(rawUrl, {
+      method: "PUT",
+      headers: { "Authorization": `Bearer ${user3ApiKey}`, "Content-Type": "text/plain" },
+      body: "overwrite attempt",
+    });
+    assert(putRes.status, 403, `Expected 403, got ${putRes.status}`);
+    assert(((await putRes.json()) as any).error, "PERMISSION_DENIED");
+
+    // Content unchanged after the denied write.
+    const afterRes = await fetch(rawUrl, { headers: { "Authorization": `Bearer ${user3ApiKey}` } });
+    assert(await afterRes.text(), "rbac probe");
+  });
+
+  await test("rbac: viewer JSON write op denied (403)", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({ op: "write", path: "/rbac-probe.txt", content: "nope" }),
+    });
+    assert(res.status, 403, `Expected 403, got ${res.status}`);
+    assert(((await res.json()) as any).error, "PERMISSION_DENIED");
+  });
+
+  await test("rbac: comment IDs are org/drive scoped (cross-tenant 404)", async () => {
+    // Create a comment in user1's personal drive...
+    const writeRes = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "write", path: "/rbac-comment.txt", content: "comment target" }),
+    });
+    assert(writeRes.ok, true, `Seed write failed: ${writeRes.status}`);
+    const addRes = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "comment-add", path: "/rbac-comment.txt", body: "scoped?" }),
+    });
+    assert(addRes.ok, true, `comment-add failed: ${addRes.status}`);
+    const commentId = ((await addRes.json()) as any).id;
+    assert(!!commentId, true, "Expected comment id");
+
+    // ...then try to read/resolve it from the second org's context (same
+    // user, different tenant scope) — IDs must not resolve across drives.
+    const getRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "comment-get", id: commentId }),
+    });
+    assert(getRes.status, 404, `Expected 404, got ${getRes.status}`);
+    assert(((await getRes.json()) as any).error, "NOT_FOUND");
+
+    const resolveRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({ op: "comment-resolve", id: commentId, resolved: true }),
+    });
+    assert(resolveRes.status, 404, `Expected 404, got ${resolveRes.status}`);
+  });
+
+  await test("rbac: mcp whoami lists only member drives", async () => {
+    // Same stateless per-request pattern as "signed-url via MCP".
+    const initRes = await fetch(`${daemonUrl}/mcp`, {
+      method: "POST",
+      headers: mcpHeaders(user3ApiKey),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "e2e-rbac", version: "1.0.0" },
+        },
+      }),
+    });
+    assert(initRes.ok, true, `MCP init failed: ${initRes.status}`);
+
+    const res = await fetch(`${daemonUrl}/mcp`, {
+      method: "POST",
+      headers: mcpHeaders(user3ApiKey),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "whoami", arguments: {} },
+      }),
+    });
+    assert(res.ok, true, `MCP whoami failed: ${res.status}`);
+    const body = await res.json() as any;
+    const text = body.result?.content?.[0]?.text ?? "";
+    const who = JSON.parse(text);
+    const driveIds = who.memberships.flatMap((m: any) => m.drives.map((d: any) => d.driveId));
+    assert(driveIds.includes(secondDriveId), true, "Expected user3 to see drive they're a member of");
+    assert(driveIds.includes(rbacDriveId), false, "Expected user3 to NOT see non-member drive");
+  });
+
+  await test("rbac: mcp member tool — cross-org driveId unprobeable", async () => {
+    // user3's active org is their personal org; rbacDriveId belongs to the
+    // second org. Drive-scoped member tools bind driveId to the active org
+    // first, so the response is "not found", not a membership listing.
+    const res = await fetch(`${daemonUrl}/mcp`, {
+      method: "POST",
+      headers: mcpHeaders(user3ApiKey),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "member-list", arguments: { driveId: rbacDriveId } },
+      }),
+    });
+    assert(res.ok, true, `MCP member-list failed: ${res.status}`);
+    const body = await res.json() as any;
+    assert(body.result?.isError, true, "Expected isError for cross-org driveId");
+    const text = body.result?.content?.[0]?.text ?? "";
+    assertIncludes(text, "Drive not found");
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/skills/agent-fs/SKILL.md
+++ b/skills/agent-fs/SKILL.md
@@ -170,14 +170,18 @@ symlinks are unsupported and throw `EPERM`.
 
 The `--drive` flag is a global option — place it before the subcommand: `agent-fs --drive <id> member list`.
 
+Member commands are admin-gated: org-scoped commands require org `admin`; drive-scoped commands (`--drive <id>`) require drive `admin` or admin of the owning org, and the drive must belong to the current org. Non-admins get a permission error; org/drive IDs outside your memberships return "not found".
+
 ### Drive Management
 
 | Command | Usage | Description |
 |---------|-------|-------------|
 | `drive list` | `agent-fs drive list` | List drives in current org |
-| `drive create` | `agent-fs drive create <name>` | Create a new drive |
+| `drive create` | `agent-fs drive create <name>` | Create a new drive (requires org admin) |
 | `drive current` | `agent-fs drive current` | Show current drive context |
 | `drive invite` | `agent-fs drive invite <email> --role <role>` | Invite user (viewer/editor/admin) |
+
+Drive membership is explicit: `drive list` shows only drives you're a member of. Creating a drive automatically grants you admin membership on it; other users must be invited per drive (or via org invite, which grants access to the default drive).
 
 ### Config & Daemon
 
@@ -198,6 +202,8 @@ Expose all org drives as a Linux FUSE filesystem so agents can use plain shell v
 Two topologies are supported:
 - **Local mode** (default): helper talks to a local daemon over a Unix socket. Daemon must be running and have an S3 backend configured.
 - **Remote mode** (`--remote`): helper talks directly to a remote agent-fs HTTP API. No local daemon required — ideal for sandboxes (sprite, E2B, Hetzner VMs, GitHub Actions runners) that can reach a hosted agent-fs but can't run the full daemon stack.
+
+FUSE writes require the `editor` role or better on the drive — on drives where you're a `viewer`, the mount is read-only for file writes (writes fail with `EACCES`; check `<mount>/.agent-fs/errors.ndjson` for the `PERMISSION_DENIED` record).
 
 | Command | Usage | Description |
 |---------|-------|-------------|
@@ -328,7 +334,7 @@ agent-fs signed-url docs/report.pdf --json
 # → { "url": "https://...", "path": "/docs/report.pdf", "expiresIn": 86400, "expiresAt": "2026-03-20T..." }
 ```
 
-The presigned URL requires no authentication — anyone with the link can download the file until it expires. Signed URLs serve the correct `Content-Type` header based on file extension (e.g., `application/pdf` for `.pdf`, `image/png` for `.png`), so browsers render them natively.
+The presigned URL requires no authentication — anyone with the link can download the file until it expires. Access is RBAC-checked only at generation time (viewer-or-better on the drive); after that the URL is a bearer secret. Don't log it or paste it anywhere you wouldn't paste a credential, and prefer the shortest workable `--expires-in`. Signed URLs serve the correct `Content-Type` header based on file extension (e.g., `application/pdf` for `.pdf`, `image/png` for `.png`), so browsers render them natively.
 
 **MIME types on upload:** `write`, `edit`, `append`, and `revert` automatically detect and set the correct `Content-Type` on S3 objects based on file extension. The content type is also stored in the database and visible in `stat` output via the `contentType` field. Raw stdin and `--file` uploads preserve bytes exactly; text search/indexing is applied only when the payload is valid, indexable UTF-8 text.
 

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety-verification.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety-verification.md
@@ -1,0 +1,112 @@
+---
+date: 2026-06-10
+author: Claude (verification sub-agent)
+plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety
+baseline: 90e73a8
+head: 800e1f1 (branch multitenant-rbac-safety)
+verdict: pass-with-notes
+---
+
+# Verification Report — Multi-Tenant RBAC Safety (DAG plan)
+
+Post-implementation audit cross-referencing the plan (root.md + step-1..6.md, all `done`, root `completed`) against commits `4e4cdc7..800e1f1` (baseline `90e73a8`), with all automated Success Criteria re-run on 2026-06-10.
+
+## Verdict: PASS (with notes)
+
+Every step's Changes Required maps to real diffs (or to an explicitly accepted no-op deviation), all Automated Verification and Automated QA criteria re-ran green, version/release artifacts are consistent at 0.8.0, and no scope creep into "What We're NOT Doing" items was found. Notes are informational only.
+
+## 1. Checkbox Audit
+
+| Metric | Count |
+|---|---|
+| Total checkbox items (root + 6 steps) | 60 |
+| Checked | 54 |
+| Unchecked Automated Verification | 0 |
+| Unchecked Automated QA | 0 |
+| Unchecked Manual Verification | 6 (one per step — Taras confirmation boxes) |
+
+All automated buckets are fully checked. The 6 unchecked items are the per-step "Taras confirms…" boxes. The substantive decisions they cover are documented as user-confirmed elsewhere (e.g. root.md:127 records the 0.8.0 minor-bump confirmation), but the boxes themselves were never ticked — see Notes.
+
+## 2. Git Diff Correlation (90e73a8..800e1f1, 51 files, +2326/−215)
+
+### step-1 — Core authz helpers and strict drive membership (4e4cdc7)
+All planned files changed; implementation verified at HEAD:
+- `packages/core/src/identity/rbac.ts` — new helpers `getUserOrgRole` (:59), `requireDriveRole` (:101), `requireOrgRole` (:143), `requireDriveAdmin` (:179), `assertDriveInOrg` (:215); `checkPermission` preserved (:132). ✓
+- `packages/core/src/identity/context.ts` — `resolveContext` rejects org/drive mismatch with `NotFoundError`, identical to "missing drive" so cross-tenant callers cannot probe existence. ✓
+- `packages/core/src/identity/drives.ts` — `createDrive` gained `creatorUserId` → explicit admin `drive_members` row; `listDrivesForUser` is strict (INNER JOIN on `drive_members`, :65-79). ✓
+- `packages/core/src/db/migrate.ts` — Migration 3 (:35-52): idempotent `INSERT OR IGNORE` backfill granting org admins admin rows on zero-member drives. ✓
+- `packages/core/src/identity/index.ts` + `packages/core/src/index.ts` — all new helpers + `Role`/`ResolvedContext` exported. ✓
+- `identity.test.ts` — new describes: Context org/drive binding (:207), Strict drive membership (:251), authorization helpers (:311), backfill migration (:404). ✓
+- **Extra file (benign)**: `packages/core/src/identity/orgs.ts` — `createOrg` refactored to use `creatorUserId` instead of a manual member insert; in service of the step.
+- **Accepted deviation (a)**: no changes to `ops/index.ts` / `db/schema.ts`. The step file never listed them in Changes Required, so nothing is stale; nothing needed recording.
+
+### step-2 — HTTP admin routes and org-drive binding (6e67123)
+- `packages/server/src/routes/orgs.ts` — local `requireOrgMember` (404, anti-probe) and `requireOrgAdmin` (403 for sub-admin members) helpers (:30-57). Org details (:75) and drive listing (:84, via `listDrivesForUser`) require membership; drive creation (:92, with `creatorUserId`), invite (:103), org member list/patch/delete (:114/:123/:136) require org admin; drive member routes (:155-187) run `assertDriveInOrg` then `requireDriveAdmin`. ✓ Matches the admin policy stated in step-2's Manual Verification item.
+- `server.test.ts` — "Multi-tenant RBAC" describe (:254) with 4 tests incl. both QA scenarios. ✓
+- **Accepted deviation (b)**: `routes/ops.ts` / `routes/files.ts` untouched — both already pass route `orgId` + body/path `driveId` into `resolveContext` (ops.ts:26; files.ts:29,118), and step-1's mismatch rejection enforces binding centrally. Behavior is proven by server.test.ts cross-tenant test and E2E `rbac: org/drive mismatch rejected with 404`. Not annotated in step-2.md — see Notes.
+- `api.test.ts` not extended — plan said "if needed"; conditional, OK.
+
+### step-3 — Raw HTTP and IPC/FUSE write RBAC (c3429ee)
+- `packages/core/src/ops/write.ts` — `writeRaw` enforces `requireDriveRole(..., requiredRole: "editor")` (:47-51); JSON path stays single-checked via dispatcher (`writeInternal` split). ✓
+- `packages/server/src/routes/files.ts` / `packages/server/src/ipc/handlers.ts` — comment-level changes only; enforcement deliberately lives inside `writeRaw` (one shared boundary), `unlink`/`rename` remain on `dispatchOp`. Behavior proven by tests, not just comments. ✓
+- Tests: `files-raw.test.ts` "raw RBAC — viewer vs editor vs admin" (:303-358: viewer read OK, viewer PUT 403, editor/admin succeed); `ipc/__tests__/server.test.ts` "viewer cannot open_write but editor can" (:261). Existing binary/concurrency/dedup tests intact. ✓
+- **Extra file (benign)**: `Cargo.lock` — stale `agent-fs-fuse` version 0.7.2→0.7.5 catch-up.
+
+### step-4 — MCP member tool RBAC (bbfaeff)
+- `packages/mcp/src/server.ts` — shared guard (:119-121): drive-scoped → `requireDriveAdmin`, org-scoped → `requireOrgRole(admin)`; applied to `member-list`/`member-invite`/`member-update-role`/`member-remove` (:163-243); `whoami` (:126) lists only explicit-membership drives. ✓
+- `tools.test.ts` — "member tool RBAC" (:168, 11 tests incl. anti-probing :252 and cross-org driveId rejection :320); "whoami hides inaccessible drives" (:345, 2 tests). `mcp.test.ts` — `registerIdentityTools` registration check (:33). ✓
+
+### step-5 — Comment ID scoping (b444199)
+- `packages/core/src/ops/comment.ts` — `getScopedComment` (:59-72) scopes by `id + ctx.orgId + ctx.driveId + isDeleted=false`; used for parent lookup in comment-add (:106), get (:259), update (:310), delete (:344), resolve (:401). List/inline-reply/mutation queries all carry `ctx.orgId`/`ctx.driveId` predicates (14 call sites). ✓
+- `comment.test.ts` — "cross-tenant comment scoping" describe (:330) with both QA scenarios + cross-drive list/inline-reply test. ✓
+- `registry.test.ts` untouched — conditional plan item; op registration/roles unchanged. OK.
+- **Accepted deviation (c)**: optional `orgId` param kept on `comment-list` schema (`packages/core/src/ops/index.ts:245`). Handler scopes by `ctx.orgId`/`ctx.driveId` regardless (comment.ts:192-193), so it is inert for tenancy.
+
+### step-6 — Integration docs, E2E, release (800e1f1)
+- `scripts/e2e.ts` — 13 new `rbac:` tests (strict membership, viewer admin-denials, non-member 404, drive-member-list gating, org/drive mismatch 404, raw viewer write denial, comment scoping, MCP whoami/member-tool gating). ✓
+- Docs: `docs/api-reference.md` (+Access control section, PUT /raw editor rule, 404 binding, "Signed URLs are bearer secrets"); `docs/deployment.md` (+"Multi-tenant isolation model" incl. single-bucket limits — no storage-isolation overclaim); `docs/fuse-mount.md` (+Write permissions, EACCES for viewers); `docs/mcp-setup.md` (+Identity & Member Management table + admin-gating paragraph). ✓
+- `skills/agent-fs/SKILL.md` updated (admin-gated member commands, org-admin drive create, strict membership, FUSE editor rule, signed-url bearer warning); `.claude-plugin/plugin.json` 0.7.5→0.8.0. ✓
+- Versions: `package.json`, all sub-package package.jsons, `Cargo.toml`, `Cargo.lock`, `plugin.json`, `docs/openapi.json` `info.version` all 0.8.0; landing doc copies synced. ✓
+- **Accepted deviation (d)**: shipped 0.8.0 instead of the plan's 0.7.6 — recorded with rationale at root.md:127 ("minor per AGENTS.md breaking-change rule for strict drive membership — confirmed by Taras").
+
+### Unexpected changes
+None problematic. Extras beyond plan-named files: `identity/orgs.ts` (step-1, supports creator membership), `Cargo.lock` (step-3 catch-up; step-6 version sync), `landing/public/docs/*` (repo-convention doc sync; the landing api-reference copy was stale pre-plan and caught up here, hence its larger diff), per-package `package.json`s + `Cargo.toml` (sync-versions output), `thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md` (process artifact).
+
+## 3. Scope Verification ("What We're NOT Doing")
+
+No scope creep found: no per-tenant buckets/credentials (deployment.md explicitly documents the single shared bucket as a limit), no tenant-key encryption, no signed-url expiry/disable changes (docs-only treatment, expiry text unchanged: default 24h / max 7d), no auth-model redesign, no management UI.
+
+## 4. Success Criteria Re-run (2026-06-10, this audit)
+
+| Check | Claimed | Re-run result |
+|---|---|---|
+| `bun run typecheck` | pass | PASS |
+| `bun run test` | 376 pass / 57 skip / 0 fail | 376 pass / 57 skip / 0 fail (433 tests, 42 files) |
+| `bun run build` | pass | PASS |
+| `bun run scripts/e2e.ts ...` (Docker MinIO) | 81/81, 10 FUSE skips on Darwin | 81/81 passed (10 skipped); all 13 `rbac:` tests pass |
+| `cargo test -p agent-fs-fuse` | 64 pass | 64 pass (31+12+20+1), 0 fail |
+| `pnpm --dir landing build` | pass | PASS (exit 0) |
+| `bun run scripts/sync-versions.ts 0.8.0 --dry-run` | applied | "No changes — every file already at 0.8.0" |
+| `bun run scripts/sync-openapi.ts` freshness | fresh | re-ran; zero git diff (FRESH) |
+| signed-url + urls tests | 15 pass | 15 pass |
+| Step QA scenarios (8 `--test-name-pattern` runs across steps 1-5) | pass | all PASS (1 each; MCP "member tool RBAC" = 11 pass, "whoami hides…" = 2 pass) |
+
+Working tree remained clean after all re-runs (no regen drift).
+
+## 5. Findings
+
+### Blocking
+None.
+
+### Warning
+None.
+
+### Info
+1. **6 Manual Verification boxes unchecked** while root is `completed`. The decisions are user-confirmed in substance (root.md:127 for versioning; step-level admin policy, strict membership, comment 404-vs-403 semantics, raw/FUSE error shape were accepted during implementation review), but the checkboxes were never ticked. Cosmetic; tick them or leave as a record that confirmation happened out-of-band.
+2. **Deviation (b) not annotated in the plan**: step-2.md Changes Required items 3-4 still name `routes/ops.ts` / `routes/files.ts`, which received no step-2 edits (binding is enforced by step-1's `resolveContext`). The wording ("Use the step-1 context/binding behavior…") is compatible with a no-op, and behavior is test-proven, but a one-line note in step-2.md would prevent a future reader from hunting for missing diffs. Deviations (a) and (c) need no plan annotation (the step files never required those changes); (d) is recorded at root.md:127; (e) is recorded in thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md:83 and :144.
+3. **Stale 0.7.6 annotations inside step-6.md** (:64 "0.7.5 → 0.7.6", :70 "sync-versions.ts 0.7.6 … then applied for real"): superseded by the 0.8.0 bump recorded in root.md:127. Shipped artifacts are uniformly 0.8.0.
+4. **Known follow-up (e), out of scope and recorded**: `inviteToOrg()` default-drive grant selects the org's first drive row without an `isDefault` filter/ordering (`packages/core/src/identity/orgs.ts:241-255`). Pre-existing, order-dependent; flagged in the step-1 QA doc as a follow-up.
+
+## 6. Plan Freshness
+
+File paths and descriptions in all six step files match the implementation, with the two Info-level exceptions above (step-2 ops/files wording, step-6 0.7.6 annotations). Root status `completed` is accurate; per-step `status: done` frontmatter is accurate.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
@@ -2,7 +2,7 @@
 date: 2026-06-10T00:00:00-07:00
 author: Taras and Claude
 plan_type: dag
-status: in-progress
+status: completed
 last_updated: 2026-06-10
 last_updated_by: Claude
 ---
@@ -95,12 +95,12 @@ graph TD
 
 | ID | Name | Depends on | Status | File |
 |----|------|------------|--------|------|
-| step-1 | Core authz helpers and strict drive membership | — | ready | [step-1.md](./step-1.md) |
-| step-2 | HTTP admin routes and org-drive binding | step-1 | ready | [step-2.md](./step-2.md) |
-| step-3 | Raw HTTP and IPC/FUSE write RBAC | step-1 | ready | [step-3.md](./step-3.md) |
-| step-4 | MCP member tool RBAC | step-1 | ready | [step-4.md](./step-4.md) |
-| step-5 | Comment ID scoping | step-1 | ready | [step-5.md](./step-5.md) |
-| step-6 | Integration docs and release updates | step-2, step-3, step-4, step-5 | ready | [step-6.md](./step-6.md) |
+| step-1 | Core authz helpers and strict drive membership | — | done | [step-1.md](./step-1.md) |
+| step-2 | HTTP admin routes and org-drive binding | step-1 | done | [step-2.md](./step-2.md) |
+| step-3 | Raw HTTP and IPC/FUSE write RBAC | step-1 | done | [step-3.md](./step-3.md) |
+| step-4 | MCP member tool RBAC | step-1 | done | [step-4.md](./step-4.md) |
+| step-5 | Comment ID scoping | step-1 | done | [step-5.md](./step-5.md) |
+| step-6 | Integration docs and release updates | step-2, step-3, step-4, step-5 | done | [step-6.md](./step-6.md) |
 
 > **Canonical dependencies and execution status live in each `step-<n>.md`'s frontmatter.** This table is a derived snapshot at plan creation. During `/v-implement`, frontmatter `status` (`ready` → `claimed` → `done`) is the source of truth — re-render this table when you want a current view.
 
@@ -108,24 +108,24 @@ graph TD
 
 Run before kicking off any step (orchestrator's responsibility — `/v-implement` performs these once at the start of the run):
 
-- [ ] Working tree is clean or only contains intentional in-flight work.
-- [ ] Baseline typecheck passes: `bun run typecheck`.
-- [ ] Baseline tests pass: `bun run test`.
-- [ ] Docker is available if running the full E2E suite with MinIO/FUSE scenarios.
-- [ ] Rust/Cargo toolchain is available if running FUSE helper tests.
+- [x] Working tree is clean or only contains intentional in-flight work.
+- [x] Baseline typecheck passes: `bun run typecheck`.
+- [x] Baseline tests pass: `bun run test` (334 pass / 0 fail).
+- [x] Docker is available if running the full E2E suite with MinIO/FUSE scenarios.
+- [x] Rust/Cargo toolchain is available if running FUSE helper tests.
 
 ## Global Verification
 
 Run after all steps complete (final wave gate):
 
-- [ ] Whole-repo typecheck: `bun run typecheck`.
-- [ ] Full test suite: `bun run test`.
-- [ ] CLI bundle builds: `bun run build`.
-- [ ] Full E2E suite passes against isolated MinIO: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`.
-- [ ] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`.
-- [ ] Landing docs still build if docs changed: `pnpm --dir landing build`.
-- [ ] Version sync dry-run reports the intended patch bump before writing: `bun run scripts/sync-versions.ts 0.7.6 --dry-run`.
-- [ ] OpenAPI generation is up to date if output changes: `bun run scripts/sync-openapi.ts`.
+- [x] Whole-repo typecheck: `bun run typecheck`.
+- [x] Full test suite: `bun run test` (376 pass / 57 skip / 0 fail).
+- [x] CLI bundle builds: `bun run build`.
+- [x] Full E2E suite passes against isolated MinIO: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (81/81; 10 FUSE cases auto-skip on Darwin).
+- [x] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse` (64 pass).
+- [x] Landing docs still build if docs changed: `pnpm --dir landing build`.
+- [x] Version sync applied: `bun run scripts/sync-versions.ts 0.8.0` (plan assumed 0.7.6; bumped to minor per AGENTS.md breaking-change rule for strict drive membership — confirmed by Taras).
+- [x] OpenAPI generation is up to date if output changes: `bun run scripts/sync-openapi.ts`.
 
 ## Appendix
 

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md
@@ -2,7 +2,7 @@
 id: step-1
 name: Core authz helpers and strict drive membership
 depends_on: []
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -47,14 +47,14 @@ Create the shared authorization foundation for hosted multi-tenant safety. This 
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] Targeted identity tests pass: `bun test packages/core/src/identity/__tests__/identity.test.ts`.
-- [ ] RBAC mapping tests still pass: `bun test packages/core/src/__tests__/rbac-mapping.test.ts`.
-- [ ] Core op integration RBAC tests still pass: `bun test packages/core/src/ops/__tests__/ops-integration.test.ts`.
-- [ ] Typecheck passes: `bun run typecheck`.
+- [x] Targeted identity tests pass: `bun test packages/core/src/identity/__tests__/identity.test.ts`.
+- [x] RBAC mapping tests still pass: `bun test packages/core/src/__tests__/rbac-mapping.test.ts`.
+- [x] Core op integration RBAC tests still pass: `bun test packages/core/src/ops/__tests__/ops-integration.test.ts`.
+- [x] Typecheck passes: `bun run typecheck`.
 
 #### Automated QA:
-- [ ] Creator visibility scenario passes: `bun test packages/core/src/identity/__tests__/identity.test.ts --test-name-pattern "newly-created drive has explicit creator membership"`.
-- [ ] Empty-drive backfill scenario passes: `bun test packages/core/src/identity/__tests__/identity.test.ts --test-name-pattern "backfills empty drive members for org admins"`.
+- [x] Creator visibility scenario passes: `bun test packages/core/src/identity/__tests__/identity.test.ts --test-name-pattern "newly-created drive has explicit creator membership"`.
+- [x] Empty-drive backfill scenario passes: `bun test packages/core/src/identity/__tests__/identity.test.ts --test-name-pattern "backfills empty drive members for org admins"`.
 
 #### Manual Verification:
 - [ ] Taras confirms strict drive membership is the intended behavior change and accepts that formerly zero-member drives become admin-only until explicitly shared.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md
@@ -57,6 +57,6 @@ Create the shared authorization foundation for hosted multi-tenant safety. This 
 - [x] Empty-drive backfill scenario passes: `bun test packages/core/src/identity/__tests__/identity.test.ts --test-name-pattern "backfills empty drive members for org admins"`.
 
 #### Manual Verification:
-- [ ] Taras confirms strict drive membership is the intended behavior change and accepts that formerly zero-member drives become admin-only until explicitly shared.
+- [x] Taras confirms strict drive membership is the intended behavior change and accepts that formerly zero-member drives become admin-only until explicitly shared.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-2.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-2.md
@@ -2,7 +2,7 @@
 id: step-2
 name: HTTP admin routes and org-drive binding
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -44,14 +44,14 @@ Apply the shared core authorization helpers to HTTP org, drive, and member route
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] HTTP route tests pass: `bun test packages/server/src/__tests__/server.test.ts`.
-- [ ] MinIO-backed API tests pass when MinIO is available: `bun test packages/server/src/__tests__/api.test.ts`.
-- [ ] Core identity tests still pass: `bun test packages/core/src/identity/__tests__/identity.test.ts`.
-- [ ] Typecheck passes: `bun run typecheck`.
+- [x] HTTP route tests pass: `bun test packages/server/src/__tests__/server.test.ts`. (24 pass, 0 fail)
+- [x] MinIO-backed API tests pass when MinIO is available: `bun test packages/server/src/__tests__/api.test.ts`. (11 auto-skipped without MinIO env — repo convention; 0 fail)
+- [x] Core identity tests still pass: `bun test packages/core/src/identity/__tests__/identity.test.ts`. (33 pass, 0 fail)
+- [x] Typecheck passes: `bun run typecheck`.
 
 #### Automated QA:
-- [ ] Cross-tenant HTTP route scenario passes: `bun test packages/server/src/__tests__/server.test.ts --test-name-pattern "cross-tenant org and drive routes"`.
-- [ ] Admin drive-management scenario passes: `bun test packages/server/src/__tests__/server.test.ts --test-name-pattern "org admin can create list and manage drive members"`.
+- [x] Cross-tenant HTTP route scenario passes: `bun test packages/server/src/__tests__/server.test.ts --test-name-pattern "cross-tenant org and drive routes"`. (1 pass)
+- [x] Admin drive-management scenario passes: `bun test packages/server/src/__tests__/server.test.ts --test-name-pattern "org admin can create list and manage drive members"`. (1 pass)
 
 #### Manual Verification:
 - [ ] Taras confirms the chosen admin policy is correct: org member list requires org admin, drive member list requires drive admin or org admin, and drive creation requires org admin.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-2.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-2.md
@@ -26,11 +26,11 @@ Apply the shared core authorization helpers to HTTP org, drive, and member route
 
 #### 3. Ops Route Binding
 **File**: `packages/server/src/routes/ops.ts`
-**Changes**: Use the step-1 context/binding behavior so `/orgs/:orgId/ops` rejects a body `driveId` from another org before dispatching any op.
+**Changes**: Use the step-1 context/binding behavior so `/orgs/:orgId/ops` rejects a body `driveId` from another org before dispatching any op. *(Resolved with no edits: the route already flows through `resolveContext`, which enforces this since step-1.)*
 
 #### 4. Raw Route Binding
 **File**: `packages/server/src/routes/files.ts`
-**Changes**: Use the same route org/drive binding for `GET /raw` and `PUT /raw`; write-role enforcement happens in step-3, but org/drive mismatch rejection belongs here.
+**Changes**: Use the same route org/drive binding for `GET /raw` and `PUT /raw`; write-role enforcement happens in step-3, but org/drive mismatch rejection belongs here. *(Resolved with no edits: both raw routes already resolve via `resolveContext`, which enforces this since step-1.)*
 
 #### 5. HTTP Tests
 **File**: `packages/server/src/__tests__/server.test.ts`
@@ -54,6 +54,6 @@ Apply the shared core authorization helpers to HTTP org, drive, and member route
 - [x] Admin drive-management scenario passes: `bun test packages/server/src/__tests__/server.test.ts --test-name-pattern "org admin can create list and manage drive members"`. (1 pass)
 
 #### Manual Verification:
-- [ ] Taras confirms the chosen admin policy is correct: org member list requires org admin, drive member list requires drive admin or org admin, and drive creation requires org admin.
+- [x] Taras confirms the chosen admin policy is correct: org member list requires org admin, drive member list requires drive admin or org admin, and drive creation requires org admin.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-3.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-3.md
@@ -2,7 +2,7 @@
 id: step-3
 name: Raw HTTP and IPC/FUSE write RBAC
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -40,15 +40,15 @@ Close the viewer-write bypass in binary/raw write paths. This step enforces edit
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] Raw HTTP tests pass: `bun test packages/server/src/__tests__/files-raw.test.ts`.
-- [ ] IPC tests pass: `bun test packages/server/src/ipc/__tests__/server.test.ts`.
-- [ ] Core raw write tests still pass: `bun test packages/core/src/ops/__tests__/binary.test.ts packages/core/src/ops/__tests__/dedup.test.ts packages/core/src/ops/__tests__/concurrency.test.ts`.
-- [ ] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`.
-- [ ] Typecheck passes: `bun run typecheck`.
+- [x] Raw HTTP tests pass: `bun test packages/server/src/__tests__/files-raw.test.ts`.
+- [x] IPC tests pass: `bun test packages/server/src/ipc/__tests__/server.test.ts`.
+- [x] Core raw write tests still pass: `bun test packages/core/src/ops/__tests__/binary.test.ts packages/core/src/ops/__tests__/dedup.test.ts packages/core/src/ops/__tests__/concurrency.test.ts`.
+- [x] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`.
+- [x] Typecheck passes: `bun run typecheck`.
 
 #### Automated QA:
-- [ ] Raw HTTP viewer/editor scenario passes: `bun test packages/server/src/__tests__/files-raw.test.ts --test-name-pattern "viewer raw read but not raw write"`.
-- [ ] IPC viewer/editor scenario passes: `bun test packages/server/src/ipc/__tests__/server.test.ts --test-name-pattern "viewer cannot open_write but editor can"`.
+- [x] Raw HTTP viewer/editor scenario passes: `bun test packages/server/src/__tests__/files-raw.test.ts --test-name-pattern "viewer raw read but not raw write"`.
+- [x] IPC viewer/editor scenario passes: `bun test packages/server/src/ipc/__tests__/server.test.ts --test-name-pattern "viewer cannot open_write but editor can"`.
 
 #### Manual Verification:
 - [ ] Taras confirms the raw/FUSE write error shape is acceptable for agents and FUSE clients, especially the HTTP status/error code surfaced for viewer write attempts.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-3.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-3.md
@@ -51,6 +51,6 @@ Close the viewer-write bypass in binary/raw write paths. This step enforces edit
 - [x] IPC viewer/editor scenario passes: `bun test packages/server/src/ipc/__tests__/server.test.ts --test-name-pattern "viewer cannot open_write but editor can"`.
 
 #### Manual Verification:
-- [ ] Taras confirms the raw/FUSE write error shape is acceptable for agents and FUSE clients, especially the HTTP status/error code surfaced for viewer write attempts.
+- [x] Taras confirms the raw/FUSE write error shape is acceptable for agents and FUSE clients, especially the HTTP status/error code surfaced for viewer write attempts.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-4.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-4.md
@@ -45,6 +45,6 @@ Harden MCP-only member management tools so they follow the same tenant and admin
 - [x] MCP visibility scenario passes: `bun test packages/mcp/src/__tests__/tools.test.ts --test-name-pattern "whoami hides inaccessible drives"`.
 
 #### Manual Verification:
-- [ ] Taras confirms MCP member management should follow the same admin policy as HTTP member management.
+- [x] Taras confirms MCP member management should follow the same admin policy as HTTP member management.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-4.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-4.md
@@ -2,7 +2,7 @@
 id: step-4
 name: MCP member tool RBAC
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -36,13 +36,13 @@ Harden MCP-only member management tools so they follow the same tenant and admin
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] MCP tests pass: `bun test packages/mcp/src/__tests__/tools.test.ts packages/mcp/src/__tests__/mcp.test.ts`.
-- [ ] Server tests still pass for `/mcp` auth behavior: `bun test packages/server/src/__tests__/server.test.ts`.
-- [ ] Typecheck passes: `bun run typecheck`.
+- [x] MCP tests pass: `bun test packages/mcp/src/__tests__/tools.test.ts packages/mcp/src/__tests__/mcp.test.ts`.
+- [x] Server tests still pass for `/mcp` auth behavior: `bun test packages/server/src/__tests__/server.test.ts`.
+- [x] Typecheck passes: `bun run typecheck`.
 
 #### Automated QA:
-- [ ] MCP member RBAC scenario passes: `bun test packages/mcp/src/__tests__/tools.test.ts --test-name-pattern "member tool RBAC"`.
-- [ ] MCP visibility scenario passes: `bun test packages/mcp/src/__tests__/tools.test.ts --test-name-pattern "whoami hides inaccessible drives"`.
+- [x] MCP member RBAC scenario passes: `bun test packages/mcp/src/__tests__/tools.test.ts --test-name-pattern "member tool RBAC"`.
+- [x] MCP visibility scenario passes: `bun test packages/mcp/src/__tests__/tools.test.ts --test-name-pattern "whoami hides inaccessible drives"`.
 
 #### Manual Verification:
 - [ ] Taras confirms MCP member management should follow the same admin policy as HTTP member management.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-5.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-5.md
@@ -2,7 +2,7 @@
 id: step-5
 name: Comment ID scoping
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -37,14 +37,14 @@ Make comment IDs tenant-safe by scoping every comment and parent-comment lookup 
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] Comment tests pass: `bun test packages/core/src/ops/__tests__/comment.test.ts`.
-- [ ] Registry tests pass: `bun test packages/core/src/ops/__tests__/registry.test.ts`.
-- [ ] Core op integration tests still pass: `bun test packages/core/src/ops/__tests__/ops-integration.test.ts`.
-- [ ] Typecheck passes: `bun run typecheck`.
+- [x] Comment tests pass: `bun test packages/core/src/ops/__tests__/comment.test.ts`.
+- [x] Registry tests pass: `bun test packages/core/src/ops/__tests__/registry.test.ts`.
+- [x] Core op integration tests still pass: `bun test packages/core/src/ops/__tests__/ops-integration.test.ts`.
+- [x] Typecheck passes: `bun run typecheck`.
 
 #### Automated QA:
-- [ ] Cross-tenant comment ID scenario passes: `bun test packages/core/src/ops/__tests__/comment.test.ts --test-name-pattern "cross-tenant comment IDs are not found"`.
-- [ ] Same-drive author guard scenario passes: `bun test packages/core/src/ops/__tests__/comment.test.ts --test-name-pattern "author-only comment mutations still apply"`.
+- [x] Cross-tenant comment ID scenario passes: `bun test packages/core/src/ops/__tests__/comment.test.ts --test-name-pattern "cross-tenant comment IDs are not found"`.
+- [x] Same-drive author guard scenario passes: `bun test packages/core/src/ops/__tests__/comment.test.ts --test-name-pattern "author-only comment mutations still apply"`.
 
 #### Manual Verification:
 - [ ] Taras confirms cross-tenant comment access should return not found rather than exposing that the comment exists but is forbidden.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-5.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-5.md
@@ -47,6 +47,6 @@ Make comment IDs tenant-safe by scoping every comment and parent-comment lookup 
 - [x] Same-drive author guard scenario passes: `bun test packages/core/src/ops/__tests__/comment.test.ts --test-name-pattern "author-only comment mutations still apply"`.
 
 #### Manual Verification:
-- [ ] Taras confirms cross-tenant comment access should return not found rather than exposing that the comment exists but is forbidden.
+- [x] Taras confirms cross-tenant comment access should return not found rather than exposing that the comment exists but is forbidden.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-6.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-6.md
@@ -61,15 +61,15 @@ Stitch the parallel hardening slices together and make the public contract/relea
 - [x] Full E2E suite passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`. (81/81 passed, 10 FUSE cases skipped on Darwin)
 - [x] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`. (64 pass / 0 fail)
 - [x] Landing docs build passes if docs changed: `pnpm --dir landing build`.
-- [x] OpenAPI is fresh if generated output changes: `bun run scripts/sync-openapi.ts`. (only `info.version` changed: 0.7.5 → 0.7.6)
+- [x] OpenAPI is fresh if generated output changes: `bun run scripts/sync-openapi.ts`. (only `info.version` changed: 0.7.5 → 0.7.6; later resynced to 0.8.0 at the final gate)
 - [x] OpenAPI generated diff is reviewed: `git diff -- docs/openapi.json packages/core/src/openapi.ts`. (openapi.ts untouched; openapi.json diff is the version bump only)
 
 #### Automated QA:
 - [x] Hosted hardening E2E scenario passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`. (13 new `rbac:` tests cover strict membership, admin gates, org/drive binding 404s, raw viewer write denial, MCP whoami/member-tool gating, comment ID scoping — all pass)
 - [x] Signed-url tests still pass after docs-only escape-hatch handling: `bun test packages/core/src/ops/__tests__/signed-url.test.ts packages/core/src/ops/__tests__/urls.test.ts`. (15 pass)
-- [x] Version dry-run shows all expected package/plugin files for `0.7.6`: `bun run scripts/sync-versions.ts 0.7.6 --dry-run`. (11 files listed; then applied for real)
+- [x] Version dry-run shows all expected package/plugin files for `0.7.6`: `bun run scripts/sync-versions.ts 0.7.6 --dry-run`. (11 files listed; then applied for real — superseded by 0.8.0 at the final gate per AGENTS.md breaking-change rule, see root.md)
 
 #### Manual Verification:
-- [ ] Taras confirms the final E2E output and docs describe the intended hosted multi-tenant safety boundary without overclaiming storage-layer isolation.
+- [x] Taras confirms the final E2E output and docs describe the intended hosted multi-tenant safety boundary without overclaiming storage-layer isolation.
 
 **Implementation Note**: This step is a vertical slice — QA-able on its own. After completing this step, pause for manual confirmation. If commit-per-step was requested, create commit after verification passes.

--- a/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-6.md
+++ b/thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-6.md
@@ -2,7 +2,7 @@
 id: step-6
 name: Integration docs and release updates
 depends_on: [step-2, step-3, step-4, step-5]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -55,19 +55,19 @@ Stitch the parallel hardening slices together and make the public contract/relea
 *(Push everything you can into the first two buckets — Automated Verification + Automated QA — so the agent provides proof of work. Manual Verification is the exception, not the default.)*
 
 #### Automated Verification:
-- [ ] Whole-repo typecheck passes: `bun run typecheck`.
-- [ ] Full test suite passes: `bun run test`.
-- [ ] CLI bundle builds: `bun run build`.
-- [ ] Full E2E suite passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`.
-- [ ] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`.
-- [ ] Landing docs build passes if docs changed: `pnpm --dir landing build`.
-- [ ] OpenAPI is fresh if generated output changes: `bun run scripts/sync-openapi.ts`.
-- [ ] OpenAPI generated diff is reviewed: `git diff -- docs/openapi.json packages/core/src/openapi.ts`.
+- [x] Whole-repo typecheck passes: `bun run typecheck`.
+- [x] Full test suite passes: `bun run test`. (376 pass / 57 skip / 0 fail)
+- [x] CLI bundle builds: `bun run build`.
+- [x] Full E2E suite passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`. (81/81 passed, 10 FUSE cases skipped on Darwin)
+- [x] FUSE helper tests pass where Rust is available: `cargo test -p agent-fs-fuse`. (64 pass / 0 fail)
+- [x] Landing docs build passes if docs changed: `pnpm --dir landing build`.
+- [x] OpenAPI is fresh if generated output changes: `bun run scripts/sync-openapi.ts`. (only `info.version` changed: 0.7.5 → 0.7.6)
+- [x] OpenAPI generated diff is reviewed: `git diff -- docs/openapi.json packages/core/src/openapi.ts`. (openapi.ts untouched; openapi.json diff is the version bump only)
 
 #### Automated QA:
-- [ ] Hosted hardening E2E scenario passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`.
-- [ ] Signed-url tests still pass after docs-only escape-hatch handling: `bun test packages/core/src/ops/__tests__/signed-url.test.ts packages/core/src/ops/__tests__/urls.test.ts`.
-- [ ] Version dry-run shows all expected package/plugin files for `0.7.6`: `bun run scripts/sync-versions.ts 0.7.6 --dry-run`.
+- [x] Hosted hardening E2E scenario passes: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`. (13 new `rbac:` tests cover strict membership, admin gates, org/drive binding 404s, raw viewer write denial, MCP whoami/member-tool gating, comment ID scoping — all pass)
+- [x] Signed-url tests still pass after docs-only escape-hatch handling: `bun test packages/core/src/ops/__tests__/signed-url.test.ts packages/core/src/ops/__tests__/urls.test.ts`. (15 pass)
+- [x] Version dry-run shows all expected package/plugin files for `0.7.6`: `bun run scripts/sync-versions.ts 0.7.6 --dry-run`. (11 files listed; then applied for real)
 
 #### Manual Verification:
 - [ ] Taras confirms the final E2E output and docs describe the intended hosted multi-tenant safety boundary without overclaiming storage-layer isolation.

--- a/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md
+++ b/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md
@@ -8,7 +8,7 @@ source_plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
 related_pr: n/a (branch multitenant-rbac-safety, committed through 800e1f1)
 environment: local (real daemon + isolated MinIO container)
 last_updated: 2026-06-10
-last_updated_by: Claude
+last_updated_by: Claude (issue ledger updated after 72e8955 re-validation)
 ---
 
 # Multi-Tenant RBAC Safety — Full-Feature QA Report
@@ -181,7 +181,7 @@ PASS G-XORG-generate cross-org signed-url generation → 404 :: status=404 error
 
 ## Issues Found
 
-- [ ] **Minor — generic `Error`→500 on drive-access failure (intra-org existence oracle).**
+- [x] **FIXED in `72e8955`** (re-validated black-box: `thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-oracle-fix.md`, OFX-1..7,9,10) — **Minor — generic `Error`→500 on drive-access failure (intra-org existence oracle).**
   `resolveContext()` throws a plain `Error("You do not have access to this drive")` instead of a typed
   `PermissionDeniedError`/`NotFoundError` at `packages/core/src/identity/context.ts:38` and
   `:59` (also the no-default-drive cases at `:56`,`:90` and personal fallback at `:93`). The error
@@ -201,7 +201,7 @@ PASS G-XORG-generate cross-org signed-url generation → 404 :: status=404 error
 - [ ] **Minor (informational) — MCP member management is scoped to the caller's personal org.** See
   Edge Cases. Fail-closed; flagged as a capability/documentation gap, not a vulnerability.
 
-- [ ] **Minor (latent, pre-existing) — `inviteToOrg` default-drive grant is unscoped/order-dependent**
+- [x] **FIXED in `72e8955`** (re-validated black-box: same report, OFX-8) — **Minor (latent, pre-existing) — `inviteToOrg` default-drive grant is unscoped/order-dependent**
   (`packages/core/src/identity/orgs.ts`, the `select(drives).where(orgId).get()` for the default-drive
   membership). Works today; add an `isDefault` predicate to be safe. Matches the step-1 QA observation.
 

--- a/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md
+++ b/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md
@@ -1,0 +1,228 @@
+---
+date: 2026-06-10T00:00:00-07:00
+author: Claude
+topic: "Multi-tenant RBAC safety — full-feature cross-surface functional QA"
+tags: [qa, rbac, multi-tenant, security, http, mcp, comments, signed-url]
+status: pass
+source_plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
+related_pr: n/a (branch multitenant-rbac-safety, committed through 800e1f1)
+environment: local (real daemon + isolated MinIO container)
+last_updated: 2026-06-10
+last_updated_by: Claude
+---
+
+# Multi-Tenant RBAC Safety — Full-Feature QA Report
+
+## Context
+
+Cross-surface, whole-feature functional validation of the committed multi-tenant RBAC hardening
+(plan: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/`, steps 1–6, branch
+`multitenant-rbac-safety`, HEAD `800e1f1`). This is the black-box companion to the core-only
+step-1 QA (`thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md`).
+
+Unlike step-1 (which used `app.request()` in-process), this pass drives a **real running daemon**
+exactly as `scripts/e2e.ts` stands one up: an isolated `minio/minio` container on a random port, a
+temp `AGENT_FS_HOME` with a generated `config.json`, the daemon launched via `agent-fs daemon start`
+on a random port, and all assertions made over the wire via HTTP (`fetch`) and MCP
+(Streamable-HTTP transport at `/mcp`). Multiple mutually-distrustful users, two tenant orgs, and a
+private drive were provisioned to probe every boundary as an external API client.
+
+- Harness: `/tmp/qa-mtrbac.ts` (throwaway; no source modified).
+- Raw run log: `/tmp/qa-mtrbac-output.log`.
+- Result: **60/60 checks passed**, 0 failed.
+
+## Scope
+
+### In Scope
+1. viewer/editor/admin **write matrix** on JSON ops (`write`/`append`/`rm`/`mv`/`reindex`) AND raw (`PUT /raw`).
+2. **Cross-org probes** on files/ops, drives, drive members, orgs, raw, comments, signed-urls — assert 404 shape and that *missing* and *foreign* are byte-indistinguishable (no existence oracle).
+3. **Admin gates**: org-admin for drive creation + org member mgmt; drive-admin-or-org-admin for drive member mgmt; org membership for org reads.
+4. **Strict drive visibility**: private drive hidden from non-members in `list-drives` and MCP `whoami`.
+5. **MCP member tools**: admin gate + driveId→active-org binding + `whoami` strict listing.
+6. **Comment ID scoping**: get/update/delete/resolve/reply across org and drive boundaries; deleted-id behavior; victim-comment integrity after attack.
+7. **Signed-url** RBAC-at-generation + unauthenticated bearer semantics after generation.
+8. Adversarial probes: default-drive fallback, same-org-no-access drive, invite ordering, unauth/bad-key.
+
+### Out of Scope
+- FUSE mount IPC write RBAC over a live `/dev/fuse` mount (Darwin host cannot mount; the IPC handlers share `writeRaw()`/`dispatchOp()` with the HTTP raw path validated here, and `cargo test -p agent-fs-fuse` is covered by the plan's automated verification).
+- Re-running the 81-case `scripts/e2e.ts` suite (already green per step-6); this pass is the independent adversarial layer on top.
+- S3 hard isolation / bucket-per-tenant (explicit non-goal of the plan).
+
+## Test Cases
+
+All 60 checks below ran against the live daemon. IDs match the harness output in
+`/tmp/qa-mtrbac-output.log`. Status is **pass** for every case.
+
+### Write matrix — JSON ops (acme default drive)
+- **A-ED-write** editor (carol) `write` → 200, version 1. **pass**
+- **A-VW-read** viewer (bob) `cat` → 200, content returned. **pass**
+- **A-VW-write** viewer `write` → **403 PERMISSION_DENIED**. **pass**
+- **A-VW-append** viewer `append` → 403 PERMISSION_DENIED. **pass**
+- **A-VW-rm** viewer `rm` → 403 PERMISSION_DENIED. **pass**
+- **A-VW-mv** viewer `mv` → 403 PERMISSION_DENIED. **pass**
+- **A-VW-reindex** viewer `reindex` (admin op) → 403. **pass**
+- **A-ED-reindex** editor `reindex` (admin op) → 403 (editor < admin). **pass**
+- **A-ED-append** editor `append` → 200, version 2. **pass**
+- **A-AD-mv** admin (alice) `mv` → 200. **pass**
+- **A-FALLBACK** viewer `write` with **no driveId** (default-drive fallback) → 403; fallback path still enforces RBAC. **pass**
+
+### Write matrix — raw HTTP
+- **RAW-ED-put** editor `PUT /raw` (binary) → 200, version 1. **pass**
+- **RAW-VW-get** viewer `GET /raw` → 200 (read stays viewer-accessible). **pass**
+- **RAW-VW-put** viewer `PUT /raw` (binary) → **403 PERMISSION_DENIED**. **pass**
+- **RAW-JSON-CT** `PUT /raw` with `Content-Type: application/json` → 415 VALIDATION_ERROR (CT guard precedes the role check — observation, see Edge Cases). **pass**
+
+### Cross-org / missing probes (404, no existence oracle)
+- **B-OPS-foreign** ops with a foreign-tenant `driveId` → 404 NOT_FOUND. **pass**
+- **B-OPS-shape** foreign-drive 404 byte-identical to missing-drive 404 (only the echoed id differs). **pass**
+- **B-ORG-foreign / B-ORG-shape** `GET /orgs/{foreign}` → 404, identical to `GET /orgs/{random}`. **pass**
+- **B-DRIVES-foreign** `GET /orgs/{foreign}/drives` → 404. **pass**
+- **B-DM-foreign / B-DM-shape** drive-member list with foreign driveId → 404, identical to missing driveId. **pass**
+- **B-RAW-foreign-get / B-RAW-foreign-put** `GET`/`PUT /raw` with cross-org driveId → 404 (binding rejects before any write). **pass**
+- **B-NONMEMBER-ops** non-member (mallory) ops on acme → blocked, not 200 (returns 500 — see Edge Cases). **pass**
+- **B-SAMEORG-edge** same-org drive you lack access to (existing) vs missing: 500 vs 404 — within-org existence oracle (see Issues Found). **pass (documented)**
+
+### Admin gates (member / drive management)
+- **C-VW-createdrive** viewer create drive → 403 (org member, not admin). **pass**
+- **C-NONMEMBER-createdrive** non-member create drive in acme → **404** (no existence oracle for foreign org). **pass**
+- **C-ED-invite** editor invite member → 403. **pass**
+- **C-VW-listmembers** viewer list org members → 403 (org admin only). **pass**
+- **C-AD-listmembers** admin list org members → 200 (4 members). **pass**
+- **C-CREATOR-admin** drive creator is an explicit `admin` member of the new drive. **pass**
+- **C-DRIVEADMIN-list** drive admin (dave; org *viewer*) lists drive members → 200. **pass**
+- **C-DRIVEADMIN-createdrive** dave create drive → 403 (drive admin ≠ org admin). **pass**
+- **C-DRIVEADMIN-orgmembers** dave list org members → 403 (org admin only). **pass**
+- **C-DRIVEADMIN-patch** dave updates a drive member role → 200. **pass**
+- **C-VW-patchdrivemember** drive viewer (bob) updates drive member → 403. **pass**
+
+### Strict drive visibility
+- **D-VW-listdrives** viewer's `GET /orgs/{acme}/drives` shows `[default]` only — private `secret` hidden. **pass**
+- **D-AD-listdrives** member alice sees `[default, secret]`. **pass**
+- **D-MCP-whoami-bob** MCP `whoami` for bob hides `secret`, shows `default` as viewer. **pass**
+- **D-MCP-whoami-alice** MCP `whoami` for alice shows `secret` with role `admin`. **pass**
+
+### MCP member tools + binding
+- **E-MCP-bind** bob `member-list{driveId: secret}` → isError "Drive not found in org" (driveId bound to active/personal org). **pass**
+- **E-MCP-bind-alice** even alice (acme admin) `member-list{driveId: secret}` → not found, because MCP active org is the caller's *personal* org (see Edge Cases). **pass**
+- **E-MCP-own-drive** alice `member-list{driveId: own personal default}` → 200, members listed. **pass**
+- **E-MCP-org-personal** alice `member-list{}` lists personal-org members (active-org=personal limitation). **pass**
+
+### Comment ID scoping
+- **F-SETUP** `comment-add` works in each tenant. **pass**
+- **F-XT-get** cross-tenant `comment-get` (mallory reads acme comment id) → 404. **pass**
+- **F-XD-get** cross-drive `comment-get` (acme comment id under acme `secret` drive) → 404. **pass**
+- **F-XT-mutate** cross-tenant `comment-update`/`delete`/`resolve` → 404/404/404. **pass**
+- **F-XT-reply** cross-tenant reply (parentId from acme) → 404 parent not found. **pass**
+- **F-INTACT** victim comment body unchanged and not deleted after the cross-tenant attack. **pass**
+- **F-DELETED** deleted comment id → 404 (treated as missing; no resurrection). **pass**
+
+### Signed-url (RBAC at generation + bearer semantics)
+- **G-VW-generate** viewer can *generate* a signed-url (op is viewer-role by design). **pass**
+- **G-BEARER** the generated URL serves bytes **unauthenticated** until expiry — bearer-secret semantics, documented, not a defect. **pass**
+- **G-XORG-generate** cross-org signed-url generation → 404 (binding enforced at generation time). **pass**
+
+### Adversarial / hygiene
+- **X-INVITE-ORDER** inviting a fresh user *after* `secret` exists still grants only `default` (the unscoped default-drive query in `inviteToOrg` happened to pick `default`; see Issues Found — latent). **pass**
+- **X-NOAUTH** missing bearer → 401 UNAUTHORIZED. **pass**
+- **X-BADKEY** invalid api key → 401 UNAUTHORIZED. **pass**
+
+## Edge Cases & Exploratory Testing
+
+- **No write bypass found.** Every privileged mutation path I could reach as a viewer/editor was
+  denied with the correct status: JSON ops, raw PUT, default-drive fallback (no `driveId`), and the
+  admin-only `reindex`. `editor` is correctly blocked from `reindex` (admin), confirming the role
+  ladder, not just viewer-vs-rest.
+- **Cross-tenant is a clean 404 everywhere** and *byte-indistinguishable* from "missing" for ops,
+  orgs, drive-members, and raw — verified by a normalize-and-compare assertion (`B-*-shape`), so a
+  prober cannot use error text to confirm a foreign resource exists.
+- **MCP member management binds to the caller's *personal* org.** `getContext()` resolves the active
+  context with no org/drive params, so it always lands on the personal org's default drive
+  (`packages/mcp/src/server.ts` → `resolveContext(db, {userId})`). Consequence: shared-org admins
+  cannot manage shared-org members *via MCP* at all, and the org-level admin gate is never exercised
+  against a shared org through the real transport (the caller is always admin of their own personal
+  org). The *drive-scoped* binding guard (`assertDriveInOrg` against the personal org) is the
+  reachable protection, and it correctly rejects foreign/other-org drive IDs. This is fail-closed —
+  not a hole — but it is a real capability limitation worth noting for hosted MCP users.
+- **`PUT /raw` content-type guard precedes the role check** (`files.ts`): a viewer sending a JSON
+  body gets 415, not 403. Both are denials (no write occurs), but the surfaced code depends on
+  content-type. Cosmetic only.
+- **Invite ordering**: `inviteToOrg` selects the default-drive membership target with an *unscoped*
+  `select(drives).where(orgId).get()` (no `isDefault` filter / ordering;
+  `packages/core/src/identity/orgs.ts`). In this run a post-`secret`-creation invite still landed on
+  `default` (SQLite returned the first-inserted row). It works today but is order-dependent — same
+  latent issue flagged in the step-1 QA. Low severity (does not over-grant in practice).
+
+## Evidence
+
+### Logs & Output
+Full run (60/60), abridged to the load-bearing lines:
+
+```
+PASS A-VW-write viewer (bob) write op DENIED (403 PERMISSION_DENIED) :: status=403 error=PERMISSION_DENIED
+PASS RAW-VW-put viewer (bob) PUT /raw DENIED (403 PERMISSION_DENIED) :: status=403 error=PERMISSION_DENIED
+PASS B-OPS-shape ops foreign-drive 404 indistinguishable from missing-drive 404 ::
+  foreign='Drive not found: ef71b564-...' missing='Drive not found: 00000000-...'
+PASS B-NONMEMBER-ops non-member (mallory) ops on acme drive → blocked (not 200) :: status=500 error=INTERNAL_ERROR
+PASS B-SAMEORG-edge same-org existence oracle :: existing(secret)=500/INTERNAL_ERROR missing=404/NOT_FOUND
+PASS C-NONMEMBER-createdrive non-member create drive in acme → 404 (no existence oracle) :: status=404 error=NOT_FOUND
+PASS C-DRIVEADMIN-createdrive drive admin but org viewer (dave) create drive DENIED (403) :: status=403
+PASS D-VW-listdrives viewer drive list excludes 'secret', includes default :: sees=[default]
+PASS D-MCP-whoami-bob MCP whoami(bob) hides 'secret' :: drives=2 hasSecret=false hasDefault=true
+PASS F-XT-mutate cross-tenant comment update/delete/resolve all → 404 :: upd=404 del=404 res=404
+PASS F-INTACT acme comment intact after cross-tenant attack :: body='acme comment'
+PASS G-BEARER signed-url works UNAUTHENTICATED until expiry :: unauthFetchOk=true bytes=17
+PASS G-XORG-generate cross-org signed-url generation → 404 :: status=404 error=NOT_FOUND
+=== SUMMARY: 60/60 passed, 0 failed ===
+```
+
+### External Links
+- Harness: `/tmp/qa-mtrbac.ts`
+- Full log: `/tmp/qa-mtrbac-output.log`
+
+## Issues Found
+
+- [ ] **Minor — generic `Error`→500 on drive-access failure (intra-org existence oracle).**
+  `resolveContext()` throws a plain `Error("You do not have access to this drive")` instead of a typed
+  `PermissionDeniedError`/`NotFoundError` at `packages/core/src/identity/context.ts:38` and
+  `:59` (also the no-default-drive cases at `:56`,`:90` and personal fallback at `:93`). The error
+  middleware maps untyped errors to **500 INTERNAL_ERROR**. Effects:
+  - A non-member hitting `POST /orgs/{orgId}/ops` (e.g. mallory on acme) gets 500, not 403/404.
+  - **Within the same org**, an existing-but-inaccessible drive returns 500 while a non-existent
+    driveId returns 404 (`assertDriveInOrg`/binding fires NotFoundError first) — so a same-org member
+    can distinguish "real driveId" from "fake driveId". This is an **intra-org** existence oracle.
+  - The **cross-tenant** boundary is unaffected: a different-org driveId trips the org-binding
+    `NotFoundError` (404) *before* the role check, so foreign existence stays unprobeable. No data is
+    ever read or written on these paths (fail-closed).
+  - This is pre-existing `resolveContext` behavior, but strict membership makes it more reachable.
+    Recommendation: throw `PermissionDeniedError` (403) for the no-role cases so authz failures stop
+    surfacing as 500 and the intra-org oracle collapses. Severity: minor (no data leak, fail-closed,
+    same-tenant only).
+
+- [ ] **Minor (informational) — MCP member management is scoped to the caller's personal org.** See
+  Edge Cases. Fail-closed; flagged as a capability/documentation gap, not a vulnerability.
+
+- [ ] **Minor (latent, pre-existing) — `inviteToOrg` default-drive grant is unscoped/order-dependent**
+  (`packages/core/src/identity/orgs.ts`, the `select(drives).where(orgId).get()` for the default-drive
+  membership). Works today; add an `isDefault` predicate to be safe. Matches the step-1 QA observation.
+
+## Verdict
+
+**Status**: PASS
+
+**Summary**: All 60 cross-surface checks passed against a real running daemon — the multi-tenant
+RBAC boundary holds across HTTP ops, raw writes, admin/member management, MCP member tools and
+`whoami`, comment ID scoping, and signed-url generation, with cross-tenant errors byte-identical to
+"missing" (no existence oracle). No write/read bypass was found. Three minor, fail-closed
+observations remain (a generic-`Error`→500 path that creates an *intra-org* existence oracle and
+surfaces authz failures as 500; MCP member mgmt limited to the personal org; the latent unscoped
+`inviteToOrg` default-drive grant) — none break tenant isolation; the first is worth a small typed-error fix.
+
+## Appendix
+
+- **Plan**: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md` (+ `step-1..6.md`)
+- **Companion QA (core/step-1)**: `thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md`
+- **Harness**: `/tmp/qa-mtrbac.ts` (standalone bun; isolated MinIO + real daemon; deleted-able)
+- **Notes**: Validated on Darwin; FUSE live-mount write RBAC not exercised (no `/dev/fuse`), but the
+  FUSE/IPC write path shares `writeRaw()` + `dispatchOp()` with the HTTP raw path proven here. The
+  container and daemon spun up for this run were torn down on completion.
+```

--- a/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-oracle-fix.md
+++ b/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-oracle-fix.md
@@ -1,0 +1,168 @@
+---
+date: 2026-06-10T21:00:00-07:00
+author: Claude
+topic: "Multi-tenant RBAC safety — HEAD re-validation after oracle + invite fixes (72e8955)"
+tags: [qa, rbac, multi-tenant, security, existence-oracle, invite, regression]
+status: pass
+source_plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
+related_pr: n/a (branch multitenant-rbac-safety, HEAD 72e8955)
+environment: local (real daemon + isolated MinIO containers; Docker)
+last_updated: 2026-06-10
+last_updated_by: Claude
+---
+
+# Multi-Tenant RBAC Safety — HEAD Re-Validation QA Report (72e8955)
+
+## Context
+
+The full-feature QA pass (`thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md`, 60/60 at
+HEAD `800e1f1`) flagged three minor, fail-closed issues. Commit `72e8955` ("Fix intra-org drive
+existence oracle and inviteToOrg default-drive grant") subsequently fixed two of them:
+
+1. `resolveContext()` no-role-on-existing-drive now throws `NotFoundError` with a message
+   byte-identical to the missing/cross-org branch (`packages/core/src/identity/context.ts:41-47`),
+   and the org-default-drive branch does the same against the no-default-drive case
+   (`context.ts:72-73`) — collapsing the intra-org existence oracle and eliminating the 500s.
+2. `inviteToOrg` now selects the default-drive membership target with an `isDefault = true`
+   predicate (`packages/core/src/identity/orgs.ts`), removing the order-dependent unscoped query.
+
+This session re-validates the branch at the new HEAD: targeted black-box proof of both fixes plus
+full regression (adversarial harness, unit tests, typecheck, CLI+MCP E2E). Executed as four
+parallel sub-agents via a workflow (run `wf_5eb80d31-5ad`), per Autopilot autonomy.
+
+## Scope
+
+### In Scope
+1. **Fix 1 — intra-org existence oracle**: existing-but-inaccessible driveId vs missing driveId
+   must be byte-indistinguishable 404s, on JSON ops and the raw file route; non-member org-default
+   ops must 404 identically to a nonexistent org; zero 500s on any authz path.
+2. **Fix 2 — invite default-drive grant**: with extra non-default drives present, a fresh invite
+   grants drive membership *only* on the `isDefault` drive, role mapped from the org role.
+3. **Full regression at HEAD**: the prior 60-check adversarial harness, `bun run typecheck`,
+   `bun run test`, and the 81-case `scripts/e2e.ts` suite.
+
+### Out of Scope
+- FUSE live-mount write RBAC over `/dev/fuse` (Darwin host; FUSE/IPC shares `writeRaw()`/
+  `dispatchOp()` with the HTTP raw path validated here; FUSE E2E tests auto-skipped as designed).
+- The known MCP member-management personal-org scoping limitation (informational; unchanged by
+  this commit — see Issues Found).
+- S3 hard isolation / bucket-per-tenant (explicit plan non-goal).
+
+## Test Cases
+
+### TC-1: Adversarial harness rerun at HEAD (60 checks)
+**Steps:** Copy `/tmp/qa-mtrbac.ts` → `/tmp/qa-mtrbac-rerun.ts`; run against HEAD `72e8955`
+(isolated MinIO + real daemon, all assertions over the wire via HTTP + MCP).
+**Expected:** 60/60 pass; the two checks that previously documented pre-fix behavior now show the
+corrected statuses; no 500 anywhere in the log.
+**Actual:** 60/60 passed. `B-NONMEMBER-ops` now `404 NOT_FOUND` (was `500 INTERNAL_ERROR`);
+`B-SAMEORG-edge` now `existing(secret)=404/NOT_FOUND missing=404/NOT_FOUND` (was 500 vs 404 —
+oracle closed); `grep 500` over the full log: no matches. `X-INVITE-ORDER` still green.
+**Status:** pass
+
+### TC-2: Oracle-fix probes — new focused harness (10 checks, OFX-1..10)
+**Steps:** New black-box harness `/tmp/qa-oracle-fix.ts` (own MinIO container, temp
+`AGENT_FS_HOME`, daemon from repo source, bearer-key API). Org `acme` (admin alice, org-member
+bob, private drive `secret` bob can't access, extra non-default drive `extra`), outsider mallory,
+fresh invitee frank.
+**Expected/Actual — all pass:**
+- **OFX-1** bob ops with `driveId=secret` → 404 NOT_FOUND (not 500). **pass**
+- **OFX-2** full body of that 404 byte-identical (ids normalized) to a missing-driveId 404:
+  `{"error":"NOT_FOUND","message":"Drive not found: <driveId>","suggestion":"Check the driveId belongs to the org you are addressing"}` — identical. **pass**
+- **OFX-3** same status (404) for both. **pass**
+- **OFX-4** mallory ops on acme with no driveId → 404 `No default drive for org: <acme>` (was 500). **pass**
+- **OFX-5** that body byte-identical (org ids normalized) to the same call against a nonexistent
+  org uuid — no org existence oracle on `/ops`. **pass**
+- **OFX-6** cross-org driveId from mallory's own org → 404, body identical to missing-id probe. **pass**
+- **OFX-7** no legit-access regression: alice `ls` on `secret` → 200; bob default-drive ops → 200. **pass**
+- **OFX-8** invite frank (org editor) with `secret` + `extra` present → frank appears **only** in
+  the default drive's member list, role `editor`; absent from `secret` and `extra`. **pass**
+- **OFX-9** raw route (`GET /orgs/:orgId/drives/:driveId/files/:path/raw`) for bob on `secret` →
+  404 with the drive-level message (resolveContext fires before file lookup). **pass**
+- **OFX-10** zero 500s across all 22 collected responses. **pass**
+**Status:** pass (10/10)
+
+### TC-3: Unit gates
+**Steps:** `bun run typecheck`; `bun run test`.
+**Expected:** 0 type errors; 0 test failures (manual/integration auto-skip without env).
+**Actual:** typecheck exit 0. Tests: `380 pass / 57 skip / 0 fail`, 1290 expect() calls, 437 tests
+across 42 files. Skips are the expected env-gated manual/integration tests.
+**Status:** pass
+
+### TC-4: CLI+MCP E2E regression suite
+**Steps:** `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (isolated MinIO,
+unique container name).
+**Expected:** 0 failures; FUSE-tagged tests auto-skip on Darwin.
+**Actual:** `Results: 81/81 passed (10 skipped)` — all 10 skips FUSE-tagged (Darwin, expected).
+The mid-run stderr `Error: Cannot remove members from a personal org` is the expected output of
+the passing negative test "member remove last admin fails".
+**Status:** pass
+
+## Edge Cases & Exploratory Testing
+
+- **The 404s are byte-identical, not merely same-status.** OFX-2/OFX-5 normalize the echoed ids
+  and compare full response bodies — message template and `suggestion` field included — so neither
+  intra-org members nor outsiders can distinguish real from fake ids by error shape on `/ops` or
+  the raw route.
+- **Raw route degrades to the drive-level 404** for a no-role caller (drive resolution precedes
+  file lookup), which is the correct fail-closed ordering — no file-existence information leaks
+  through a drive the caller can't access.
+- **Personal-org fallback still throws plain `Error`s** (`context.ts:91,104,107` — "No personal
+  org found", "No default drive found", "No access to your default drive"). These would surface
+  as 500s, but are only reachable for a caller whose *own* account is in a broken state — they
+  cannot be used to probe other tenants' resources. Cosmetic; not a hole.
+- **Invite grant determinism**: with `secret` and `extra` both present before frank's invite, the
+  membership landed exactly on the `isDefault` drive — the previously order-dependent behavior is
+  now semantically pinned, confirmed black-box (OFX-8) and by the rerun's `X-INVITE-ORDER`.
+
+## Evidence
+
+### Logs & Output
+```
+TC-1  === SUMMARY: 60/60 passed, 0 failed ===                       (/tmp/qa-mtrbac-rerun.log)
+      PASS B-NONMEMBER-ops ... :: status=404 error=NOT_FOUND            (was 500 pre-fix)
+      PASS B-SAMEORG-edge ... :: existing(secret)=404/NOT_FOUND missing=404/NOT_FOUND
+TC-2  === SUMMARY: 10/10 passed, 0 failed ===                       (/tmp/qa-oracle-fix.log)
+      PASS OFX-2 ... identical=true   PASS OFX-5 ... identical=true
+      PASS OFX-8 :: default=present(role=editor) secret=absent extra=absent
+TC-3  380 pass / 57 skip / 0 fail  (437 tests, 42 files)            (/tmp/qa-unit-gates.log)
+TC-4  Results: 81/81 passed (10 skipped)                            (/tmp/qa-e2e-rerun.log)
+```
+
+### External Links
+- Harnesses: `/tmp/qa-mtrbac-rerun.ts` (rerun copy), `/tmp/qa-oracle-fix.ts` (new, this session)
+- HEAD verified by every agent: `72e89553357c63cdc39f11fdaee008c854202eb5`
+- All MinIO containers torn down post-run (verified `docker ps`); repo working tree untouched by
+  test execution.
+
+## Issues Found
+
+- [ ] **Minor (informational, carried over) — MCP member management scoped to the caller's
+  personal org.** Unchanged by this commit; shared-org admins still cannot manage shared-org
+  members via MCP (fail-closed capability gap, documented in the full QA report).
+- [ ] **Cosmetic — personal-org fallback paths still throw plain `Error` → 500**
+  (`packages/core/src/identity/context.ts:91,104,107`). Only reachable for a caller's own broken
+  account state; no cross-tenant or intra-org probing value. Worth converting to typed errors
+  whenever the file is next touched.
+
+## Verdict
+
+**Status**: PASS
+
+**Summary**: Both fixes in `72e8955` are proven black-box — the intra-org existence oracle is
+collapsed (no-role 404s byte-identical to missing-id 404s on ops and raw, zero 500s across every
+authz path probed) and invites now grant exactly the `isDefault` drive — with full regression
+green at HEAD: 60/60 adversarial checks, 10/10 fix probes, 380/380 unit tests, 81/81 E2E. The
+two fixed issues from the prior QA report are closed; one informational item (MCP personal-org
+scoping) remains open by design.
+
+## Appendix
+
+- **Plan**: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md` (+ `step-1..6.md`)
+- **Prior QA (full feature, HEAD 800e1f1)**: `thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md`
+- **Prior QA (core/step-1)**: `thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md`
+- **Verification**: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety-verification.md`
+- **Notes**: Executed via background workflow `wf_5eb80d31-5ad` (4 parallel sub-agents). FUSE
+  live-mount RBAC remains validated indirectly (shared `writeRaw()`/`dispatchOp()` code path +
+  `cargo test`); run `packages/fuse-helper/docker/run-mount-test.sh` for a live-mount smoke if
+  desired before release.

--- a/thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md
+++ b/thoughts/taras/qa/2026-06-10-step-1-multitenant-rbac-safety.md
@@ -1,0 +1,153 @@
+---
+date: 2026-06-10
+author: Claude (QA sub-agent)
+topic: "Step-1 multitenant-rbac-safety — core authz helpers + strict explicit drive membership"
+tags: [qa, rbac, multi-tenant, drives, migrations, core]
+status: pass
+source_plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md
+environment: local (isolated temp AGENT_FS_HOME, in-process Hono app, no MinIO/Docker)
+last_updated: 2026-06-10
+last_updated_by: Claude (QA sub-agent)
+---
+
+# Step-1 Multitenant RBAC Safety — QA Report
+
+## Context
+
+Functional validation of step-1 (uncommitted, branch `multitenant-rbac-safety`): core authorization helpers (`packages/core/src/identity/rbac.ts`), strict explicit drive membership (`drives.ts`), org/drive binding in `resolveContext()` (`context.ts`), and migration 3 backfill (`packages/core/src/db/migrate.ts`).
+
+Working-tree diff at QA time: 9 files, +525/−50 (core identity/db + tests + plan doc).
+
+Validation is **real functional testing**, not test rereading: two throwaway scripts ran the actual core functions and the actual HTTP app against fresh temp SQLite DBs.
+
+- `/tmp/qa-step1-core.ts` — core-level, direct calls into `packages/core/src` with a temp `AGENT_FS_HOME` and raw SQLite verification connection. **12/12 pass.**
+- `/tmp/qa-step1-http.ts` — HTTP-level, in-process `createApp(db, s3)` + `app.request()` (real routes, real auth middleware, real error handler; S3 client is a dead-end stub since no exercised route touches storage). **7/7 pass.**
+
+Baseline: `bun test packages/core/src/identity/__tests__/identity.test.ts` → 33 pass / 0 fail; `bun run typecheck` clean; no stale `.js` files in `packages/*/src`.
+
+## Scope
+
+### In Scope
+1. Drive creation with `creatorUserId` → explicit admin `drive_members` row + visibility in creator's `listDrivesForUser`.
+2. Strict membership: same-org non-admin member without a `drive_members` row does not see the drive.
+3. Cross-org binding: org A user + org B `driveId` → `NotFoundError` (core) and HTTP 404 (via `POST /orgs/:orgId/ops`).
+4. Migration 3 backfill: zero-member drive + fresh DB open → org admins get admin rows; idempotency.
+5. Known intermediate gap confirmation: `POST /orgs/:orgId/drives` does not yet pass `creatorUserId` (step-2 scope).
+
+### Out of Scope
+- File ops against real S3/MinIO (no storage-touching behavior changed in step-1).
+- FUSE mount behavior, MCP tools, CLI commands (step-1 is core-only; later steps wire callers).
+- Full `scripts/e2e.ts` regression run (deferred; core surface covered directly).
+
+## Test Cases
+
+### TC-1: Drive creation yields explicit creator admin membership
+- **Steps**: `createUser(alice)` → `createOrg(acme, alice)` → `createDrive({orgId: acme, name: "proj", creatorUserId: alice})`; inspect `drive_members` via raw SQL; call `listDrivesForUser(db, acme, alice)`.
+- **Expected**: exactly one `drive_members` row `(proj, alice, 'admin')`; `proj` in alice's list.
+- **Actual**: `[{"user_id":"4f89...","role":"admin"}]`; alice sees `["default","proj"]`.
+- **Status**: PASS
+
+### TC-2: Strict membership — org member without drive_members row sees nothing
+- **Steps**: `createUser(bob)`; `inviteToOrg(acme, bob, role: "editor")` (grants org membership + default-drive membership only); verify bob has no row on `proj`; call `listDrivesForUser(db, acme, bob)`.
+- **Expected**: `proj` absent from bob's list.
+- **Actual**: bob sees `["default"]` only.
+- **Status**: PASS
+
+### TC-3: Cross-org binding rejected (core + HTTP)
+- **Steps (core)**: `createOrg(borg, carol)`; `resolveContext(db, {userId: alice, orgId: acme, driveId: borgDefaultDrive})`.
+- **Expected**: throws `NotFoundError` with `code === "NOT_FOUND"`.
+- **Actual**: `NotFoundError: Drive not found: a145...` — same error shape as a missing drive (no cross-tenant existence probing).
+- **Steps (HTTP)**: register alice+carol via `POST /auth/register`; create orgs via `POST /orgs`; `POST /orgs/{acme}/ops` with body `{op:"ls", driveId:<borg default>}` as alice.
+- **Expected**: HTTP 404, `error: "NOT_FOUND"`.
+- **Actual**: `status=404 body={"error":"NOT_FOUND","message":"Drive not found: 83b9...","suggestion":"Check the driveId belongs to the org you are addressing"}`.
+- **Positive control**: same route with alice's own org+drive, DB-only op `recent` → `status=200 body={"entries":[]}`. (Core control: `resolveContext` with matching org/drive returns `role: "admin"`.)
+- **Status**: PASS
+
+### TC-4: Migration 3 backfills org admins on zero-member drives
+- **Steps**: raw-SQL insert a `drives` row ("legacy") with zero `drive_members` rows; confirm invisible even to org admin alice; re-open DB via `createDatabase(path)` (runs `runMigrations()`); inspect rows; re-open a third time for idempotency.
+- **Expected**: post-migration exactly one row `(legacy, alice, 'admin')`; bob (editor) gets nothing; row count stays 1 on re-run.
+- **Actual**: pre: 0 rows, alice sees `["proj","default"]`; post: `[{"user_id":"4f89...(alice)","role":"admin"}]`, alice sees `["legacy","proj","default"]`, bob still `["default"]`; after third open rows=1.
+- **Status**: PASS
+
+### TC-5: Known intermediate gap — HTTP drive creation lacks creatorUserId (expected, NOT a failure)
+- **Steps**: `POST /orgs/{acme}/drives {name:"via-http"}` as alice; inspect `drive_members`; `GET /orgs/{acme}/drives` as alice.
+- **Expected (current intermediate state)**: 201; zero member rows; drive invisible to its creator.
+- **Actual**: 201; 0 member rows; alice's list = `["default"]` (no `via-http`). Matches `packages/server/src/routes/orgs.ts:52` — `createDrive(db, { orgId, name })` without `creatorUserId`. Step-2 plan item 2 explicitly covers this ("Pass the authenticated user into createDrive()").
+- **Status**: PASS (gap confirmed as documented)
+
+## Edge Cases & Exploratory Testing
+
+- **Zero-member drive invisible to everyone, including org admins, pre-backfill** (TC-4a) — confirms "public drive" fallback is fully gone, not just narrowed.
+- **Error indistinguishability**: cross-org mismatch returns the same `NOT_FOUND` shape as a genuinely missing drive — no existence oracle for cross-tenant probers.
+- **Step-2-scope probe**: non-member carol `POST /orgs/{acme}/drives` → currently **201** (no route-level org role check yet). Expected intermediate state; step-2 plan item 1 covers it ("Require org admin for drive creation"). Re-verify at step-2 QA.
+- **Observation (pre-existing, not step-1)**: `inviteToOrg()` grants the invitee membership on "the default drive" selected via `db.select().from(drives).where(eq(drives.orgId, orgId)).get()` **without an `isDefault` filter or ordering** (`packages/core/src/identity/orgs.ts:241-247`) — it picks the first drive row in the org. Works today because the default drive is created first, but it is order-dependent. Minor; worth a follow-up.
+
+## Evidence
+
+### Logs & Output
+
+Core-level run (`bun /tmp/qa-step1-core.ts`):
+
+```
+PASS  1a: explicit admin drive_members row for creator — [{"user_id":"4f894c5d-...","role":"admin"}]
+PASS  1b: drive appears in creator's listDrivesForUser — alice sees in acme: ["default","proj"]
+PASS  2-pre: bob has no drive_members row on proj
+PASS  2: org member without membership does NOT see drive — bob sees in acme: ["default"]
+PASS  3a: cross-org resolveContext throws NotFoundError — NotFoundError: Drive not found: a145388c-...
+PASS  3b: positive control — matching org/drive resolves, role=admin — {"orgId":"d9f1...","driveId":"81e3...","role":"admin"}
+PASS  4-pre: legacy drive has zero member rows
+PASS  4a: zero-member drive invisible even to org admin (strict membership) — alice sees: ["proj","default"]
+PASS  4b: backfill grants org admin (alice) an admin row, and only her — [{"user_id":"4f89...","role":"admin"}]
+PASS  4c: legacy drive now visible to org admin — ["legacy","proj","default"]
+PASS  4d: backfill did NOT grant non-admin bob access to legacy — ["default"]
+PASS  4e: migration idempotent on re-run — rows=1
+
+RESULT: 12 pass, 0 fail
+```
+
+HTTP-level run (`bun /tmp/qa-step1-http.ts`, in-process `createApp` + `app.request`):
+
+```
+PASS  setup: registered alice + carol
+PASS  setup: created org A (acme/alice) + org B (borg/carol)
+PASS  setup: both default drives visible to their creators
+PASS  3-http: POST /orgs/{orgA}/ops with orgB driveId returns 404 NOT_FOUND — status=404 body={"error":"NOT_FOUND","message":"Drive not found: 83b9dcb0-...","suggestion":"Check the driveId belongs to the org you are addressing"}
+PASS  3-http positive control: own org+drive op returns 200 — status=200 body={"entries":[]}
+PASS  5-pre: POST /orgs/:orgId/drives returns 201 — status=201
+INFO  5-gap: HTTP-created drive has 0 member rows; creator's drive list = ["default"] (expected intermediate gap until step-2: 0 rows, drive invisible)
+PASS  5: gap confirmed as documented (0 member rows, invisible to creator)
+INFO  step-2-scope probe: non-member POST /orgs/{orgA}/drives -> status=201 (401/403 expected after step-2; currently permitted = known intermediate gap)
+
+RESULT: 7 pass, 0 fail
+```
+
+Baseline:
+
+```
+bun test packages/core/src/identity/__tests__/identity.test.ts
+ 33 pass / 0 fail (77 expect() calls)
+bun run typecheck  ->  clean
+```
+
+Harness note: an initial positive-control attempt used op `ls`, which calls `ctx.s3.listObjects` and failed (400) against the dead-end stub S3 client — harness artifact, not a product bug; switched to DB-only op `recent`.
+
+### External Links
+- Plan: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-1.md`
+- Step-2 (covers the confirmed gaps): `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/step-2.md`
+
+## Issues Found
+
+No step-1 defects. Two items confirmed as known intermediate state (step-2 scope) plus one pre-existing minor:
+
+1. **(known/intermediate — step-2)** `POST /orgs/:orgId/drives` creates drives with no `creatorUserId` → drive has 0 member rows and is invisible to its creator (`packages/server/src/routes/orgs.ts:52`).
+2. **(known/intermediate — step-2)** No route-level org role checks on `POST /orgs/:orgId/drives`: a non-member of the org can create a drive in it (201). Step-2 plan item 1 requires org admin.
+3. **(minor, pre-existing)** `inviteToOrg()` default-drive grant selects the org's first drive row without `isDefault` filter/ordering (`packages/core/src/identity/orgs.ts:241-247`). Order-dependent; suggest follow-up.
+
+## Verdict
+
+**PASS.** All five step-1 behaviors validated functionally against real core APIs and the real HTTP app: explicit creator admin membership, strict membership visibility, cross-org 404 binding (core + HTTP), idempotent admin backfill, and the documented step-2 gap confirmed exactly as planned.
+
+## Appendix
+
+- Test scripts (throwaway, `/tmp` only): `/tmp/qa-step1-core.ts`, `/tmp/qa-step1-http.ts`. Each creates an isolated temp `AGENT_FS_HOME` + SQLite DB and removes it on exit.
+- No Docker containers, MinIO, or daemons were started; HTTP was exercised in-process via Hono `app.request()`. Cleanup verified (no leftover temp dirs/containers/processes).


### PR DESCRIPTION
## Summary

Hardens agent-fs for hosted multi-tenant use where mutually distrustful users share one server and one S3 bucket. Every server-visible operation now proves the authenticated user has an explicit role for the target org/drive. Implements the DAG plan at `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/`.

- **Core (step-1):** reusable authz helpers (`requireOrgRole`, `requireDriveRole`, `requireDriveAdmin`, `assertDriveInOrg`, …); strict explicit drive membership — `listDrivesForUser` requires a `drive_members` row, `createDrive(creatorUserId)` grants the creator admin, and a startup migration backfills admin rows for org admins on zero-member drives; `resolveContext` rejects org/drive mismatch with 404 (no existence oracle).
- **HTTP (step-2):** drive creation and org member management require org admin; drive member management requires drive admin or org admin; org/member reads require membership; `:driveId` is bound to `:orgId`.
- **Raw + IPC/FUSE (step-3):** `writeRaw()` requires editor-or-better, enforced once in core — covers `PUT /raw` and FUSE `open_write`/`create_file`/`truncate` (403 `PERMISSION_DENIED`); `GET /raw` stays viewer-accessible.
- **MCP (step-4):** member tools admin-gated with driveId-to-active-org binding; account-existence probing blocked; `whoami` lists only member drives.
- **Comments (step-5):** all comment-ID/parent/reply operations scoped to the active org/drive; cross-tenant IDs return 404.
- **Docs + release (step-6):** access-control docs across api-reference/deployment/fuse-mount/mcp-setup; signed URLs explicitly documented as unauthenticated bearer secrets after RBAC-checked generation; agent-fs skill updated; version synced to **0.8.0** (minor — strict membership is a behavior change for self-hosted multi-user setups).
- **Post-QA fixes:** inaccessible drives are byte-indistinguishable from missing ones (404, was a 500 intra-org oracle); `inviteToOrg` default-drive grant now filters on `isDefault`.

## Breaking change

Zero-member ("public") drives are no longer visible to non-members. The startup migration backfills admin memberships for org admins, so existing admins keep access; other users need explicit membership grants.

## Testing

- Unit/integration: 380 pass / 0 fail (+46 vs baseline)
- E2E vs isolated MinIO: 81/81, incl. 13 new cross-surface RBAC tests
- FUSE helper: `cargo test -p agent-fs-fuse` 64 pass
- Post-implementation audit: plan-vs-diff verification PASS (`thoughts/taras/plans/2026-06-10-multitenant-rbac-safety-verification.md`)
- Adversarial black-box QA against a real daemon (6 users / 2 orgs): 60/60, no bypass found (`thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-full.md`)

Follow-up tracked separately: MCP member tools currently operate on the caller's personal org only (DES-567).