### PR TITLE
fix(cli): translate `recent --since` duration shorthand to a date (0.8.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": {
     "name": "desplega-ai"
   },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/landing/public/docs/openapi.json
+++ b/landing/public/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.0",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.0"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.1",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.1"
   },
   "dependencies": {
     "commander": "^14.0.3",

--- a/packages/cli/src/__tests__/since-duration.test.ts
+++ b/packages/cli/src/__tests__/since-duration.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect } from "bun:test";
+import { resolveSinceDuration } from "../commands/ops.js";
+
+/**
+ * `agent-fs recent --since <duration>` advertises a relative shorthand (1h, 24h,
+ * 7d). The server coerces `since` to a Date, so `new Date("1h")` is invalid and
+ * the request 400s. resolveSinceDuration() translates the shorthand to an
+ * absolute ISO timestamp client-side while leaving real dates untouched.
+ */
+describe("resolveSinceDuration", () => {
+  test("translates hour shorthand to an ISO timestamp ~that long ago", () => {
+    const before = Date.now();
+    const iso = resolveSinceDuration("1h");
+    const after = Date.now();
+    const t = Date.parse(iso);
+    expect(Number.isNaN(t)).toBe(false);
+    // Should be roughly one hour before now (allow slop for the two Date.now calls).
+    expect(after - 3_600_000 - t).toBeGreaterThanOrEqual(-5);
+    expect(before - 3_600_000 - t).toBeLessThanOrEqual(5);
+  });
+
+  test("supports s/m/h/d/w units and a multi-digit amount", () => {
+    const now = Date.now();
+    const cases: Array<[string, number]> = [
+      ["30s", 30_000],
+      ["15m", 15 * 60_000],
+      ["24h", 24 * 3_600_000],
+      ["7d", 7 * 86_400_000],
+      ["2w", 2 * 604_800_000],
+    ];
+    for (const [input, ms] of cases) {
+      const t = Date.parse(resolveSinceDuration(input));
+      expect(Math.abs(now - ms - t)).toBeLessThanOrEqual(1000);
+    }
+  });
+
+  test("is case-insensitive and tolerates inner whitespace", () => {
+    const a = Date.parse(resolveSinceDuration("1H"));
+    const b = Date.parse(resolveSinceDuration("1 h"));
+    expect(Number.isNaN(a)).toBe(false);
+    expect(Number.isNaN(b)).toBe(false);
+  });
+
+  test("passes ISO timestamps through unchanged", () => {
+    const iso = "2026-06-10T18:19:06.068Z";
+    expect(resolveSinceDuration(iso)).toBe(iso);
+  });
+
+  test("passes non-duration / unknown-unit tokens through unchanged", () => {
+    // Unknown unit, bare number, and date-like strings must not be rewritten —
+    // the server's z.coerce.date() still gets the original value.
+    expect(resolveSinceDuration("1y")).toBe("1y");
+    expect(resolveSinceDuration("1700000000000")).toBe("1700000000000");
+    expect(resolveSinceDuration("2026-06-10")).toBe("2026-06-10");
+    expect(resolveSinceDuration("yesterday")).toBe("yesterday");
+  });
+});

--- a/packages/cli/src/commands/ops.ts
+++ b/packages/cli/src/commands/ops.ts
@@ -9,6 +9,30 @@ interface OpCommandDef {
   options: Array<{ flag: string; description: string }>;
 }
 
+const SINCE_UNIT_MS: Record<string, number> = {
+  s: 1_000,
+  m: 60_000,
+  h: 3_600_000,
+  d: 86_400_000,
+  w: 604_800_000,
+};
+
+/**
+ * Resolve a relative duration shorthand (e.g. "1h", "24h", "7d", "30m", "1w")
+ * to an absolute ISO-8601 timestamp (now minus the duration). The `recent` op's
+ * `since` field is a coerced Date server-side (`z.coerce.date()`), so durations
+ * must be resolved client-side — `new Date("1h")` is an Invalid Date. Any value
+ * that is not a bare <number><unit> token is returned unchanged, so real ISO
+ * strings / epoch values still reach the server's coercion untouched.
+ */
+export function resolveSinceDuration(value: string): string {
+  const match = /^(\d+)\s*([smhdw])$/i.exec(value.trim());
+  if (!match) return value;
+  const amount = parseInt(match[1], 10);
+  const unitMs = SINCE_UNIT_MS[match[2].toLowerCase()];
+  return new Date(Date.now() - amount * unitMs).toISOString();
+}
+
 const OP_COMMANDS: OpCommandDef[] = [
   { name: "write", args: [{ name: "path", required: true }], options: [{ flag: "--content <text>", description: "File content (reads stdin if omitted)" }, { flag: "--file <path>", description: "Read bytes from a local file and upload without text decoding" }, { flag: "-m, --message <msg>", description: "Version message" }, { flag: "--expected-version <n>", description: "Fail if file is not at this version (optimistic concurrency)" }] },
   { name: "cat", args: [{ name: "path", required: true }], options: [{ flag: "--offset <n>", description: "Line offset" }, { flag: "--limit <n>", description: "Max lines" }] },
@@ -125,6 +149,13 @@ export function registerOpCommands(
         if (params[key] !== undefined) {
           params[key] = parseInt(params[key]);
         }
+      }
+
+      // `recent --since` advertises a duration shorthand (1h, 24h, 7d); the
+      // server coerces `since` to a Date, so resolve durations to an absolute
+      // ISO timestamp here. ISO/epoch values pass through unchanged.
+      if (def.name === "recent" && typeof params.since === "string") {
+        params.since = resolveSinceDuration(params.since);
       }
 
       try {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -826,6 +826,14 @@ async function runStandardTests(daemonUrl: string) {
     assert(result.entries.length > 0, true, "Expected recent entries");
   });
 
+  await test("recent --since <duration>", () => {
+    // Regression: the CLI must translate the advertised duration shorthand
+    // (1h/24h/7d) into an absolute date before sending, since the server
+    // coerces `since` to a Date and `new Date("1h")` is invalid.
+    const result = runJson("recent --since 24h");
+    assert(result.entries.length > 0, true, "Expected recent entries within 24h");
+  });
+
   // -- diff --
 
   await test("diff (between versions)", () => {

--- a/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-live-prod.md
+++ b/thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-live-prod.md
@@ -1,0 +1,131 @@
+---
+date: 2026-06-10T21:30:00-07:00
+author: Claude
+topic: "Multi-tenant RBAC safety — live production QA after merge + Fly deploy (0.8.0)"
+tags: [qa, rbac, multi-tenant, production, live, cli, smoke, existence-oracle]
+status: pass
+source_plan: thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md
+related_pr: https://github.com/desplega-ai/agent-fs/pull/16 (merged, 8dca70d)
+environment: production (https://agent-fs-taras.fly.dev, Fly app agent-fs-taras, version 0.8.0)
+last_updated: 2026-06-10
+last_updated_by: Claude
+---
+
+# Multi-Tenant RBAC Safety — Live Production QA (0.8.0)
+
+## Context
+
+After PR #16 merged to `main` (merge commit `8dca70d`) the Fly deploy redeployed the backend.
+`GET https://agent-fs-taras.fly.dev/health` → `{"ok":true,"version":"0.8.0"}`, confirming the merged
+RBAC + oracle code is serving. This pass validates the feature **against the live production
+backend** — both the local `agent-fs` CLI 0.8.0 driving prod over the wire, and direct-HTTP RBAC
+oracle probes confirming commit `72e8955`'s fix in production. Run as two parallel sub-agents
+(workflow `wf_810f0348-547`), scratch users + data only, all created files cleaned up.
+
+## Scope
+
+### In Scope
+1. **CLI smoke** — local `agent-fs` (0.8.0) against prod via `AGENT_FS_API_URL`/`AGENT_FS_API_KEY`:
+   write/cat/append/edit/log/ls/stat/tree/signed-url/fts/search/comment/recent + rm cleanup.
+2. **RBAC oracle probe** — two scratch users; cross-org/cross-drive/raw/auth denials must be
+   byte-identical 404s with zero 500s (the deployed `72e8955` behavior), 401 on missing/bad auth,
+   200 on legit own-drive access.
+
+### Out of Scope
+- Pre-existing user data (never touched/enumerated).
+- FUSE live mount (Darwin host).
+- Admin/destructive ops beyond the scratch flow.
+
+## Test Cases
+
+### TC-1: RBAC + existence-oracle probe over raw HTTP (8/8 pass) — PRIMARY
+Two scratch users (userA, userB; no shared org/drive). userA wrote one scratch file into its
+default drive (`910effa2-…`).
+- **P1** userB ops on userA's org, no driveId → **404** `No default drive for org: <id>`. **pass**
+- **P2** userB ops on a ghost org uuid → 404; body **byte-identical** to P1 (org id normalized).
+  `P1_P2_IDENTICAL=true`. **pass**
+- **P3** userB ops on its own org with `driveId=<userA's drive>` → **404** `Drive not found: <id>`
+  + `suggestion`. **pass**
+- **P4** userB ops with a missing driveId → 404; body **byte-identical** to P3 (driveId normalized).
+  `P3_P4_IDENTICAL=true`. **pass**
+- **P5** userB `GET /orgs/{userA.org}/drives/{userA.drive}/files/…/raw` → **404** (drive-level
+  NOT_FOUND; resolveContext fires before file lookup — no file-existence leak). **pass**
+- **P6** no Authorization header → **401**; bogus bearer → **401**. **pass**
+- **P7** **no-500 sweep**: per-probe statuses `[P1:404, P2:404, P3:404, P4:404, P5:404, P6a:401,
+  P6b:401, P8:200]` — `P7_ANY_500=false`. **pass**
+- **P8** userB ops on its **own** org default drive → **200** (no legit-access regression). **pass**
+**Status:** pass — the deployed oracle fix holds in production.
+
+### TC-2: Local CLI 0.8.0 smoke against prod (9/10 functional steps pass)
+`agent-fs --version` → 0.8.0 (matches prod). Scratch prefix `qa-live-4a8a5c5e/`.
+- **write** → v1, 11 B. **pass**
+- **cat** → exact bytes `hello world`. **pass**
+- **append** → content `hello world more` (16 B). **pass** (cosmetic: printed `v1`; the write+append
+  coalesced into a single v1 per the authoritative `log`).
+- **edit** (`more`→`extra`) → v2, content `hello world extra` (17 B). **pass**
+- **log** → 2 entries `[v2 edit (17B), v1 append (16B)]`. **pass**
+- **ls / stat / tree** → stat authoritative (size 17, currentVersion 2, embeddingStatus indexed).
+  **pass** (cosmetic: `ls` showed stale size 11 vs stat's 17).
+- **signed-url** → Tigris URL; unauthenticated `GET` → 200, 17 bytes, current content. **pass**
+  (bearer-secret semantics, as designed).
+- **fts / search** → distinctive word found by both keyword (`fts`) and semantic (`search`,
+  score 0.0327). **pass** (no embedding-latency miss).
+- **comment add/list** → round-trip clean (id `79acda4b…`, body echoed, `resolved:false`). **pass**
+- **recent `--since 1h`** → **FAIL** (see Issues Found). `recent` (no `--since`) and
+  `recent --since <ISO>` both work and list the scratch files.
+- **cleanup** → both files `rm`'d; `ls` empty; `cat` on deleted → "File not found". **pass**
+**Status:** pass with one defect (the `--since` duration shorthand).
+
+## Edge Cases & Exploratory Testing
+- Production 404 bodies are **byte-identical** (not just same-status) across cross-org, cross-drive,
+  and raw surfaces — confirmed in the live environment, matching the local re-validation.
+- `signed-url` serves bytes unauthenticated until expiry (bearer-secret model) — works in prod.
+- Semantic `search` returned the scratch file immediately — prod embedding pipeline is live.
+- Harness note (not product bugs): the public register endpoint is `POST /auth/register` (not
+  `/register`); and a stale local `~/.agent-fs/config.json` `defaultOrg` shadows a freshly-registered
+  org, worked around with `--org` (no config mutated).
+
+## Evidence
+
+```
+HEALTH   GET /health -> {"ok":true,"version":"0.8.0"}
+TC-1     8/8 probes pass; P1_P2_IDENTICAL=true; P3_P4_IDENTICAL=true; P7_ANY_500=false
+         statuses=[P1:404 P2:404 P3:404 P4:404 P5:404 P6a:401 P6b:401 P8:200]
+TC-2     9/10 CLI steps pass; cleanup verified (ls empty, cat->File not found)
+         FAIL: `recent --since 1h` -> {"code":"invalid_date","path":["since"],"message":"Invalid date"}
+```
+Workflow: `wf_810f0348-547` (2 agents). API keys redacted. All scratch files removed.
+
+## Issues Found
+
+- [ ] **Minor — `agent-fs recent --since <duration>` is broken (doc/contract mismatch).** The CLI
+  forwards the literal duration string (`1h`) to the server; the core `recent` schema coerces
+  `since` with `z.coerce.date()` (`packages/core/src/ops/index.ts:159`), so `new Date("1h")` →
+  Invalid Date → `400 invalid_date`. But the CLI help and `skills/agent-fs/SKILL.md` both advertise
+  `--since <duration> (e.g., 1h, 24h)`. **Fix:** translate the duration shorthand to an absolute ISO
+  timestamp in the CLI before sending (`packages/cli/src/commands/ops.ts`, where `since` is currently
+  passed untransformed) — keeps the core/MCP `z.coerce.date()` contract intact (still accepts ISO /
+  epoch / Date). Pre-existing; unrelated to the RBAC branch; not a regression from this merge.
+- [ ] **Cosmetic — `ls` size lag.** `ls` reported the original write size (11) while `stat` showed
+  the current size (17). `stat` is authoritative; `ls` size appears to lag a same-window mutation.
+- [ ] **Cosmetic — `append` version label.** A write immediately followed by `append` coalesced into
+  a single `v1` (the printed label said `v1`); `log` is consistent. Likely intentional same-window
+  coalescing; worth confirming the printed label matches intent.
+
+## Verdict
+
+**Status**: PASS
+
+**Summary**: The multi-tenant RBAC + existence-oracle hardening is validated **in production**
+(0.8.0): 8/8 live RBAC probes pass with byte-identical 404s and zero 500s, and the local CLI 0.8.0
+round-trips cleanly against prod across 9/10 functional surfaces. The single failure
+(`recent --since 1h`) is a pre-existing, RBAC-unrelated CLI/doc contract bug (duration shorthand not
+translated to a date) with a clear localized fix; two further findings are cosmetic. No security or
+tenant-isolation issue; the deployed fix behaves exactly as the local re-validation predicted.
+
+## Appendix
+- **PR**: https://github.com/desplega-ai/agent-fs/pull/16 (merged `8dca70d`)
+- **Prior QA**: `…-multitenant-rbac-safety-full.md`, `…-multitenant-rbac-safety-oracle-fix.md`,
+  `…-step-1-multitenant-rbac-safety.md`
+- **Plan**: `thoughts/taras/plans/2026-06-10-multitenant-rbac-safety/root.md`
+- **Notes**: Production scratch users persist (API has no user-delete); only two were created.


### PR DESCRIPTION
## What

`agent-fs recent --since 1h` was rejected by the server with `400 invalid_date`. The CLI forwarded the literal duration string while the server coerces `since` with `z.coerce.date()` — `new Date("1h")` is an Invalid Date — even though `--help` and `skills/agent-fs/SKILL.md` both advertise `--since <duration>` with `1h`/`24h`.

This translates the duration shorthand (`s`/`m`/`h`/`d`/`w`, e.g. `1h`, `24h`, `7d`, `1w`) to an absolute ISO-8601 timestamp **client-side** before sending. Real ISO/epoch values pass through untouched, so the core/MCP `z.coerce.date()` contract is unchanged.

## Changes

- `resolveSinceDuration()` + wiring in `packages/cli/src/commands/ops.ts`
- Unit tests: `packages/cli/src/__tests__/since-duration.test.ts` (5 cases — units, case-insensitivity, ISO/epoch/garbage pass-through)
- E2E regression case (`recent --since 24h`) in `scripts/e2e.ts`
- Version bump `0.8.0 → 0.8.1` (`sync-versions.ts`) + regenerated `docs/openapi.json` (+ landing copy)
- Live prod QA report for the merged RBAC work that surfaced this defect (`thoughts/taras/qa/2026-06-10-multitenant-rbac-safety-live-prod.md`)

## Verification

- `bun run typecheck` clean; `bun run test` → 385 pass / 0 fail (5 new)
- Live-verified against prod (`agent-fs-taras.fly.dev`) with the source CLI: `recent --since 1h` and `--since 7d` now return entries (previously `400 invalid_date`)

## Context

Found during **live production QA** of the multi-tenant RBAC branch (PR #16, merged). Pre-existing, unrelated to RBAC, no security impact — a CLI/doc contract bug.