### PR TITLE
feat: `sql` command — DuckDB queries over stored documents (CLI, API, MCP, UI)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "author": {
     "name": "desplega-ai"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "author": {
     "name": "desplega-ai"
   },

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ agent-fs was built to power the shared filesystem in [agent-swarm](https://githu
 ## Key Features
 
 - **Semantic search** — Index and search files using vector embeddings (OpenAI, Google GenAI, or local llama.cpp)
+- **SQL queries** — Run sandboxed DuckDB SQL over stored documents (CSV, TSV, Parquet, Excel, JSON, NDJSON, SQLite, DuckDB) — see [docs/sql.md](./docs/sql.md)
 - **Structured storage** — SQLite-backed file operations with metadata and versioning
 - **S3-compatible sync** — Sync agent workspaces to any S3-compatible object store
 - **Identity management** — Persistent agent identity files that evolve over time

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "agent-fs",
       "devDependencies": {
+        "@duckdb/node-api": "1.5.3-r.3",
         "bun-types": "^1.2.0",
         "typescript": "^5.7.0",
         "yaml": "^2.8.2",
@@ -13,12 +14,13 @@
     },
     "packages/cli": {
       "name": "@desplega.ai/agent-fs",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "bin": {
         "agent-fs": "dist/cli.js",
       },
       "dependencies": {
         "@aws-sdk/client-s3": "^3.750.0",
+        "@duckdb/node-api": "1.5.3-r.3",
         "@google/genai": "^1.45.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "chonkie": "^0.3.0",
@@ -33,8 +35,8 @@
         "zod": "^3.24.0",
       },
       "optionalDependencies": {
-        "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.7.0",
-        "@desplega.ai/agent-fs-fuse-linux-x64": "^0.7.0",
+        "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.1",
+        "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.1",
         "sqlite-vec-darwin-arm64": "^0.1.9",
         "sqlite-vec-darwin-x64": "^0.1.9",
         "sqlite-vec-linux-arm64": "^0.1.9",
@@ -44,10 +46,11 @@
     },
     "packages/core": {
       "name": "@desplega.ai/agent-fs-core",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.750.0",
         "@aws-sdk/s3-request-presigner": "^3.750.0",
+        "@duckdb/node-api": "1.5.3-r.3",
         "@google/genai": "^1.45.0",
         "chonkie": "^0.3.0",
         "diff": "^8.0.3",
@@ -65,15 +68,15 @@
     },
     "packages/fuse-helper-linux-arm64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-      "version": "0.7.3",
+      "version": "0.8.1",
     },
     "packages/fuse-helper-linux-x64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-      "version": "0.7.3",
+      "version": "0.8.1",
     },
     "packages/just-bash": {
       "name": "@desplega.ai/agent-fs-just-bash",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "peerDependencies": {
         "just-bash": ">=3.0.1",
       },
@@ -83,7 +86,7 @@
     },
     "packages/mcp": {
       "name": "@desplega.ai/agent-fs-mcp",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -92,7 +95,7 @@
     },
     "packages/server": {
       "name": "@desplega.ai/agent-fs-server",
-      "version": "0.7.3",
+      "version": "0.8.1",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@desplega.ai/agent-fs-mcp": "workspace:*",
@@ -212,6 +215,26 @@
     "@desplega.ai/agent-fs-server": ["@desplega.ai/agent-fs-server@workspace:packages/server"],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.3-r.3", "", { "dependencies": { "@duckdb/node-bindings": "1.5.3-r.3" } }, "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA=="],
+
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.3-r.3", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3", "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3", "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3", "@duckdb/node-bindings-win32-x64": "1.5.3-r.3" } }, "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg=="],
+
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.3-r.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ=="],
+
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.3-r.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg=="],
+
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ=="],
+
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ=="],
+
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw=="],
+
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA=="],
+
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.3-r.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.3-r.3", "", { "os": "win32", "cpu": "x64" }, "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",
@@ -765,6 +765,69 @@
                       },
                       "path": {
                         "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "title": "sql",
+                    "description": "Run a DuckDB SQL query over documents stored in the drive. Reference documents directly by path string literal (e.g. SELECT * FROM '/data/sales.csv') or bind them as named tables via `tables` ({ name: path } or { name: { path, format } } to override format detection). Supports csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also .gz except parquet/xlsx), sqlite (.db/.sqlite/.sqlite3, tables exposed as name.tablename), and .duckdb files. Queries run sandboxed: no filesystem or network access beyond the bound documents. Returns { columns, rows, rowCount, truncated, files, elapsedMs }.",
+                    "required": [
+                      "op",
+                      "query"
+                    ],
+                    "properties": {
+                      "op": {
+                        "type": "string",
+                        "const": "sql"
+                      },
+                      "driveId": {
+                        "type": "string",
+                        "description": "Target drive ID (optional, uses default drive)"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "tables": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": "string"
+                                },
+                                "format": {
+                                  "type": "string",
+                                  "enum": [
+                                    "csv",
+                                    "tsv",
+                                    "parquet",
+                                    "xlsx",
+                                    "json",
+                                    "ndjson",
+                                    "sqlite",
+                                    "duckdb"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "maxRows": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10000
                       }
                     },
                     "additionalProperties": false

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.8.2",
+    "version": "0.9.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/docs/sql.md
+++ b/docs/sql.md
@@ -1,0 +1,144 @@
+# SQL Queries
+
+Run DuckDB SQL directly against documents stored in agent-fs — CSV, TSV, Parquet, Excel, JSON, NDJSON, SQLite databases, and DuckDB databases. Available as a CLI command (`agent-fs sql`), an API op (`sql`), and an MCP tool.
+
+```bash
+agent-fs sql "SELECT category, sum(amount) FROM '/finance/2026.csv' GROUP BY category"
+```
+
+## Supported formats
+
+| Format | Extensions | Notes |
+|--------|------------|-------|
+| CSV | `.csv`, `.csv.gz` | Delimiter, header, and types auto-detected |
+| TSV | `.tsv`, `.tab`, `.tsv.gz` | Tab-delimited |
+| Parquet | `.parquet` | |
+| Excel | `.xlsx` | First sheet; header auto-detected |
+| JSON | `.json`, `.json.gz` | Arrays of objects or single objects |
+| NDJSON | `.ndjson`, `.jsonl` (+ `.gz`) | Newline-delimited JSON |
+| SQLite | `.db`, `.sqlite`, `.sqlite3` | All tables exposed — see below |
+| DuckDB | `.duckdb` | Tables from the `main` schema |
+
+## Referencing documents
+
+There are two ways to make a document queryable:
+
+### 1. Path literals (file formats)
+
+Reference any stored CSV/TSV/Parquet/Excel/JSON/NDJSON document by its drive path as a quoted string, exactly like DuckDB's own file syntax:
+
+```bash
+agent-fs sql "SELECT * FROM '/data/sales.csv' WHERE amount > 100"
+agent-fs sql "SELECT a.id FROM '/data/a.parquet' a JOIN '/data/b.ndjson' b USING (id)"
+```
+
+Only string literals that resolve to an existing document in the drive are bound — other strings are left untouched, so `WHERE name = 'report.csv'` works as expected.
+
+### 2. Named table bindings
+
+Bind documents to table names with `--table` (repeatable). Required for SQLite/DuckDB databases, and useful for readable multi-file queries:
+
+```bash
+agent-fs sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id" \
+  -t sales=/data/sales.csv -t tags=/data/tags.parquet
+```
+
+SQLite and DuckDB databases expose every table under the binding name as a schema:
+
+```bash
+# /backups/app.db has tables `users` and `orders`
+agent-fs sql "SELECT u.email, count(*) FROM app.users u JOIN app.orders o ON o.user_id = u.id GROUP BY 1" \
+  -t app=/backups/app.db
+```
+
+### Making any document SQL-able (format override)
+
+If a document doesn't have a recognized extension, override the format with a `:format` suffix (CLI) or `{ path, format }` (API/MCP):
+
+```bash
+agent-fs sql "SELECT sum(a) FROM logs" -t logs=/raw/data.txt:csv
+```
+
+Formats: `csv`, `tsv`, `parquet`, `xlsx`, `json`, `ndjson`, `sqlite`, `duckdb`.
+
+## CLI usage
+
+```bash
+agent-fs sql [query] [options]
+
+  -t, --table <name=path[:format]>  Bind a document as a named table (repeatable)
+  --max-rows <n>                    Max rows to return (default: 1000, max: 10000)
+  --json                            Output the raw result object
+```
+
+The query can also be piped via stdin:
+
+```bash
+echo "SELECT count(*) FROM '/data/events.ndjson'" | agent-fs sql
+```
+
+Multi-statement queries are supported — the result of the last statement is returned:
+
+```bash
+agent-fs sql "CREATE TABLE big AS SELECT * FROM '/data/sales.csv' WHERE amount > 100; SELECT count(*) FROM big"
+```
+
+## API usage
+
+`sql` is a standard op on the dispatch endpoint:
+
+```bash
+curl -X POST http://localhost:7433/orgs/{orgId}/ops \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "op": "sql",
+    "driveId": "<driveId>",
+    "query": "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id",
+    "tables": {
+      "sales": "/data/sales.csv",
+      "tags": { "path": "/data/tags.parquet", "format": "parquet" }
+    },
+    "maxRows": 1000
+  }'
+```
+
+Response:
+
+```json
+{
+  "columns": [{ "name": "name", "type": "VARCHAR" }, { "name": "tag", "type": "VARCHAR" }],
+  "rows": [{ "name": "alpha", "tag": "aa" }],
+  "rowCount": 1,
+  "truncated": false,
+  "files": [
+    { "table": "sales", "path": "/data/sales.csv", "format": "csv" },
+    { "table": "tags", "path": "/data/tags.parquet", "format": "parquet" }
+  ],
+  "elapsedMs": 42
+}
+```
+
+Value encoding: `BIGINT`s outside JavaScript's safe integer range and timestamps/dates/UUIDs are returned as strings; decimals as numbers; lists and structs as JSON arrays/objects; blobs as `<blob N bytes>` placeholders. The op requires the `viewer` role.
+
+The same op is exposed as the `sql` MCP tool with identical arguments.
+
+## Web UI
+
+The live UI has a SQL workbench at `/sql/~/{orgId}/{driveId}` — pick documents, write queries (Cmd+Enter to run), and view results as a table or quick chart. CSV/TSV/Parquet/JSON/NDJSON queries run client-side via DuckDB WASM; Excel/SQLite/DuckDB documents automatically run on the server. Open it from any queryable file via the **Query** button in the file detail view.
+
+## Sandboxing & limits
+
+User SQL never touches the host. Referenced documents are downloaded and materialized into an in-memory DuckDB instance during setup; before any user SQL executes, external access is disabled, the local filesystem is turned off, and the configuration is locked. SQLite files are converted in an isolated bridge instance — the instance that runs your query never loads the sqlite extension, closing its direct-I/O escape hatch. Attempts to read host paths, fetch URLs, `ATTACH`, `COPY ... TO`, or change settings fail with a `VALIDATION_ERROR`.
+
+Server-side knobs (environment variables on the daemon/server):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `AGENT_FS_SQL_TIMEOUT_MS` | `30000` | Query timeout (the query is interrupted) |
+| `AGENT_FS_SQL_MAX_FILE_BYTES` | `268435456` (256 MB) | Per-document size cap |
+| `AGENT_FS_SQL_MEMORY_LIMIT` | `512MB` | DuckDB memory limit |
+
+`maxRows` caps the returned rows (default 1000, max 10000); `truncated: true` signals there were more.
+
+Note: the first query that touches an `.xlsx` or SQLite document downloads the DuckDB `excel`/`sqlite` extension on the server (cached in `~/.duckdb` afterwards), so the server needs outbound network access once.

--- a/landing/content/markdown.ts
+++ b/landing/content/markdown.ts
@@ -103,6 +103,7 @@ fully self-hostable.
 ### Reference
 
 - API reference: https://agent-fs.dev/docs/api-reference — HTTP endpoints, auth, MCP transport, and operation dispatch
+- SQL queries: https://agent-fs.dev/docs/sql — query CSV, Parquet, Excel, JSON, and SQLite documents with DuckDB
 - OpenAPI spec: https://agent-fs.dev/docs/openapi.json
 
 ### Mounting (FUSE)
@@ -125,6 +126,7 @@ prefer fetching markdown directly.
 - \`agent-fs cat <path>\` — read a file
 - \`agent-fs search '<query>'\` — semantic search over stored files
 - \`agent-fs fts '<query>'\` — full-text search over stored files
+- \`agent-fs sql "SELECT * FROM '/data/sales.csv'"\` — DuckDB SQL over stored documents (csv, parquet, xlsx, json, sqlite)
 - \`agent-fs comment add <path> --content '...'\` — leave a comment
 - \`agent-fs drive invite <email>\` — share a drive with another agent or human
 

--- a/landing/public/docs/openapi.json
+++ b/landing/public/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.8.1",
+    "version": "0.9.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",
@@ -765,6 +765,69 @@
                       },
                       "path": {
                         "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "title": "sql",
+                    "description": "Run a DuckDB SQL query over documents stored in the drive. Reference documents directly by path string literal (e.g. SELECT * FROM '/data/sales.csv') or bind them as named tables via `tables` ({ name: path } or { name: { path, format } } to override format detection). Supports csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also .gz except parquet/xlsx), sqlite (.db/.sqlite/.sqlite3, tables exposed as name.tablename), and .duckdb files. Queries run sandboxed: no filesystem or network access beyond the bound documents. Returns { columns, rows, rowCount, truncated, files, elapsedMs }.",
+                    "required": [
+                      "op",
+                      "query"
+                    ],
+                    "properties": {
+                      "op": {
+                        "type": "string",
+                        "const": "sql"
+                      },
+                      "driveId": {
+                        "type": "string",
+                        "description": "Target drive ID (optional, uses default drive)"
+                      },
+                      "query": {
+                        "type": "string"
+                      },
+                      "tables": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": "string"
+                                },
+                                "format": {
+                                  "type": "string",
+                                  "enum": [
+                                    "csv",
+                                    "tsv",
+                                    "parquet",
+                                    "xlsx",
+                                    "json",
+                                    "ndjson",
+                                    "sqlite",
+                                    "duckdb"
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "path"
+                              ],
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "maxRows": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 10000
                       }
                     },
                     "additionalProperties": false

--- a/landing/public/docs/sql.md
+++ b/landing/public/docs/sql.md
@@ -1,0 +1,144 @@
+# SQL Queries
+
+Run DuckDB SQL directly against documents stored in agent-fs — CSV, TSV, Parquet, Excel, JSON, NDJSON, SQLite databases, and DuckDB databases. Available as a CLI command (`agent-fs sql`), an API op (`sql`), and an MCP tool.
+
+```bash
+agent-fs sql "SELECT category, sum(amount) FROM '/finance/2026.csv' GROUP BY category"
+```
+
+## Supported formats
+
+| Format | Extensions | Notes |
+|--------|------------|-------|
+| CSV | `.csv`, `.csv.gz` | Delimiter, header, and types auto-detected |
+| TSV | `.tsv`, `.tab`, `.tsv.gz` | Tab-delimited |
+| Parquet | `.parquet` | |
+| Excel | `.xlsx` | First sheet; header auto-detected |
+| JSON | `.json`, `.json.gz` | Arrays of objects or single objects |
+| NDJSON | `.ndjson`, `.jsonl` (+ `.gz`) | Newline-delimited JSON |
+| SQLite | `.db`, `.sqlite`, `.sqlite3` | All tables exposed — see below |
+| DuckDB | `.duckdb` | Tables from the `main` schema |
+
+## Referencing documents
+
+There are two ways to make a document queryable:
+
+### 1. Path literals (file formats)
+
+Reference any stored CSV/TSV/Parquet/Excel/JSON/NDJSON document by its drive path as a quoted string, exactly like DuckDB's own file syntax:
+
+```bash
+agent-fs sql "SELECT * FROM '/data/sales.csv' WHERE amount > 100"
+agent-fs sql "SELECT a.id FROM '/data/a.parquet' a JOIN '/data/b.ndjson' b USING (id)"
+```
+
+Only string literals that resolve to an existing document in the drive are bound — other strings are left untouched, so `WHERE name = 'report.csv'` works as expected.
+
+### 2. Named table bindings
+
+Bind documents to table names with `--table` (repeatable). Required for SQLite/DuckDB databases, and useful for readable multi-file queries:
+
+```bash
+agent-fs sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id" \
+  -t sales=/data/sales.csv -t tags=/data/tags.parquet
+```
+
+SQLite and DuckDB databases expose every table under the binding name as a schema:
+
+```bash
+# /backups/app.db has tables `users` and `orders`
+agent-fs sql "SELECT u.email, count(*) FROM app.users u JOIN app.orders o ON o.user_id = u.id GROUP BY 1" \
+  -t app=/backups/app.db
+```
+
+### Making any document SQL-able (format override)
+
+If a document doesn't have a recognized extension, override the format with a `:format` suffix (CLI) or `{ path, format }` (API/MCP):
+
+```bash
+agent-fs sql "SELECT sum(a) FROM logs" -t logs=/raw/data.txt:csv
+```
+
+Formats: `csv`, `tsv`, `parquet`, `xlsx`, `json`, `ndjson`, `sqlite`, `duckdb`.
+
+## CLI usage
+
+```bash
+agent-fs sql [query] [options]
+
+  -t, --table <name=path[:format]>  Bind a document as a named table (repeatable)
+  --max-rows <n>                    Max rows to return (default: 1000, max: 10000)
+  --json                            Output the raw result object
+```
+
+The query can also be piped via stdin:
+
+```bash
+echo "SELECT count(*) FROM '/data/events.ndjson'" | agent-fs sql
+```
+
+Multi-statement queries are supported — the result of the last statement is returned:
+
+```bash
+agent-fs sql "CREATE TABLE big AS SELECT * FROM '/data/sales.csv' WHERE amount > 100; SELECT count(*) FROM big"
+```
+
+## API usage
+
+`sql` is a standard op on the dispatch endpoint:
+
+```bash
+curl -X POST http://localhost:7433/orgs/{orgId}/ops \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "op": "sql",
+    "driveId": "<driveId>",
+    "query": "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id",
+    "tables": {
+      "sales": "/data/sales.csv",
+      "tags": { "path": "/data/tags.parquet", "format": "parquet" }
+    },
+    "maxRows": 1000
+  }'
+```
+
+Response:
+
+```json
+{
+  "columns": [{ "name": "name", "type": "VARCHAR" }, { "name": "tag", "type": "VARCHAR" }],
+  "rows": [{ "name": "alpha", "tag": "aa" }],
+  "rowCount": 1,
+  "truncated": false,
+  "files": [
+    { "table": "sales", "path": "/data/sales.csv", "format": "csv" },
+    { "table": "tags", "path": "/data/tags.parquet", "format": "parquet" }
+  ],
+  "elapsedMs": 42
+}
+```
+
+Value encoding: `BIGINT`s outside JavaScript's safe integer range and timestamps/dates/UUIDs are returned as strings; decimals as numbers; lists and structs as JSON arrays/objects; blobs as `<blob N bytes>` placeholders. The op requires the `viewer` role.
+
+The same op is exposed as the `sql` MCP tool with identical arguments.
+
+## Web UI
+
+The live UI has a SQL workbench at `/sql/~/{orgId}/{driveId}` — pick documents, write queries (Cmd+Enter to run), and view results as a table or quick chart. CSV/TSV/Parquet/JSON/NDJSON queries run client-side via DuckDB WASM; Excel/SQLite/DuckDB documents automatically run on the server. Open it from any queryable file via the **Query** button in the file detail view.
+
+## Sandboxing & limits
+
+User SQL never touches the host. Referenced documents are downloaded and materialized into an in-memory DuckDB instance during setup; before any user SQL executes, external access is disabled, the local filesystem is turned off, and the configuration is locked. SQLite files are converted in an isolated bridge instance — the instance that runs your query never loads the sqlite extension, closing its direct-I/O escape hatch. Attempts to read host paths, fetch URLs, `ATTACH`, `COPY ... TO`, or change settings fail with a `VALIDATION_ERROR`.
+
+Server-side knobs (environment variables on the daemon/server):
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `AGENT_FS_SQL_TIMEOUT_MS` | `30000` | Query timeout (the query is interrupted) |
+| `AGENT_FS_SQL_MAX_FILE_BYTES` | `268435456` (256 MB) | Per-document size cap |
+| `AGENT_FS_SQL_MEMORY_LIMIT` | `512MB` | DuckDB memory limit |
+
+`maxRows` caps the returned rows (default 1000, max 10000); `truncated: true` signals there were more.
+
+Note: the first query that touches an `.xlsx` or SQLite document downloads the DuckDB `excel`/`sqlite` extension on the server (cached in `~/.duckdb` afterwards), so the server needs outbound network access once.

--- a/landing/public/sitemap.md
+++ b/landing/public/sitemap.md
@@ -14,6 +14,8 @@ machine-readable representation (where available) linked alongside.
 - [/docs](https://agent-fs.dev/docs) — Documentation index.
 - [/docs/api-reference](https://agent-fs.dev/docs/api-reference) — HTTP API,
   auth, MCP transport, and operation dispatch.
+- [/docs/sql](https://agent-fs.dev/docs/sql) — Query CSV, Parquet, Excel, JSON,
+  and SQLite documents with DuckDB (CLI, API, MCP).
 - [/docs/mcp-setup](https://agent-fs.dev/docs/mcp-setup) — MCP client setup.
 - [/docs/deployment](https://agent-fs.dev/docs/deployment) — Local and hosted
   deployment guide.

--- a/landing/public/sitemap.xml
+++ b/landing/public/sitemap.xml
@@ -19,6 +19,12 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://agent-fs.dev/docs/sql</loc>
+    <lastmod>2026-06-11</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://agent-fs.dev/docs/mcp-setup</loc>
     <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>

--- a/landing/src/content/docs.ts
+++ b/landing/src/content/docs.ts
@@ -8,6 +8,7 @@ import mountingOverview from "../../../docs/mounting/README.md?raw"
 import mountingE2b from "../../../docs/mounting/e2b.md?raw"
 import mountingHetzner from "../../../docs/mounting/hetzner.md?raw"
 import mountingSprite from "../../../docs/mounting/sprite.md?raw"
+import sqlQueries from "../../../docs/sql.md?raw"
 
 export type DocEntry = {
   slug: string
@@ -42,6 +43,14 @@ export const DOCS: DocEntry[] = [
     section: "Start",
     sourcePath: "docs/deployment.md",
     markdown: deployment,
+  },
+  {
+    slug: "sql",
+    title: "SQL Queries",
+    summary: "Query CSV, Parquet, Excel, JSON, and SQLite documents with DuckDB.",
+    section: "Reference",
+    sourcePath: "docs/sql.md",
+    markdown: sqlQueries,
   },
   {
     slug: "fuse-mount",

--- a/landing/src/pages/DocsPage.tsx
+++ b/landing/src/pages/DocsPage.tsx
@@ -685,6 +685,62 @@ export function DocsPage({ slug }: { slug?: string }) {
   const activeId = useActiveHeading(activeDoc.slug)
   const sidebarRef = useRef<HTMLElement | null>(null)
 
+  // Per-document SEO/GEO: unique title, description, canonical, Open Graph,
+  // Twitter, and TechArticle JSON-LD so each doc page is independently
+  // indexable by search engines and citable by answer engines.
+  useEffect(() => {
+    const url = `https://agent-fs.dev/docs/${activeDoc.slug}`
+    const title = `${activeDoc.title} — agent-fs docs`
+    document.title = title
+
+    const upsertMeta = (
+      key: string,
+      content: string,
+      attr: "name" | "property" = "name",
+    ) => {
+      let el = document.head.querySelector<HTMLMetaElement>(`meta[${attr}="${key}"]`)
+      if (!el) {
+        el = document.createElement("meta")
+        el.setAttribute(attr, key)
+        document.head.appendChild(el)
+      }
+      el.setAttribute("content", content)
+    }
+    upsertMeta("description", activeDoc.summary)
+    upsertMeta("og:title", title, "property")
+    upsertMeta("og:description", activeDoc.summary, "property")
+    upsertMeta("og:url", url, "property")
+    upsertMeta("og:type", "article", "property")
+    upsertMeta("twitter:title", title)
+    upsertMeta("twitter:description", activeDoc.summary)
+
+    let canonical = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+    if (!canonical) {
+      canonical = document.createElement("link")
+      canonical.rel = "canonical"
+      document.head.appendChild(canonical)
+    }
+    canonical.href = url
+
+    const jsonLd = {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      headline: activeDoc.title,
+      description: activeDoc.summary,
+      url,
+      inLanguage: "en",
+      isPartOf: { "@type": "WebSite", name: "agent-fs", url: "https://agent-fs.dev" },
+    }
+    let script = document.getElementById("doc-jsonld") as HTMLScriptElement | null
+    if (!script) {
+      script = document.createElement("script")
+      script.id = "doc-jsonld"
+      script.type = "application/ld+json"
+      document.head.appendChild(script)
+    }
+    script.textContent = JSON.stringify(jsonLd)
+  }, [activeDoc])
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {

--- a/live/package.json
+++ b/live/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@duckdb/duckdb-wasm": "1.32.0",
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/space-grotesk": "^5.2.10",
     "@monaco-editor/react": "^4.7.0",

--- a/live/package.json
+++ b/live/package.json
@@ -17,6 +17,8 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tailwindcss/vite": "^4.2.1",
     "@tanstack/react-query": "^5.64.0",
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "highlight.js": "^11.11.1",

--- a/live/pnpm-lock.yaml
+++ b/live/pnpm-lock.yaml
@@ -32,6 +32,12 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.64.0
         version: 5.90.21(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-virtual':
+        specifier: ^3.14.2
+        version: 3.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -697,6 +703,26 @@ packages:
     resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/react-virtual@3.14.2':
+    resolution: {integrity: sha512-IpWnmCLvuymRfeeLNVXIzNEYBFLpd3drVIS91sqV78VTZFyldlChkOocZRCPp1B+Wnk09bcLNme8WaMU/9/9bQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -3579,6 +3605,22 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.2.4
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/react-virtual@3.14.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.17.0': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:

--- a/live/pnpm-lock.yaml
+++ b/live/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@duckdb/duckdb-wasm':
+        specifier: 1.32.0
+        version: 1.32.0
       '@fontsource/jetbrains-mono':
         specifier: ^5.2.8
         version: 5.2.8
@@ -283,6 +286,9 @@ packages:
   '@dotenvx/dotenvx@1.55.1':
     resolution: {integrity: sha512-WEuKyoe9CA7dfcFBnNbL0ndbCNcptaEYBygfFo9X1qEG+HD7xku4CYIplw6sbAHJavesZWbVBHeRSpvri0eKqw==}
     hasBin: true
+
+  '@duckdb/duckdb-wasm@1.32.0':
+    resolution: {integrity: sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==}
 
   '@ecies/ciphers@0.2.5':
     resolution: {integrity: sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==}
@@ -586,6 +592,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@swc/helpers@0.5.23':
+    resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -694,6 +703,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
 
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
@@ -809,6 +824,9 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
+
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
@@ -890,8 +908,20 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  apache-arrow@17.0.0:
+    resolution: {integrity: sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==}
+    hasBin: true
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==}
+    engines: {node: '>=6'}
+
+  array-back@6.2.3:
+    resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==}
+    engines: {node: '>=12.17'}
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -951,6 +981,14 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==}
+    engines: {node: '>=12'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1012,6 +1050,14 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
+    engines: {node: '>=12.20.0'}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -1454,6 +1500,13 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==}
+    engines: {node: '>=4.0.0'}
+
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -1530,6 +1583,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -1737,6 +1794,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
+    engines: {node: '>=0.8'}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -1924,6 +1985,9 @@ packages:
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
@@ -2593,8 +2657,16 @@ packages:
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==}
+    engines: {node: '>=12.17'}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -2676,8 +2748,19 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==}
+    engines: {node: '>=8'}
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==}
+    engines: {node: '>=12.17'}
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -2826,6 +2909,10 @@ packages:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
+
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==}
+    engines: {node: '>=12.17'}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -3124,6 +3211,10 @@ snapshots:
       picomatch: 4.0.3
       which: 4.0.0
 
+  '@duckdb/duckdb-wasm@1.32.0':
+    dependencies:
+      apache-arrow: 17.0.0
+
   '@ecies/ciphers@0.2.5(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
@@ -3405,6 +3496,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@swc/helpers@0.5.23':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.2.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -3495,6 +3590,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
 
   '@types/d3-array@3.2.2': {}
 
@@ -3635,6 +3734,10 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@25.5.0':
     dependencies:
       undici-types: 7.18.2
@@ -3698,7 +3801,23 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  apache-arrow@17.0.0:
+    dependencies:
+      '@swc/helpers': 0.5.23
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 20.19.43
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.4
+      flatbuffers: 24.12.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+
   argparse@2.0.1: {}
+
+  array-back@3.1.0: {}
+
+  array-back@6.2.3: {}
 
   ast-types@0.16.1:
     dependencies:
@@ -3762,6 +3881,15 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
@@ -3814,6 +3942,20 @@ snapshots:
   color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
+
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.3
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   commander@11.1.0: {}
 
@@ -4275,6 +4417,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
+
+  flatbuffers@24.12.23: {}
+
   formdata-polyfill@4.0.10:
     dependencies:
       fetch-blob: 3.2.0
@@ -4340,6 +4488,8 @@ snapshots:
   graphql@16.13.1: {}
 
   hachure-fill@0.5.2: {}
+
+  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -4523,6 +4673,8 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bignum@0.0.3: {}
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -4661,6 +4813,8 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   lodash-es@4.18.1: {}
+
+  lodash.camelcase@4.3.0: {}
 
   log-symbols@6.0.0:
     dependencies:
@@ -5673,7 +5827,16 @@ snapshots:
 
   stylis@4.4.0: {}
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   tabbable@6.4.0: {}
+
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.3
+      wordwrapjs: 5.1.1
 
   tagged-tag@1.0.0: {}
 
@@ -5741,7 +5904,13 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typical@4.0.0: {}
+
+  typical@7.3.0: {}
+
   ufo@1.6.3: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 
@@ -5858,6 +6027,8 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  wordwrapjs@5.1.1: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/live/src/App.tsx
+++ b/live/src/App.tsx
@@ -11,6 +11,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary"
 import { CredentialsPage } from "@/pages/Credentials"
 import { FileBrowserPage } from "@/pages/FileBrowser"
 import { FileDetailPage } from "@/pages/FileDetail"
+import { SqlPage } from "@/pages/SqlPage"
 import { Spinner } from "@/components/ui/spinner"
 
 const queryClient = new QueryClient({
@@ -122,6 +123,17 @@ function DetailRoute() {
   )
 }
 
+function SqlRoute() {
+  return (
+    <>
+      <RouteParamsSync />
+      <Shell>
+        <SqlPage />
+      </Shell>
+    </>
+  )
+}
+
 function FilesRoute() {
   return (
     <Shell>
@@ -170,6 +182,7 @@ export default function App() {
                   <Route path="/orgs/:orgId/files/*" element={<OrgFileRedirect />} />
                   <Route path="/file/~/:orgId/:driveId/*" element={<FileRoute />} />
                   <Route path="/detail/~/:orgId/:driveId/*" element={<DetailRoute />} />
+                  <Route path="/sql/~/:orgId/:driveId" element={<SqlRoute />} />
                   <Route path="/files" element={<FilesRoute />} />
                   <Route path="*" element={<Navigate to="/files" replace />} />
                 </Route>

--- a/live/src/api/client.ts
+++ b/live/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { MeResponse, Drive, OrgMembersResult, RegisterResponse } from "./types"
+import type { MeResponse, Drive, OrgMembersResult, RegisterResponse, SqlResult, SqlTableBinding } from "./types"
 
 export interface ApiError {
   error: string
@@ -108,6 +108,14 @@ export class AgentFsClient {
       { path },
       driveId,
     )
+  }
+
+  async sqlQuery(
+    orgId: string,
+    driveId: string,
+    params: { query: string; tables?: Record<string, SqlTableBinding>; maxRows?: number },
+  ): Promise<SqlResult> {
+    return this.callOp<SqlResult>(orgId, "sql", { ...params }, driveId)
   }
 
   getRawUrl(orgId: string, driveId: string, path: string): string {

--- a/live/src/api/types.ts
+++ b/live/src/api/types.ts
@@ -187,6 +187,41 @@ export interface GrepResult {
   matches: GrepMatch[]
 }
 
+// SQL types (from core/ops/types.ts)
+
+export type SqlFormat =
+  | "csv"
+  | "tsv"
+  | "parquet"
+  | "xlsx"
+  | "json"
+  | "ndjson"
+  | "sqlite"
+  | "duckdb"
+
+/** Named table binding: document path, or { path, format } to override format detection. */
+export type SqlTableBinding = string | { path: string; format?: SqlFormat }
+
+export interface SqlColumn {
+  name: string
+  type: string
+}
+
+export interface SqlBoundFile {
+  table: string
+  path: string
+  format: SqlFormat
+}
+
+export interface SqlResult {
+  columns: SqlColumn[]
+  rows: Record<string, unknown>[]
+  rowCount: number
+  truncated: boolean
+  files: SqlBoundFile[]
+  elapsedMs: number
+}
+
 // Auth types
 
 export interface OrgMember {

--- a/live/src/components/AccountSwitcher.tsx
+++ b/live/src/components/AccountSwitcher.tsx
@@ -41,6 +41,7 @@ export function AccountSwitcher() {
               if (cred.id === credential.id) return
               switchAccount(cred.id)
               toast(`Switched to ${cred.name}`)
+              navigate("/")
             }}
           >
             <div className="flex-1 min-w-0">

--- a/live/src/components/data-grid/DataGrid.tsx
+++ b/live/src/components/data-grid/DataGrid.tsx
@@ -1,0 +1,195 @@
+import { useMemo, useRef, useState } from "react"
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type SortingState,
+} from "@tanstack/react-table"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+export interface DataGridColumn {
+  name: string
+  type?: string
+}
+
+interface DataGridProps {
+  columns: DataGridColumn[]
+  rows: Record<string, unknown>[]
+  className?: string
+  /** Estimated row height in px (fixed-height rows keep virtualization simple). */
+  rowHeight?: number
+}
+
+const ROW_NUM_WIDTH = 52
+const DEFAULT_COL_WIDTH = 160
+const MIN_COL_WIDTH = 64
+
+/**
+ * Virtualized, themed data grid shared by the SQL results panel and tabular
+ * file previews. Headless TanStack Table for sizing/sorting + react-virtual for
+ * row windowing, so tens of thousands of rows render without choking the DOM.
+ */
+export function DataGrid({ columns, rows, className, rowHeight = 30 }: DataGridProps) {
+  const [sorting, setSorting] = useState<SortingState>([])
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const tableColumns = useMemo<ColumnDef<Record<string, unknown>>[]>(
+    () =>
+      columns.map((col) => ({
+        id: col.name,
+        accessorFn: (row) => row[col.name],
+        header: col.name,
+        size: DEFAULT_COL_WIDTH,
+        minSize: MIN_COL_WIDTH,
+        // String sort keeps mixed types comparable and stable.
+        sortingFn: (a, b, id) =>
+          collator.compare(toText(a.getValue(id)), toText(b.getValue(id))),
+      })),
+    [columns],
+  )
+
+  const table = useReactTable({
+    data: rows,
+    columns: tableColumns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    columnResizeMode: "onChange",
+  })
+
+  const tableRows = table.getRowModel().rows
+  const rowVirtualizer = useVirtualizer({
+    count: tableRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => rowHeight,
+    overscan: 12,
+  })
+
+  const totalWidth = table.getTotalSize() + ROW_NUM_WIDTH
+  const virtualRows = rowVirtualizer.getVirtualItems()
+
+  return (
+    <div ref={scrollRef} className={cn("min-h-0 flex-1 overflow-auto", className)}>
+      <div style={{ width: totalWidth, minWidth: "100%" }} className="text-xs">
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex border-b border-border bg-background">
+          <div
+            className="shrink-0 px-2 py-1.5 text-right font-normal text-muted-foreground/50"
+            style={{ width: ROW_NUM_WIDTH }}
+          >
+            #
+          </div>
+          {table.getHeaderGroups()[0]?.headers.map((header) => {
+            const sorted = header.column.getIsSorted()
+            const type = columns.find((c) => c.name === header.column.id)?.type
+            return (
+              <div
+                key={header.id}
+                className="group/h relative flex items-center px-2 py-1.5 font-medium"
+                style={{ width: header.getSize() }}
+              >
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <button
+                        type="button"
+                        onClick={header.column.getToggleSortingHandler()}
+                        className="flex min-w-0 items-center gap-1 truncate text-left hover:text-foreground"
+                      >
+                        <span className="truncate">{header.column.id}</span>
+                        {sorted === "asc" ? (
+                          <ArrowUp className="size-3 shrink-0 text-muted-foreground" />
+                        ) : sorted === "desc" ? (
+                          <ArrowDown className="size-3 shrink-0 text-muted-foreground" />
+                        ) : (
+                          <ChevronsUpDown className="size-3 shrink-0 text-muted-foreground/0 group-hover/h:text-muted-foreground/40" />
+                        )}
+                      </button>
+                    }
+                  />
+                  <TooltipContent className="font-mono">{type ?? "?"}</TooltipContent>
+                </Tooltip>
+                {/* Column resize handle */}
+                <div
+                  onMouseDown={header.getResizeHandler()}
+                  onTouchStart={header.getResizeHandler()}
+                  className={cn(
+                    "absolute top-0 right-0 h-full w-1 cursor-col-resize touch-none select-none",
+                    "opacity-0 group-hover/h:opacity-100",
+                    header.column.getIsResizing() ? "bg-primary opacity-100" : "bg-border",
+                  )}
+                />
+              </div>
+            )
+          })}
+        </div>
+
+        {/* Body */}
+        <div
+          className="relative font-mono"
+          style={{ height: rowVirtualizer.getTotalSize() }}
+        >
+          {virtualRows.map((vr) => {
+            const row = tableRows[vr.index]
+            return (
+              <div
+                key={row.id}
+                className="absolute left-0 flex w-full border-b border-border/50 hover:bg-muted/40"
+                style={{ height: vr.size, transform: `translateY(${vr.start}px)` }}
+              >
+                <div
+                  className="shrink-0 px-2 py-1 text-right text-muted-foreground/40 tabular-nums"
+                  style={{ width: ROW_NUM_WIDTH }}
+                >
+                  {vr.index + 1}
+                </div>
+                {row.getVisibleCells().map((cell) => (
+                  <Cell
+                    key={cell.id}
+                    value={cell.getValue()}
+                    width={cell.column.getSize()}
+                  />
+                ))}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: "base" })
+
+function toText(value: unknown): string {
+  if (value === null || value === undefined) return ""
+  return typeof value === "object" ? JSON.stringify(value) : String(value)
+}
+
+function Cell({ value, width }: { value: unknown; width: number }) {
+  if (value === null || value === undefined) {
+    return (
+      <div
+        className="truncate px-2 py-1 italic text-muted-foreground/40"
+        style={{ width }}
+      >
+        NULL
+      </div>
+    )
+  }
+  const text = toText(value)
+  return (
+    <div
+      className="truncate px-2 py-1 tabular-nums"
+      style={{ width }}
+      title={text.length > 48 ? text : undefined}
+    >
+      {text}
+    </div>
+  )
+}

--- a/live/src/components/layout/DriveSwitcher.tsx
+++ b/live/src/components/layout/DriveSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router"
 import { HardDrive, Check } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { useBrowser } from "@/contexts/browser"
@@ -19,6 +20,7 @@ import { toast } from "@/stores/toast"
 export function DriveSwitcher() {
   const { drives, driveId, driveName, setDriveId } = useAuth()
   const { selectFile } = useBrowser()
+  const navigate = useNavigate()
   const displayName = driveName || driveId.slice(0, 8)
 
   if (drives.length <= 1) {
@@ -68,6 +70,7 @@ export function DriveSwitcher() {
               setDriveId(drive.id)
               selectFile(null)
               toast(`Switched to ${drive.name}`)
+              navigate("/")
             }}
           >
             <HardDrive className="size-3 text-muted-foreground" />

--- a/live/src/components/layout/OrgSwitcher.tsx
+++ b/live/src/components/layout/OrgSwitcher.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router"
 import { Building2, Check } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { useBrowser } from "@/contexts/browser"
@@ -19,6 +20,7 @@ import { toast } from "@/stores/toast"
 export function OrgSwitcher() {
   const { orgs, orgId, orgName, setOrgId } = useAuth()
   const { selectFile } = useBrowser()
+  const navigate = useNavigate()
   const displayName = orgName || orgId?.slice(0, 8) || "..."
 
   if (orgs.length <= 1) {
@@ -68,6 +70,7 @@ export function OrgSwitcher() {
               setOrgId(org.id)
               selectFile(null)
               toast(`Switched to ${org.name}`)
+              navigate("/")
             }}
           >
             <Building2 className="size-3 text-muted-foreground" />

--- a/live/src/components/sql/DocumentPicker.tsx
+++ b/live/src/components/sql/DocumentPicker.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { FileText, Plus, X } from "lucide-react"
+import { useAuth } from "@/contexts/auth"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Spinner } from "@/components/ui/spinner"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+import { QUERYABLE_EXTENSIONS, sanitizeTableName, type BoundDoc } from "@/lib/sql-engine/types"
+import type { GlobMatch, GlobResult } from "@/api/types"
+
+/** The glob op treats `{}` as literal characters (no brace expansion), so run
+ *  one glob per queryable extension in parallel and merge the matches. */
+const QUERYABLE_GLOBS = Object.keys(QUERYABLE_EXTENSIONS).map((ext) => `**/*.${ext}`)
+
+function useQueryableDocs() {
+  const { client, orgId, driveId } = useAuth()
+
+  return useQuery({
+    queryKey: ["sql-docs", orgId, driveId],
+    queryFn: async () => {
+      const results = await Promise.all(
+        QUERYABLE_GLOBS.map((pattern) =>
+          client
+            .callOp<GlobResult>(orgId!, "glob", { pattern }, driveId)
+            .catch(() => ({ matches: [] }) as GlobResult),
+        ),
+      )
+      const byPath = new Map<string, GlobMatch>()
+      for (const result of results) {
+        for (const match of result.matches) byPath.set(match.path, match)
+      }
+      return [...byPath.values()].sort((a, b) => a.path.localeCompare(b.path))
+    },
+    enabled: !!orgId && !!driveId,
+  })
+}
+
+interface DocumentPickerProps {
+  docs: BoundDoc[]
+  onAdd: (path: string) => void
+  onRemove: (path: string) => void
+  onRename: (path: string, table: string) => void
+}
+
+export function DocumentPicker({ docs, onAdd, onRemove, onRename }: DocumentPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [filter, setFilter] = useState("")
+  const { data: matches, isLoading } = useQueryableDocs()
+
+  const available = useMemo(() => {
+    const picked = new Set(docs.map((d) => d.path))
+    const needle = filter.trim().toLowerCase()
+    return (matches ?? []).filter(
+      (m) =>
+        !picked.has(m.path.replace(/^\/+/, "")) &&
+        (!needle || m.path.toLowerCase().includes(needle)),
+    )
+  }, [matches, docs, filter])
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {docs.map((doc) => (
+        <DocChip key={doc.path} doc={doc} onRemove={onRemove} onRename={onRename} />
+      ))}
+
+      <Popover
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next)
+          if (!next) setFilter("")
+        }}
+      >
+        <PopoverTrigger
+          render={
+            <Button variant="outline" size="xs" className="gap-1 text-muted-foreground">
+              <Plus />
+              Add document
+            </Button>
+          }
+        />
+        <PopoverContent align="start" className="w-80 gap-1.5 p-2">
+          <Input
+            placeholder="Filter documents…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="h-7 text-xs"
+            autoFocus
+          />
+          <div className="flex max-h-64 flex-col gap-0.5 overflow-y-auto">
+            {isLoading ? (
+              <div className="flex justify-center py-4">
+                <Spinner size="sm" />
+              </div>
+            ) : available.length === 0 ? (
+              <p className="px-2 py-3 text-xs text-muted-foreground">
+                {matches && matches.length > 0
+                  ? "No matching documents."
+                  : "No queryable documents in this drive (csv, tsv, parquet, xlsx, json, jsonl, sqlite, duckdb)."}
+              </p>
+            ) : (
+              available.map((match) => (
+                <button
+                  key={match.path}
+                  type="button"
+                  onClick={() => {
+                    onAdd(match.path)
+                    setOpen(false)
+                    setFilter("")
+                  }}
+                  className={cn(
+                    "flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs",
+                    "hover:bg-muted transition-colors",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+                  )}
+                >
+                  <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate font-mono">{match.path}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">
+                    {formatBytes(match.size)}
+                  </span>
+                </button>
+              ))
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      {docs.length === 0 && (
+        <span className="text-xs text-muted-foreground">
+          Bind documents to query them by table name, or reference drive paths directly
+          (server engine).
+        </span>
+      )}
+    </div>
+  )
+}
+
+function DocChip({
+  doc,
+  onRemove,
+  onRename,
+}: {
+  doc: BoundDoc
+  onRemove: (path: string) => void
+  onRename: (path: string, table: string) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [draft, setDraft] = useState(doc.table)
+
+  const filename = doc.path.split("/").pop() ?? doc.path
+
+  const commit = () => {
+    setEditing(false)
+    const sanitized = sanitizeTableName(draft)
+    if (sanitized && sanitized !== doc.table) onRename(doc.path, sanitized)
+  }
+
+  return (
+    <span className="inline-flex h-6 items-center gap-1.5 rounded-lg border border-border bg-muted/40 pl-2 pr-1 text-xs">
+      {editing ? (
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commit()
+            if (e.key === "Escape") {
+              setDraft(doc.table)
+              setEditing(false)
+            }
+          }}
+          autoFocus
+          aria-label="Table name"
+          className="h-4 border-b border-ring bg-transparent font-mono text-xs font-medium outline-none"
+          style={{ width: `${Math.max(draft.length, 3) + 1}ch` }}
+        />
+      ) : (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => {
+                  setDraft(doc.table)
+                  setEditing(true)
+                }}
+                className="rounded-sm font-mono text-xs font-medium outline-none hover:text-primary focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                {doc.table}
+              </button>
+            }
+          />
+          <TooltipContent>/{doc.path} — click to rename</TooltipContent>
+        </Tooltip>
+      )}
+      {filename !== `${doc.table}.${doc.path.split(".").pop()}` && (
+        <span className="max-w-40 truncate text-muted-foreground/70">{filename}</span>
+      )}
+      <button
+        type="button"
+        onClick={() => onRemove(doc.path)}
+        aria-label={`Remove ${doc.table}`}
+        className="rounded-sm p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      >
+        <X className="size-3" />
+      </button>
+    </span>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—"
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/live/src/components/sql/DocumentPicker.tsx
+++ b/live/src/components/sql/DocumentPicker.tsx
@@ -12,8 +12,13 @@ import { QUERYABLE_EXTENSIONS, sanitizeTableName, type BoundDoc } from "@/lib/sq
 import type { GlobMatch, GlobResult } from "@/api/types"
 
 /** The glob op treats `{}` as literal characters (no brace expansion), so run
- *  one glob per queryable extension in parallel and merge the matches. */
-const QUERYABLE_GLOBS = Object.keys(QUERYABLE_EXTENSIONS).map((ext) => `**/*.${ext}`)
+ *  one glob per queryable extension in parallel and merge the matches. Gzipped
+ *  text formats (`.csv.gz`, …) get their own globs since the op handles them. */
+const GZIP_EXTENSIONS = ["csv", "tsv", "json", "jsonl", "ndjson"]
+const QUERYABLE_GLOBS = [
+  ...Object.keys(QUERYABLE_EXTENSIONS).map((ext) => `**/*.${ext}`),
+  ...GZIP_EXTENSIONS.map((ext) => `**/*.${ext}.gz`),
+]
 
 function useQueryableDocs() {
   const { client, orgId, driveId } = useAuth()

--- a/live/src/components/sql/DocumentPicker.tsx
+++ b/live/src/components/sql/DocumentPicker.tsx
@@ -40,7 +40,7 @@ function useQueryableDocs() {
 
 interface DocumentPickerProps {
   docs: BoundDoc[]
-  onAdd: (path: string) => void
+  onAdd: (path: string, size?: number) => void
   onRemove: (path: string) => void
   onRename: (path: string, table: string) => void
 }
@@ -106,7 +106,7 @@ export function DocumentPicker({ docs, onAdd, onRemove, onRename }: DocumentPick
                   key={match.path}
                   type="button"
                   onClick={() => {
-                    onAdd(match.path)
+                    onAdd(match.path, match.size)
                     setOpen(false)
                     setFilter("")
                   }}
@@ -198,6 +198,11 @@ function DocChip({
       )}
       {filename !== `${doc.table}.${doc.path.split(".").pop()}` && (
         <span className="max-w-40 truncate text-muted-foreground/70">{filename}</span>
+      )}
+      {doc.size != null && (
+        <span className="text-[10px] text-muted-foreground/60 tabular-nums">
+          {formatBytes(doc.size)}
+        </span>
       )}
       <button
         type="button"

--- a/live/src/components/sql/ResultsChart.tsx
+++ b/live/src/components/sql/ResultsChart.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import type { SqlColumn } from "@/api/types"
+
+/**
+ * Hand-rolled SVG bar/line chart for query results — no charting dependency.
+ * Theme-aware via CSS variables (--primary, --border, --muted-foreground).
+ */
+
+const MAX_BAR_POINTS = 200
+const MAX_LINE_POINTS = 2000
+
+const PAD = { top: 12, right: 16, bottom: 26, left: 56 }
+
+/** Columns whose sampled values are all numbers (NULLs ignored). */
+export function getNumericColumns(
+  columns: SqlColumn[],
+  rows: Record<string, unknown>[],
+): string[] {
+  const sample = rows.slice(0, 50)
+  return columns
+    .filter((col) => {
+      let seen = false
+      for (const row of sample) {
+        const v = row[col.name]
+        if (v === null || v === undefined) continue
+        if (typeof v !== "number" || !Number.isFinite(v)) return false
+        seen = true
+      }
+      return seen
+    })
+    .map((col) => col.name)
+}
+
+/** First text/date column to use as the X axis (null -> row index). */
+export function getXColumn(
+  columns: SqlColumn[],
+  rows: Record<string, unknown>[],
+): string | null {
+  const numeric = new Set(getNumericColumns(columns, rows))
+  const sample = rows.slice(0, 50)
+  for (const col of columns) {
+    if (numeric.has(col.name)) continue
+    const ok = sample.some((row) => {
+      const v = row[col.name]
+      return typeof v === "string" || typeof v === "number"
+    })
+    if (ok) return col.name
+  }
+  return null
+}
+
+function useElementSize<T extends HTMLElement>() {
+  const ref = useRef<T | null>(null)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (entry) setSize({ width: entry.contentRect.width, height: entry.contentRect.height })
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, size }
+}
+
+/** ~`count` round-numbered ticks spanning [min, max]. */
+function niceTicks(min: number, max: number, count: number): number[] {
+  if (min === max) max = min === 0 ? 1 : min + Math.abs(min)
+  const span = max - min
+  const rawStep = span / count
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rawStep)))
+  const normalized = rawStep / magnitude
+  const step =
+    (normalized < 1.5 ? 1 : normalized < 3 ? 2 : normalized < 7 ? 5 : 10) * magnitude
+  const ticks: number[] = []
+  for (let t = Math.ceil(min / step) * step; t <= max + step / 1e6; t += step) {
+    ticks.push(Math.abs(t) < step / 1e6 ? 0 : t)
+  }
+  return ticks
+}
+
+const compactFmt = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+})
+
+function formatTick(v: number): string {
+  if (Math.abs(v) >= 1000) return compactFmt.format(v)
+  return Number.isInteger(v) ? String(v) : v.toFixed(Math.abs(v) < 1 ? 2 : 1)
+}
+
+interface ResultsChartProps {
+  columns: SqlColumn[]
+  rows: Record<string, unknown>[]
+  kind: "bar" | "line"
+  yColumn: string
+}
+
+export function ResultsChart({ columns, rows, kind, yColumn }: ResultsChartProps) {
+  const { ref, size } = useElementSize<HTMLDivElement>()
+
+  const cap = kind === "bar" ? MAX_BAR_POINTS : MAX_LINE_POINTS
+  const xColumn = useMemo(() => getXColumn(columns, rows), [columns, rows])
+
+  const points = useMemo(() => {
+    return rows.slice(0, cap).map((row, i) => {
+      const rawY = row[yColumn]
+      const y = typeof rawY === "number" && Number.isFinite(rawY) ? rawY : null
+      const rawX = xColumn ? row[xColumn] : i + 1
+      const label = rawX === null || rawX === undefined ? `#${i + 1}` : String(rawX)
+      return { label, y }
+    })
+  }, [rows, cap, xColumn, yColumn])
+
+  const yValues = points.flatMap((p) => (p.y === null ? [] : [p.y]))
+
+  if (yValues.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-8 text-sm text-muted-foreground">
+        No numeric values in “{yColumn}” to plot.
+      </div>
+    )
+  }
+
+  const dataMin = Math.min(...yValues)
+  const dataMax = Math.max(...yValues)
+  // Bars are anchored at zero; lines track the data range.
+  const yMin = kind === "bar" ? Math.min(0, dataMin) : dataMin
+  const yMax = kind === "bar" ? Math.max(0, dataMax) : dataMax
+
+  const { width, height } = size
+  const innerW = Math.max(0, width - PAD.left - PAD.right)
+  const innerH = Math.max(0, height - PAD.top - PAD.bottom)
+  const span = yMax - yMin || 1
+
+  const yScale = (v: number) => PAD.top + innerH - ((v - yMin) / span) * innerH
+  const xScale = (i: number) =>
+    PAD.left + (points.length === 1 ? innerW / 2 : (i / (points.length - 1)) * innerW)
+
+  const ticks = niceTicks(yMin, yMax, 4).filter((t) => t >= yMin && t <= yMax)
+
+  // At most ~8 x labels, evenly spaced.
+  const labelStep = Math.max(1, Math.ceil(points.length / 8))
+  const xLabels = points
+    .map((p, i) => ({ label: p.label, i }))
+    .filter(({ i }) => i % labelStep === 0)
+
+  const barWidth = points.length > 0 ? (innerW / points.length) * 0.8 : 0
+  const barX = (i: number) => PAD.left + (i + 0.1) * (innerW / points.length)
+
+  const linePath = points
+    .map((p, i) => (p.y === null ? null : `${xScale(i)},${yScale(p.y)}`))
+    .filter((s): s is string => s !== null)
+    .map((coords, i) => `${i === 0 ? "M" : "L"}${coords}`)
+    .join(" ")
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {rows.length > cap && (
+        <p className="shrink-0 px-3 pt-2 text-[11px] text-muted-foreground">
+          Chart shows the first {cap.toLocaleString()} of {rows.length.toLocaleString()} rows.
+        </p>
+      )}
+      <div ref={ref} className="min-h-0 flex-1 p-2">
+        {width > 0 && height > 0 && (
+          <svg width={width} height={height} role="img" aria-label={`${kind} chart of ${yColumn}`}>
+            {/* Horizontal grid + y tick labels */}
+            {ticks.map((t) => (
+              <g key={t}>
+                <line
+                  x1={PAD.left}
+                  x2={width - PAD.right}
+                  y1={yScale(t)}
+                  y2={yScale(t)}
+                  stroke="var(--border)"
+                  strokeWidth={1}
+                  strokeDasharray={t === 0 ? undefined : "3 3"}
+                />
+                <text
+                  x={PAD.left - 8}
+                  y={yScale(t)}
+                  textAnchor="end"
+                  dominantBaseline="middle"
+                  fontSize={10}
+                  fill="var(--muted-foreground)"
+                >
+                  {formatTick(t)}
+                </text>
+              </g>
+            ))}
+
+            {/* X tick labels */}
+            {xLabels.map(({ label, i }) => (
+              <text
+                key={i}
+                x={kind === "bar" ? barX(i) + barWidth / 2 : xScale(i)}
+                y={height - PAD.bottom + 14}
+                textAnchor="middle"
+                fontSize={10}
+                fill="var(--muted-foreground)"
+              >
+                {label.length > 12 ? `${label.slice(0, 11)}…` : label}
+              </text>
+            ))}
+
+            {kind === "bar" ? (
+              points.map((p, i) => {
+                if (p.y === null) return null
+                const zero = yScale(Math.max(yMin, Math.min(yMax, 0)))
+                const top = yScale(p.y)
+                return (
+                  <rect
+                    key={i}
+                    x={barX(i)}
+                    y={Math.min(top, zero)}
+                    width={Math.max(1, barWidth)}
+                    height={Math.max(1, Math.abs(zero - top))}
+                    rx={1}
+                    fill="var(--primary)"
+                    fillOpacity={0.85}
+                  >
+                    <title>{`${p.label}: ${p.y.toLocaleString()}`}</title>
+                  </rect>
+                )
+              })
+            ) : (
+              <>
+                <path d={linePath} fill="none" stroke="var(--primary)" strokeWidth={1.5} />
+                {points.length <= 60 &&
+                  points.map((p, i) =>
+                    p.y === null ? null : (
+                      <circle key={i} cx={xScale(i)} cy={yScale(p.y)} r={2.5} fill="var(--primary)">
+                        <title>{`${p.label}: ${p.y.toLocaleString()}`}</title>
+                      </circle>
+                    ),
+                  )}
+              </>
+            )}
+          </svg>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/live/src/components/sql/ResultsPanel.tsx
+++ b/live/src/components/sql/ResultsPanel.tsx
@@ -1,0 +1,294 @@
+import { useMemo, useState } from "react"
+import { ChartColumn, ChartLine, ChevronDown, Copy, Download, Table2, TriangleAlert } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Kbd } from "@/components/ui/kbd"
+import { Spinner } from "@/components/ui/spinner"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { downloadBlob } from "@/lib/download"
+import { cn } from "@/lib/utils"
+import { toast } from "@/stores/toast"
+import { ResultsChart, getNumericColumns } from "./ResultsChart"
+import type { SqlRunResult } from "@/lib/sql-engine/types"
+
+export interface SqlRunError {
+  message: string
+  suggestion?: string
+}
+
+type ViewMode = "table" | "bar" | "line"
+
+interface ResultsPanelProps {
+  result: SqlRunResult | null
+  error: SqlRunError | null
+  running: boolean
+  className?: string
+}
+
+export function ResultsPanel({ result, error, running, className }: ResultsPanelProps) {
+  const [viewMode, setViewMode] = useState<ViewMode>("table")
+  const [yColumn, setYColumn] = useState<string | null>(null)
+
+  const numericColumns = useMemo(
+    () => (result ? getNumericColumns(result.columns, result.rows) : []),
+    [result],
+  )
+  // Selected Y column, falling back to the first numeric column when the
+  // previous selection no longer exists in the result.
+  const effectiveY =
+    yColumn && numericColumns.includes(yColumn) ? yColumn : (numericColumns[0] ?? null)
+
+  const hasRows = !!result && result.rows.length > 0
+
+  const copyJson = async () => {
+    if (!result) return
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(result.rows, null, 2))
+      toast.success("Results copied as JSON")
+    } catch {
+      toast.error("Copy failed")
+    }
+  }
+
+  const downloadCsv = () => {
+    if (!result) return
+    const csv = toCsv(result)
+    downloadBlob(new Blob([csv], { type: "text/csv;charset=utf-8" }), "query-results.csv")
+  }
+
+  return (
+    <div className={cn("flex min-w-0 flex-col", className)}>
+      {/* Toolbar */}
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border px-2">
+        <ToggleGroup
+          value={[viewMode]}
+          onValueChange={(value) => {
+            const next = value[0] as ViewMode | undefined
+            if (next) setViewMode(next)
+          }}
+        >
+          <ToggleGroupItem value="table" aria-label="Table view">
+            <Table2 />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="bar" aria-label="Bar chart">
+            <ChartColumn />
+          </ToggleGroupItem>
+          <ToggleGroupItem value="line" aria-label="Line chart">
+            <ChartLine />
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {viewMode !== "table" && hasRows && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="xs"
+                  className="gap-1 font-mono text-muted-foreground"
+                  disabled={numericColumns.length === 0}
+                >
+                  Y: {effectiveY ?? "—"}
+                  <ChevronDown />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="start" className="w-44">
+              <DropdownMenuRadioGroup
+                value={effectiveY ?? undefined}
+                onValueChange={(value) => setYColumn(String(value))}
+              >
+                {numericColumns.map((name) => (
+                  <DropdownMenuRadioItem key={name} value={name} className="font-mono text-xs">
+                    {name}
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+
+        <div className="ml-auto flex items-center gap-1">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={copyJson}
+                  disabled={!hasRows}
+                  className="text-muted-foreground"
+                  aria-label="Copy results as JSON"
+                >
+                  <Copy />
+                </Button>
+              }
+            />
+            <TooltipContent>Copy results as JSON</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={downloadCsv}
+                  disabled={!hasRows}
+                  className="text-muted-foreground"
+                  aria-label="Download results as CSV"
+                >
+                  <Download />
+                </Button>
+              }
+            />
+            <TooltipContent>Download as CSV</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* Body */}
+      {running ? (
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner />
+        </div>
+      ) : error ? (
+        <div className="flex-1 overflow-auto p-4">
+          <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3">
+            <div className="flex items-start gap-2">
+              <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <div className="min-w-0">
+                <p className="text-sm font-medium text-destructive">Query failed</p>
+                <p className="mt-1 font-mono text-xs whitespace-pre-wrap break-words text-destructive/90">
+                  {error.message}
+                </p>
+                {error.suggestion && (
+                  <p className="mt-2 text-xs text-muted-foreground">{error.suggestion}</p>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : !result ? (
+        <div className="flex flex-1 flex-col items-center justify-center gap-1.5 p-8 text-center">
+          <Table2 className="size-6 text-muted-foreground/50" />
+          <p className="text-sm text-muted-foreground">Run a query to see results</p>
+          <p className="text-xs text-muted-foreground/70">
+            Press <Kbd>⌘⏎</Kbd> in the editor or hit Run
+          </p>
+        </div>
+      ) : result.rows.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="text-sm text-muted-foreground">Query returned no rows.</p>
+        </div>
+      ) : viewMode === "table" ? (
+        <ResultsTable result={result} />
+      ) : effectiveY ? (
+        <ResultsChart
+          columns={result.columns}
+          rows={result.rows}
+          kind={viewMode}
+          yColumn={effectiveY}
+        />
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="text-sm text-muted-foreground">No numeric columns to chart.</p>
+        </div>
+      )}
+
+      {/* Footer */}
+      {result && !running && !error && (
+        <div className="flex h-7 shrink-0 items-center gap-2 border-t border-border px-3 text-[11px] text-muted-foreground">
+          <span className="tabular-nums">
+            {result.rowCount.toLocaleString()} row{result.rowCount === 1 ? "" : "s"} in{" "}
+            {result.elapsedMs.toLocaleString()}ms
+          </span>
+          {result.truncated && <span>· truncated</span>}
+          <Badge variant="outline" className="ml-auto h-4 px-1.5 font-mono text-[10px]">
+            {result.engine}
+          </Badge>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ResultsTable({ result }: { result: SqlRunResult }) {
+  return (
+    <div className="min-h-0 flex-1 overflow-auto">
+      <table className="w-full border-collapse text-xs">
+        <thead className="sticky top-0 z-10 bg-background">
+          <tr>
+            <th className="w-10 border-b border-border px-2 py-1.5 text-right font-normal text-muted-foreground/60">
+              #
+            </th>
+            {result.columns.map((col) => (
+              <th
+                key={col.name}
+                className="border-b border-border px-2 py-1.5 text-left font-medium whitespace-nowrap"
+              >
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<span className="cursor-default">{col.name}</span>}
+                  />
+                  <TooltipContent className="font-mono">{col.type}</TooltipContent>
+                </Tooltip>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="font-mono">
+          {result.rows.map((row, i) => (
+            <tr key={i} className="hover:bg-muted/50">
+              <td className="border-b border-border/50 px-2 py-1 text-right text-muted-foreground/50 tabular-nums">
+                {i + 1}
+              </td>
+              {result.columns.map((col) => (
+                <ResultCell key={col.name} value={row[col.name]} />
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ResultCell({ value }: { value: unknown }) {
+  if (value === null || value === undefined) {
+    return (
+      <td className="border-b border-border/50 px-2 py-1 whitespace-nowrap italic text-muted-foreground/50">
+        NULL
+      </td>
+    )
+  }
+  const text = typeof value === "object" ? JSON.stringify(value) : String(value)
+  return (
+    <td
+      className="max-w-md truncate border-b border-border/50 px-2 py-1 whitespace-nowrap tabular-nums"
+      title={text.length > 60 ? text : undefined}
+    >
+      {text}
+    </td>
+  )
+}
+
+function toCsv(result: SqlRunResult): string {
+  const escape = (value: unknown): string => {
+    if (value === null || value === undefined) return ""
+    const text = typeof value === "object" ? JSON.stringify(value) : String(value)
+    return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+  }
+  const header = result.columns.map((c) => escape(c.name)).join(",")
+  const lines = result.rows.map((row) =>
+    result.columns.map((c) => escape(row[c.name])).join(","),
+  )
+  return [header, ...lines].join("\n")
+}

--- a/live/src/components/sql/ResultsPanel.tsx
+++ b/live/src/components/sql/ResultsPanel.tsx
@@ -16,6 +16,7 @@ import {
 import { downloadBlob } from "@/lib/download"
 import { cn } from "@/lib/utils"
 import { toast } from "@/stores/toast"
+import { DataGrid } from "@/components/data-grid/DataGrid"
 import { ResultsChart, getNumericColumns } from "./ResultsChart"
 import type { SqlRunResult } from "@/lib/sql-engine/types"
 
@@ -189,7 +190,7 @@ export function ResultsPanel({ result, error, running, className }: ResultsPanel
           <p className="text-sm text-muted-foreground">Query returned no rows.</p>
         </div>
       ) : viewMode === "table" ? (
-        <ResultsTable result={result} />
+        <DataGrid columns={result.columns} rows={result.rows} />
       ) : effectiveY ? (
         <ResultsChart
           columns={result.columns}
@@ -217,66 +218,6 @@ export function ResultsPanel({ result, error, running, className }: ResultsPanel
         </div>
       )}
     </div>
-  )
-}
-
-function ResultsTable({ result }: { result: SqlRunResult }) {
-  return (
-    <div className="min-h-0 flex-1 overflow-auto">
-      <table className="w-full border-collapse text-xs">
-        <thead className="sticky top-0 z-10 bg-background">
-          <tr>
-            <th className="w-10 border-b border-border px-2 py-1.5 text-right font-normal text-muted-foreground/60">
-              #
-            </th>
-            {result.columns.map((col) => (
-              <th
-                key={col.name}
-                className="border-b border-border px-2 py-1.5 text-left font-medium whitespace-nowrap"
-              >
-                <Tooltip>
-                  <TooltipTrigger
-                    render={<span className="cursor-default">{col.name}</span>}
-                  />
-                  <TooltipContent className="font-mono">{col.type}</TooltipContent>
-                </Tooltip>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="font-mono">
-          {result.rows.map((row, i) => (
-            <tr key={i} className="hover:bg-muted/50">
-              <td className="border-b border-border/50 px-2 py-1 text-right text-muted-foreground/50 tabular-nums">
-                {i + 1}
-              </td>
-              {result.columns.map((col) => (
-                <ResultCell key={col.name} value={row[col.name]} />
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
-function ResultCell({ value }: { value: unknown }) {
-  if (value === null || value === undefined) {
-    return (
-      <td className="border-b border-border/50 px-2 py-1 whitespace-nowrap italic text-muted-foreground/50">
-        NULL
-      </td>
-    )
-  }
-  const text = typeof value === "object" ? JSON.stringify(value) : String(value)
-  return (
-    <td
-      className="max-w-md truncate border-b border-border/50 px-2 py-1 whitespace-nowrap tabular-nums"
-      title={text.length > 60 ? text : undefined}
-    >
-      {text}
-    </td>
   )
 }
 

--- a/live/src/components/sql/SqlEditor.tsx
+++ b/live/src/components/sql/SqlEditor.tsx
@@ -1,17 +1,27 @@
 import { useEffect, useRef } from "react"
-import Editor, { type OnMount } from "@monaco-editor/react"
+import Editor, { useMonaco, type OnMount } from "@monaco-editor/react"
 import { Spinner } from "@/components/ui/spinner"
 import { useTheme } from "@/hooks/use-theme"
+
+/** A schema/table/column name offered as an editor autocomplete suggestion. */
+export interface SqlCompletion {
+  label: string
+  detail?: string
+  kind?: "table" | "schema" | "column"
+}
 
 interface SqlEditorProps {
   value: string
   onChange: (value: string) => void
   /** Invoked on Cmd/Ctrl+Enter inside the editor. */
   onRun: () => void
+  /** Bound table / database names suggested as you type. */
+  completions?: SqlCompletion[]
 }
 
-export function SqlEditor({ value, onChange, onRun }: SqlEditorProps) {
+export function SqlEditor({ value, onChange, onRun, completions = [] }: SqlEditorProps) {
   const { resolvedTheme } = useTheme()
+  const monaco = useMonaco()
 
   // Monaco commands capture their closure at mount; route through a ref so
   // Cmd/Ctrl+Enter always runs with the latest query/docs/limit.
@@ -20,9 +30,54 @@ export function SqlEditor({ value, onChange, onRun }: SqlEditorProps) {
     onRunRef.current = onRun
   }, [onRun])
 
+  // Latest completions, read live by the provider registered once below.
+  const completionsRef = useRef(completions)
+  useEffect(() => {
+    completionsRef.current = completions
+  }, [completions])
+
+  // Register a SQL completion provider for bound tables/databases. Monaco's
+  // built-in SQL keyword completion still applies alongside these.
+  useEffect(() => {
+    if (!monaco) return
+    const provider = monaco.languages.registerCompletionItemProvider("sql", {
+      triggerCharacters: [" ", ".", "\n", "("],
+      provideCompletionItems: (model, position) => {
+        const word = model.getWordUntilPosition(position)
+        const range = {
+          startLineNumber: position.lineNumber,
+          endLineNumber: position.lineNumber,
+          startColumn: word.startColumn,
+          endColumn: word.endColumn,
+        }
+        const kindFor = (k?: SqlCompletion["kind"]) =>
+          k === "schema"
+            ? monaco.languages.CompletionItemKind.Module
+            : k === "column"
+              ? monaco.languages.CompletionItemKind.Field
+              : monaco.languages.CompletionItemKind.Struct
+        return {
+          suggestions: completionsRef.current.map((c) => ({
+            label: c.label,
+            kind: kindFor(c.kind),
+            insertText: c.label,
+            detail: c.detail,
+            range,
+          })),
+        }
+      },
+    })
+    return () => provider.dispose()
+  }, [monaco])
+
   const handleMount: OnMount = (editor, monaco) => {
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
-      onRunRef.current()
+    // addAction registers a reliable keybinding (addCommand's binding can be
+    // shadowed by Monaco defaults). Cmd/Ctrl+Enter runs the query.
+    editor.addAction({
+      id: "agent-fs.run-query",
+      label: "Run query",
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter],
+      run: () => onRunRef.current(),
     })
   }
 

--- a/live/src/components/sql/SqlEditor.tsx
+++ b/live/src/components/sql/SqlEditor.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from "react"
+import Editor, { type OnMount } from "@monaco-editor/react"
+import { Spinner } from "@/components/ui/spinner"
+import { useTheme } from "@/hooks/use-theme"
+
+interface SqlEditorProps {
+  value: string
+  onChange: (value: string) => void
+  /** Invoked on Cmd/Ctrl+Enter inside the editor. */
+  onRun: () => void
+}
+
+export function SqlEditor({ value, onChange, onRun }: SqlEditorProps) {
+  const { resolvedTheme } = useTheme()
+
+  // Monaco commands capture their closure at mount; route through a ref so
+  // Cmd/Ctrl+Enter always runs with the latest query/docs/limit.
+  const onRunRef = useRef(onRun)
+  useEffect(() => {
+    onRunRef.current = onRun
+  }, [onRun])
+
+  const handleMount: OnMount = (editor, monaco) => {
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+      onRunRef.current()
+    })
+  }
+
+  return (
+    <Editor
+      language="sql"
+      value={value}
+      onChange={(v) => onChange(v ?? "")}
+      theme={resolvedTheme === "dark" ? "vs-dark" : "vs"}
+      onMount={handleMount}
+      loading={
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
+        </div>
+      }
+      options={{
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        fontSize: 13,
+        lineHeight: 20,
+        fontFamily: "'JetBrains Mono', ui-monospace, monospace",
+        fontLigatures: true,
+        lineNumbers: "on",
+        renderLineHighlight: "none",
+        overviewRulerBorder: false,
+        hideCursorInOverviewRuler: true,
+        scrollbar: {
+          verticalScrollbarSize: 8,
+          horizontalScrollbarSize: 8,
+        },
+        padding: { top: 8 },
+        wordWrap: "on",
+        automaticLayout: true,
+        tabSize: 2,
+      }}
+    />
+  )
+}

--- a/live/src/components/viewers/DatabasePreviewViewer.tsx
+++ b/live/src/components/viewers/DatabasePreviewViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { TriangleAlert, Database } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { Badge } from "@/components/ui/badge"
@@ -47,9 +47,15 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
     client && orgId && driveId ? { client, orgId, driveId } : null
   const docPath = path.replace(/^\/+/, "")
 
+  // Monotonic request token: every load captures the current value and only
+  // applies its result if it's still the latest, so a slow response for an old
+  // file/table can't overwrite a newer one.
+  const reqRef = useRef(0)
+
   const loadTable = useCallback(
     async (tables: string[], table: string) => {
       if (!ctx || !format) return
+      const reqId = ++reqRef.current
       setState({ status: "loading" })
       try {
         const result = await runSql(
@@ -60,8 +66,10 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
           },
           ctx,
         )
+        if (reqRef.current !== reqId) return
         setState({ status: "ready", tables, selected: table, result })
       } catch (err) {
+        if (reqRef.current !== reqId) return
         const e = err as { message?: string; suggestion?: string }
         setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
       }
@@ -71,6 +79,7 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
 
   const start = useCallback(async () => {
     if (!ctx || !format) return
+    const reqId = ++reqRef.current
     setState({ status: "loading" })
     try {
       const introspect = await runSql(
@@ -81,6 +90,7 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
         },
         ctx,
       )
+      if (reqRef.current !== reqId) return
       const tables = introspect.rows.map((r) => String(r.table_name))
       if (tables.length === 0) {
         setState({ status: "empty" })
@@ -88,6 +98,7 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
       }
       await loadTable(tables, tables[0])
     } catch (err) {
+      if (reqRef.current !== reqId) return
       const e = err as { message?: string; suggestion?: string }
       setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
     }
@@ -97,6 +108,10 @@ export function DatabasePreviewViewer({ path, size, className }: DatabasePreview
     if (!format || !ctx) return
     if (autoPreview) void start()
     else setState({ status: "idle" })
+    // Invalidate any in-flight request when the file/scope changes.
+    return () => {
+      reqRef.current++
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [path, format, autoPreview, orgId, driveId])
 

--- a/live/src/components/viewers/DatabasePreviewViewer.tsx
+++ b/live/src/components/viewers/DatabasePreviewViewer.tsx
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useState } from "react"
+import { TriangleAlert, Database } from "lucide-react"
+import { useAuth } from "@/contexts/auth"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Spinner } from "@/components/ui/spinner"
+import { DataGrid } from "@/components/data-grid/DataGrid"
+import { runSql } from "@/lib/sql-engine"
+import { deriveTableName, formatForPath } from "@/lib/sql-engine/types"
+import type { SqlEngineContext, SqlRunResult } from "@/lib/sql-engine/types"
+import { cn } from "@/lib/utils"
+
+const PREVIEW_ROWS = 500
+const AUTO_PREVIEW_MAX_BYTES = 25 * 1024 * 1024
+
+interface DatabasePreviewViewerProps {
+  /** Drive path (leading slash optional) of a sqlite/duckdb database. */
+  path: string
+  size?: number
+  className?: string
+}
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; tables: string[]; selected: string; result: SqlRunResult }
+  | { status: "empty" }
+  | { status: "error"; message: string; suggestion?: string }
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`
+}
+
+/**
+ * Preview for sqlite/duckdb database files: lists the tables and renders the
+ * selected one in the shared DataGrid. Queries run on the server engine (the
+ * sqlite/duckdb readers aren't available in DuckDB-WASM).
+ */
+export function DatabasePreviewViewer({ path, size, className }: DatabasePreviewViewerProps) {
+  const { client, orgId, driveId } = useAuth()
+  const format = formatForPath(path)
+  const schema = deriveTableName(path, [])
+  const autoPreview = size == null || size <= AUTO_PREVIEW_MAX_BYTES
+  const [state, setState] = useState<State>({ status: "idle" })
+
+  const ctx: SqlEngineContext | null =
+    client && orgId && driveId ? { client, orgId, driveId } : null
+  const docPath = path.replace(/^\/+/, "")
+
+  const loadTable = useCallback(
+    async (tables: string[], table: string) => {
+      if (!ctx || !format) return
+      setState({ status: "loading" })
+      try {
+        const result = await runSql(
+          {
+            query: `SELECT * FROM ${quoteIdent(schema)}.${quoteIdent(table)} LIMIT ${PREVIEW_ROWS}`,
+            docs: [{ path: docPath, table: schema, format }],
+            maxRows: PREVIEW_ROWS,
+          },
+          ctx,
+        )
+        setState({ status: "ready", tables, selected: table, result })
+      } catch (err) {
+        const e = err as { message?: string; suggestion?: string }
+        setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
+      }
+    },
+    [ctx, format, schema, docPath],
+  )
+
+  const start = useCallback(async () => {
+    if (!ctx || !format) return
+    setState({ status: "loading" })
+    try {
+      const introspect = await runSql(
+        {
+          query: `SELECT table_name FROM duckdb_tables() WHERE schema_name = '${schema}' ORDER BY table_name`,
+          docs: [{ path: docPath, table: schema, format }],
+          maxRows: 1000,
+        },
+        ctx,
+      )
+      const tables = introspect.rows.map((r) => String(r.table_name))
+      if (tables.length === 0) {
+        setState({ status: "empty" })
+        return
+      }
+      await loadTable(tables, tables[0])
+    } catch (err) {
+      const e = err as { message?: string; suggestion?: string }
+      setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
+    }
+  }, [ctx, format, schema, docPath, loadTable])
+
+  useEffect(() => {
+    if (!format || !ctx) return
+    if (autoPreview) void start()
+    else setState({ status: "idle" })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path, format, autoPreview, orgId, driveId])
+
+  if (!format) return null
+
+  if (state.status === "loading") {
+    return (
+      <div className={cn("flex flex-1 items-center justify-center", className)}>
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className={cn("flex-1 overflow-auto p-4", className)}>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3">
+          <div className="flex items-start gap-2">
+            <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-destructive">Couldn't preview this database</p>
+              <p className="mt-1 font-mono text-xs break-words whitespace-pre-wrap text-destructive/90">
+                {state.message}
+              </p>
+              {state.suggestion && (
+                <p className="mt-2 text-xs text-muted-foreground">{state.suggestion}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.status === "empty") {
+    return (
+      <div className={cn("flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center", className)}>
+        <Database className="size-6 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">This database has no tables.</p>
+      </div>
+    )
+  }
+
+  if (state.status === "idle") {
+    return (
+      <div className={cn("flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center", className)}>
+        <Database className="size-6 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">
+          Large database{size ? ` (${formatBytes(size)})` : ""} — preview not loaded automatically.
+        </p>
+        <Button variant="secondary" size="sm" onClick={() => void start()}>
+          Preview tables
+        </Button>
+      </div>
+    )
+  }
+
+  const { tables, selected, result } = state
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
+      {/* Table switcher */}
+      <div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-2 py-1.5">
+        <span className="shrink-0 pr-1 text-[11px] text-muted-foreground">Tables:</span>
+        {tables.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => void loadTable(tables, t)}
+            className={cn(
+              "shrink-0 rounded-md px-2 py-0.5 font-mono text-xs transition-colors",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              t === selected
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {t}
+          </button>
+        ))}
+      </div>
+
+      {result.rows.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-mono">{selected}</span> is empty.
+          </p>
+        </div>
+      ) : (
+        <DataGrid columns={result.columns} rows={result.rows} />
+      )}
+
+      <div className="flex h-7 shrink-0 items-center gap-2 border-t border-border px-3 text-[11px] text-muted-foreground">
+        <span className="tabular-nums">
+          {result.rowCount.toLocaleString()} row{result.rowCount === 1 ? "" : "s"}
+        </span>
+        {result.truncated && <span>· first {PREVIEW_ROWS}</span>}
+        <span>· {tables.length} table{tables.length === 1 ? "" : "s"}</span>
+        {size != null && <span className="tabular-nums">· {formatBytes(size)}</span>}
+        <Badge variant="outline" className="ml-auto h-4 px-1.5 font-mono text-[10px]">
+          {result.engine}
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type MutableRefObject } from "react"
-import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download } from "lucide-react"
+import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database } from "lucide-react"
 import { useNavigate } from "react-router"
+import { isQueryablePath } from "@/lib/sql-engine/types"
 import { useAuth } from "@/contexts/auth"
 import { useKeyboardShortcuts, type ShortcutMap } from "@/hooks/use-keyboard-shortcuts"
 import { useFileActions } from "@/hooks/use-file-actions"
@@ -18,6 +19,8 @@ import { ImageViewer } from "./ImageViewer"
 import { VideoViewer } from "./VideoViewer"
 import { PdfViewer } from "./PdfViewer"
 import { FallbackViewer } from "./FallbackViewer"
+import { TablePreviewViewer } from "./TablePreviewViewer"
+import { DatabasePreviewViewer } from "./DatabasePreviewViewer"
 import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 import {
@@ -42,10 +45,34 @@ const BINARY_EXTS = new Set([
   "zip", "gz", "tar", "tgz", "bz2", "xz", "7z", "rar",
   "woff", "woff2", "ttf", "otf", "eot",
   "wasm", "bin", "exe", "dll", "so", "dylib", "o", "a",
+  // Office / binary documents — must never render as text (they're octet-stream
+  // and would otherwise dump raw zip/OLE bytes into the text viewer).
+  "doc", "docx", "ppt", "pptx", "xls", "odt", "ods", "odp",
 ])
+
+// Tabular formats previewed as a data grid by default. Binary ones (parquet,
+// xlsx) had no preview before; text ones (csv, tsv) get a Table/Source toggle.
+// Multi-table formats (sqlite, duckdb) are intentionally excluded — there's no
+// single obvious table to show — so they keep the Query-with-SQL entry point.
+const TABULAR_BINARY_EXTS = new Set(["parquet", "xlsx"])
+const TABULAR_TEXT_EXTS = new Set(["csv", "tsv", "ndjson", "jsonl"])
+// Multi-table database files — previewed via the table-switching DB viewer.
+const DATABASE_EXTS = new Set(["db", "sqlite", "sqlite3", "duckdb"])
 
 function getExt(path: string): string {
   return path.split(".").pop()?.toLowerCase() ?? ""
+}
+
+function isTabularBinary(path: string): boolean {
+  return TABULAR_BINARY_EXTS.has(getExt(path))
+}
+
+function isTabularText(path: string): boolean {
+  return TABULAR_TEXT_EXTS.has(getExt(path))
+}
+
+function isDatabaseFile(path: string): boolean {
+  return DATABASE_EXTS.has(getExt(path))
 }
 
 function isImage(path: string): boolean {
@@ -65,7 +92,7 @@ function isPdf(path: string): boolean {
 }
 
 const TEXT_EXTS = new Set([
-  "txt", "ts", "tsx", "js", "jsx", "json", "md", "mdx", "css", "scss",
+  "txt", "ts", "tsx", "js", "jsx", "json", "jsonl", "ndjson", "md", "mdx", "css", "scss",
   "html", "xml", "yaml", "yml", "toml", "sh", "bash", "py", "rb", "rs",
   "go", "java", "c", "cpp", "h", "hpp", "sql", "graphql", "env", "cfg",
   "ini", "conf", "log", "csv", "tsv", "dockerfile", "makefile", "lock",
@@ -100,8 +127,18 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   const commentCount = commentsData?.comments.length ?? 0
   const [showRaw, setShowRaw] = useState(false)
 
+  const isTabBin = isTabularBinary(path)
+  const isTabTxt = isTabularText(path)
+  const isDb = isDatabaseFile(path)
+
+  // Files rendered by querying their data (parquet, xlsx, sqlite/duckdb, and
+  // csv/tsv/ndjson in grid mode) need no raw-bytes fetch — the grid data comes
+  // from the SQL engine. The raw fetch (presigned URL) is only used for text
+  // and the optional "Source" toggle of tabular-text files.
   const { data: content, isLoading } = useFileContent(
-    isImg || isVid || isPdf(path) ? null : path
+    isImg || isVid || isPdf(path) || isTabBin || isDb || (isTabTxt && !showRaw)
+      ? null
+      : path
   )
 
   // Outline only exists for a rendered markdown preview. When the viewer shows
@@ -136,7 +173,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
       fileActions.download()
     },
   }
-  if (isMd) {
+  if (isMd || isTabTxt) {
     fileShortcuts.e = (e) => {
       e.preventDefault()
       setShowRaw((v) => !v)
@@ -148,13 +185,89 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
       navigate(`/detail/~/${orgId}/${driveId}/${path}`)
     }
   }
+
+  // Tabular/data files (csv, tsv, parquet, xlsx, json, ndjson, sqlite, duckdb)
+  // get a direct entry point into the SQL workbench, pre-bound to this file.
+  const onQuery =
+    isQueryablePath(path) && orgId && driveId
+      ? () => navigate(`/sql/~/${orgId}/${driveId}?path=${encodeURIComponent(path)}`)
+      : undefined
+  if (onQuery) {
+    fileShortcuts.q = (e) => {
+      e.preventDefault()
+      onQuery()
+    }
+  }
   useKeyboardShortcuts(fileShortcuts)
 
   if (isImg) {
     return (
       <div className={cn("flex flex-col h-full min-w-0", className)}>
-        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} />}
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
         <ImageViewer path={path} className="flex-1" />
+      </div>
+    )
+  }
+
+  // Binary tabular files (parquet, xlsx): render a data-grid preview by
+  // querying the file through the SQL engine. No text content to fetch.
+  if (isTabBin) {
+    return (
+      <div className={cn("flex flex-col h-full min-w-0", className)}>
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
+        <TablePreviewViewer path={path} size={stat?.size} className="flex-1 min-h-0" />
+      </div>
+    )
+  }
+
+  // Database files (sqlite, duckdb): list tables and preview the selected one.
+  if (isDb) {
+    return (
+      <div className={cn("flex flex-col h-full min-w-0", className)}>
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
+        <DatabasePreviewViewer path={path} size={stat?.size} className="flex-1 min-h-0" />
+      </div>
+    )
+  }
+
+  // Tabular text files (csv, tsv, ndjson): data-grid preview by default (data
+  // from the SQL engine, so it works even when the raw-bytes fetch can't), with
+  // a Source toggle to the raw text.
+  if (isTabTxt) {
+    return (
+      <div className={cn("flex flex-col h-full min-w-0", className)}>
+        {showHeader && (
+          <ViewerHeader
+            path={path}
+            actions={fileActions}
+            showExpand={showExpandButton}
+            onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)}
+            onQuery={onQuery}
+            showViewToggle
+            showRaw={showRaw}
+            onToggleRaw={() => setShowRaw(!showRaw)}
+          />
+        )}
+        {showRaw ? (
+          isLoading ? (
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner />
+            </div>
+          ) : content ? (
+            <TextViewer
+              content={content.content}
+              path={path}
+              truncated={content.truncated}
+              comments={commentsData?.comments}
+              className="flex-1 min-h-0"
+              onScrollToCommentRef={onScrollToCommentRef}
+            />
+          ) : (
+            <FallbackViewer path={path} className="flex-1" />
+          )
+        ) : (
+          <TablePreviewViewer path={path} size={stat?.size} className="flex-1 min-h-0" />
+        )}
       </div>
     )
   }
@@ -162,7 +275,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   if (isVid) {
     return (
       <div className={cn("flex flex-col h-full min-w-0", className)}>
-        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} />}
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
         <VideoViewer path={path} className="flex-1" />
       </div>
     )
@@ -171,7 +284,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   if (isPdf(path)) {
     return (
       <div className={cn("flex flex-col h-full min-w-0", className)}>
-        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} />}
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
         <PdfViewer path={path} className="flex-1" />
       </div>
     )
@@ -186,7 +299,14 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   }
 
   if (!content) {
-    return <FallbackViewer path={path} className={className} />
+    // Binary/unpreviewable files (parquet, xlsx, sqlite, …) still get a header
+    // so their actions — including Query with SQL for tabular data — are reachable.
+    return (
+      <div className={cn("flex flex-col h-full min-w-0", className)}>
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
+        <FallbackViewer path={path} className="flex-1" />
+      </div>
+    )
   }
 
   const textable = isTextFile(path, stat?.contentType)
@@ -194,13 +314,13 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   if (!textable) {
     return (
       <div className={cn("flex flex-col h-full min-w-0", className)}>
-        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} />}
+        {showHeader && <ViewerHeader path={path} actions={fileActions} showExpand={showExpandButton} onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)} onQuery={onQuery} />}
         <FallbackViewer path={path} className="flex-1" />
       </div>
     )
   }
 
-  // For markdown-like files: show raw/preview toggle in header
+  // For markdown-like files: show raw/preview toggle in header.
   const viewingRaw = isMd ? showRaw : true
 
   return (
@@ -211,8 +331,9 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           actions={fileActions}
           showExpand={showExpandButton}
           onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)}
+          onQuery={onQuery}
           commentCount={commentCount}
-          isMd={isMd}
+          showViewToggle={isMd}
           showRaw={showRaw}
           onToggleRaw={() => setShowRaw(!showRaw)}
         />
@@ -240,13 +361,14 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   )
 }
 
-function ViewerHeader({ path, actions, showExpand, onExpand, commentCount = 0, isMd, showRaw, onToggleRaw }: {
+function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCount = 0, showViewToggle, showRaw, onToggleRaw }: {
   path: string
   actions: ReturnType<typeof useFileActions>
   showExpand: boolean
   onExpand: () => void
+  onQuery?: () => void
   commentCount?: number
-  isMd?: boolean
+  showViewToggle?: boolean
   showRaw?: boolean
   onToggleRaw?: () => void
 }) {
@@ -316,7 +438,7 @@ function ViewerHeader({ path, actions, showExpand, onExpand, commentCount = 0, i
           />
           <TooltipContent>Download <Kbd className="ml-1">D</Kbd></TooltipContent>
         </Tooltip>
-        {isMd && onToggleRaw && (
+        {showViewToggle && onToggleRaw && (
           <Tooltip>
             <TooltipTrigger
               render={
@@ -332,6 +454,24 @@ function ViewerHeader({ path, actions, showExpand, onExpand, commentCount = 0, i
               }
             />
             <TooltipContent>{showRaw ? "Preview" : "Source"} <Kbd className="ml-1">E</Kbd></TooltipContent>
+          </Tooltip>
+        )}
+        {onQuery && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={onQuery}
+                  className="text-muted-foreground"
+                  aria-label="Query with SQL"
+                >
+                  <Database />
+                </Button>
+              }
+            />
+            <TooltipContent>Query with SQL <Kbd className="ml-1">Q</Kbd></TooltipContent>
           </Tooltip>
         )}
         {showExpand && (

--- a/live/src/components/viewers/TablePreviewViewer.tsx
+++ b/live/src/components/viewers/TablePreviewViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { TriangleAlert, Table2 } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { Badge } from "@/components/ui/badge"
@@ -40,16 +40,15 @@ export function TablePreviewViewer({ path, size, className }: TablePreviewViewer
   const autoPreview = size == null || size <= AUTO_PREVIEW_MAX_BYTES
   const [state, setState] = useState<State>({ status: "idle" })
 
-  useEffect(() => {
+  // Monotonic request token so a slow response for a previous file can't
+  // overwrite the current one (covers both the auto effect and the manual button).
+  const reqRef = useRef(0)
+
+  const load = (reqId: number) => {
     if (!format || !client || !orgId || !driveId) return
-    if (!autoPreview) {
-      setState({ status: "idle" })
-      return
-    }
-    let cancelled = false
-    setState({ status: "loading" })
     const docPath = path.replace(/^\/+/, "")
     const table = deriveTableName(path, [])
+    setState({ status: "loading" })
     runSql(
       {
         query: `SELECT * FROM "${table}" LIMIT ${PREVIEW_ROWS}`,
@@ -60,43 +59,30 @@ export function TablePreviewViewer({ path, size, className }: TablePreviewViewer
       { forceServer: true },
     )
       .then((result) => {
-        if (!cancelled) setState({ status: "done", result })
+        if (reqRef.current === reqId) setState({ status: "done", result })
       })
       .catch((err: unknown) => {
-        if (cancelled) return
-        const e = err as { message?: string; suggestion?: string }
-        setState({
-          status: "error",
-          message: e?.message ?? "Preview failed",
-          suggestion: e?.suggestion,
-        })
-      })
-    return () => {
-      cancelled = true
-    }
-    // Re-run when the file or auto-preview gate changes.
-  }, [path, format, autoPreview, client, orgId, driveId])
-
-  const runNow = () => {
-    if (!format || !client || !orgId || !driveId) return
-    const docPath = path.replace(/^\/+/, "")
-    const table = deriveTableName(path, [])
-    setState({ status: "loading" })
-    runSql(
-      {
-        query: `SELECT * FROM "${table}" LIMIT ${PREVIEW_ROWS}`,
-        docs: [{ path: docPath, table, format }],
-        maxRows: PREVIEW_ROWS,
-      },
-      { client, orgId, driveId },
-      { forceServer: true },
-    )
-      .then((result) => setState({ status: "done", result }))
-      .catch((err: unknown) => {
+        if (reqRef.current !== reqId) return
         const e = err as { message?: string; suggestion?: string }
         setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
       })
   }
+
+  useEffect(() => {
+    if (!format || !client || !orgId || !driveId) return
+    if (!autoPreview) {
+      setState({ status: "idle" })
+      return
+    }
+    load(++reqRef.current)
+    // Invalidate the in-flight request when the file/scope changes.
+    return () => {
+      reqRef.current++
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [path, format, autoPreview, client, orgId, driveId])
+
+  const runNow = () => load(++reqRef.current)
 
   if (!format) return null
 

--- a/live/src/components/viewers/TablePreviewViewer.tsx
+++ b/live/src/components/viewers/TablePreviewViewer.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react"
+import { TriangleAlert, Table2 } from "lucide-react"
+import { useAuth } from "@/contexts/auth"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Spinner } from "@/components/ui/spinner"
+import { DataGrid } from "@/components/data-grid/DataGrid"
+import { runSql } from "@/lib/sql-engine"
+import { deriveTableName, formatForPath } from "@/lib/sql-engine/types"
+import type { SqlRunResult } from "@/lib/sql-engine/types"
+import { cn } from "@/lib/utils"
+
+const PREVIEW_ROWS = 500
+// Above this, don't auto-download+parse on file open — offer an explicit button.
+const AUTO_PREVIEW_MAX_BYTES = 25 * 1024 * 1024
+
+interface TablePreviewViewerProps {
+  /** Drive path (leading slash optional). */
+  path: string
+  /** File size in bytes, used to gate auto-preview. */
+  size?: number
+  className?: string
+}
+
+type State =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "done"; result: SqlRunResult }
+  | { status: "error"; message: string; suggestion?: string }
+
+/**
+ * Default preview for tabular documents: runs `SELECT * FROM <doc> LIMIT N`
+ * through the shared SQL engine (DuckDB-WASM for csv/tsv/parquet, server for
+ * xlsx) and renders the rows in the shared DataGrid. Large files require an
+ * explicit click so opening a file never silently pulls hundreds of MB.
+ */
+export function TablePreviewViewer({ path, size, className }: TablePreviewViewerProps) {
+  const { client, orgId, driveId } = useAuth()
+  const format = formatForPath(path)
+  const autoPreview = size == null || size <= AUTO_PREVIEW_MAX_BYTES
+  const [state, setState] = useState<State>({ status: "idle" })
+
+  useEffect(() => {
+    if (!format || !client || !orgId || !driveId) return
+    if (!autoPreview) {
+      setState({ status: "idle" })
+      return
+    }
+    let cancelled = false
+    setState({ status: "loading" })
+    const docPath = path.replace(/^\/+/, "")
+    const table = deriveTableName(path, [])
+    runSql(
+      {
+        query: `SELECT * FROM "${table}" LIMIT ${PREVIEW_ROWS}`,
+        docs: [{ path: docPath, table, format }],
+        maxRows: PREVIEW_ROWS,
+      },
+      { client, orgId, driveId },
+      { forceServer: true },
+    )
+      .then((result) => {
+        if (!cancelled) setState({ status: "done", result })
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        const e = err as { message?: string; suggestion?: string }
+        setState({
+          status: "error",
+          message: e?.message ?? "Preview failed",
+          suggestion: e?.suggestion,
+        })
+      })
+    return () => {
+      cancelled = true
+    }
+    // Re-run when the file or auto-preview gate changes.
+  }, [path, format, autoPreview, client, orgId, driveId])
+
+  const runNow = () => {
+    if (!format || !client || !orgId || !driveId) return
+    const docPath = path.replace(/^\/+/, "")
+    const table = deriveTableName(path, [])
+    setState({ status: "loading" })
+    runSql(
+      {
+        query: `SELECT * FROM "${table}" LIMIT ${PREVIEW_ROWS}`,
+        docs: [{ path: docPath, table, format }],
+        maxRows: PREVIEW_ROWS,
+      },
+      { client, orgId, driveId },
+      { forceServer: true },
+    )
+      .then((result) => setState({ status: "done", result }))
+      .catch((err: unknown) => {
+        const e = err as { message?: string; suggestion?: string }
+        setState({ status: "error", message: e?.message ?? "Preview failed", suggestion: e?.suggestion })
+      })
+  }
+
+  if (!format) return null
+
+  if (state.status === "loading") {
+    return (
+      <div className={cn("flex flex-1 items-center justify-center", className)}>
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className={cn("flex-1 overflow-auto p-4", className)}>
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3">
+          <div className="flex items-start gap-2">
+            <TriangleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-destructive">Couldn't preview this file</p>
+              <p className="mt-1 font-mono text-xs break-words whitespace-pre-wrap text-destructive/90">
+                {state.message}
+              </p>
+              {state.suggestion && (
+                <p className="mt-2 text-xs text-muted-foreground">{state.suggestion}</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.status === "idle") {
+    return (
+      <div className={cn("flex flex-1 flex-col items-center justify-center gap-2 p-8 text-center", className)}>
+        <Table2 className="size-6 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">
+          Large file{size ? ` (${formatBytes(size)})` : ""} — preview not loaded automatically.
+        </p>
+        <Button variant="secondary" size="sm" onClick={runNow}>
+          Preview as table
+        </Button>
+      </div>
+    )
+  }
+
+  const { result } = state
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col", className)}>
+      {result.rows.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center p-8">
+          <p className="text-sm text-muted-foreground">This file has no rows.</p>
+        </div>
+      ) : (
+        <DataGrid columns={result.columns} rows={result.rows} />
+      )}
+      <div className="flex h-7 shrink-0 items-center gap-2 border-t border-border px-3 text-[11px] text-muted-foreground">
+        <span className="tabular-nums">
+          {result.rowCount.toLocaleString()} row{result.rowCount === 1 ? "" : "s"}
+        </span>
+        {result.truncated && <span>· first {PREVIEW_ROWS}</span>}
+        {size != null && <span className="tabular-nums">· {formatBytes(size)}</span>}
+        <span className="text-muted-foreground/60">
+          · {result.engine === "wasm" ? "loaded in browser" : "loaded on server"}
+        </span>
+        <Badge variant="outline" className="ml-auto h-4 px-1.5 font-mono text-[10px]">
+          {result.engine}
+        </Badge>
+      </div>
+    </div>
+  )
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}

--- a/live/src/lib/sql-engine/duckdb.ts
+++ b/live/src/lib/sql-engine/duckdb.ts
@@ -1,0 +1,188 @@
+import * as duckdb from "@duckdb/duckdb-wasm"
+import mvpWasmUrl from "@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url"
+import mvpWorkerUrl from "@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url"
+import ehWasmUrl from "@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url"
+import ehWorkerUrl from "@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url"
+import type { BoundDoc, SqlEngineContext, SqlRunInput, SqlRunResult } from "./types"
+
+/**
+ * Browser engine: DuckDB-WASM. This module is only ever loaded via dynamic
+ * import (see ./index.ts) so the wasm bundles never affect initial page load.
+ * The eh/mvp bundles need no COOP/COEP headers.
+ */
+
+/** Module-level singleton — the db (and its registered file buffers) survives
+ *  across runs so repeat queries skip the wasm boot and file re-downloads. */
+let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null
+
+/** Registered virtual file name -> source key (org/drive/path) it was loaded from. */
+const registeredFiles = new Map<string, string>()
+
+async function initDb(): Promise<duckdb.AsyncDuckDB> {
+  const bundle = await duckdb.selectBundle({
+    mvp: { mainModule: mvpWasmUrl, mainWorker: mvpWorkerUrl },
+    eh: { mainModule: ehWasmUrl, mainWorker: ehWorkerUrl },
+  })
+  const worker = new Worker(bundle.mainWorker!)
+  const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), worker)
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker)
+  return db
+}
+
+function getDb(): Promise<duckdb.AsyncDuckDB> {
+  if (!dbPromise) {
+    dbPromise = initDb().catch((err) => {
+      // Allow a retry on the next run instead of caching a failed boot.
+      dbPromise = null
+      throw err
+    })
+  }
+  return dbPromise
+}
+
+/** Drive path -> the name the file is registered under (leading slash stripped). */
+function virtualName(path: string): string {
+  return path.replace(/^\/+/, "")
+}
+
+function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`
+}
+
+function quoteString(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+/** The DuckDB table function that reads the registered file for a doc's format. */
+function readerFor(doc: BoundDoc, file: string): string {
+  const f = quoteString(file)
+  switch (doc.format) {
+    case "csv":
+      return `read_csv_auto(${f})`
+    case "tsv":
+      // Real tab character — DuckDB string literals don't process backslash escapes.
+      return `read_csv_auto(${f}, delim='\t')`
+    case "parquet":
+      return `read_parquet(${f})`
+    case "json":
+      return `read_json_auto(${f})`
+    case "ndjson":
+      return `read_json_auto(${f}, format='newline_delimited')`
+    default:
+      throw new Error(`Format "${doc.format}" cannot run in the browser engine`)
+  }
+}
+
+/** Fetch + register each doc's bytes, skipping files already registered from
+ *  the same org/drive/path. */
+async function ensureRegistered(
+  db: duckdb.AsyncDuckDB,
+  docs: BoundDoc[],
+  ctx: SqlEngineContext,
+): Promise<void> {
+  for (const doc of docs) {
+    const name = virtualName(doc.path)
+    const key = `${ctx.orgId}/${ctx.driveId}:${name}`
+    if (registeredFiles.get(name) === key) continue
+
+    const blob = await ctx.client.fetchRaw(ctx.orgId, ctx.driveId, doc.path)
+    const bytes = new Uint8Array(await blob.arrayBuffer())
+    if (registeredFiles.has(name)) {
+      await db.dropFile(name).catch(() => {})
+      registeredFiles.delete(name)
+    }
+    await db.registerFileBuffer(name, bytes)
+    registeredFiles.set(name, key)
+  }
+}
+
+/** Replace exact quoted drive-path literals (with or without leading slash)
+ *  with the registered virtual file name so `SELECT * FROM '/data/sales.csv'`
+ *  works in the browser too. */
+function rewritePathLiterals(query: string, docs: BoundDoc[]): string {
+  let out = query
+  for (const doc of docs) {
+    const name = virtualName(doc.path)
+    const target = quoteString(name)
+    for (const literal of [`'/${name}'`, `"/${name}"`, `"${name}"`, `'${name}'`]) {
+      out = out.split(literal).join(target)
+    }
+  }
+  return out
+}
+
+/** Wrap plain SELECT-ish statements so the engine never materializes more than
+ *  maxRows + 1 rows (the +1 detects truncation). Other statements run as-is
+ *  and are sliced client-side. */
+function withLimit(query: string, maxRows: number): string {
+  const trimmed = query.trim().replace(/;+\s*$/, "")
+  if (/^(select|with|from|values)\b/i.test(trimmed)) {
+    return `SELECT * FROM (${trimmed}) AS __agent_fs_result LIMIT ${maxRows + 1}`
+  }
+  return trimmed
+}
+
+/** Convert Arrow JS values into plain JSON-safe values: BigInt -> number when
+ *  within the safe range (else string), Date -> ISO string, binary -> hex,
+ *  nested vectors/structs -> arrays/objects. Keeps JSON.stringify and React
+ *  rendering from ever throwing. */
+function sanitizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) return null
+  if (typeof value === "bigint") {
+    return value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(value)
+      : value.toString()
+  }
+  if (value instanceof Date) return value.toISOString()
+  if (value instanceof Uint8Array) {
+    const hex = Array.from(value.slice(0, 64), (b) => b.toString(16).padStart(2, "0")).join("")
+    return `\\x${hex}${value.length > 64 ? "…" : ""}`
+  }
+  if (Array.isArray(value)) return value.map(sanitizeValue)
+  if (typeof value === "object") {
+    const withToJson = value as { toJSON?: () => unknown }
+    if (typeof withToJson.toJSON === "function") return sanitizeValue(withToJson.toJSON())
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) out[k] = sanitizeValue(v)
+    return out
+  }
+  return value
+}
+
+export async function runInBrowser(
+  input: SqlRunInput,
+  ctx: SqlEngineContext,
+): Promise<SqlRunResult> {
+  const db = await getDb()
+  await ensureRegistered(db, input.docs, ctx)
+
+  const conn = await db.connect()
+  try {
+    // (Re)create one view per bound doc so `SELECT * FROM <table>` works.
+    for (const doc of input.docs) {
+      const reader = readerFor(doc, virtualName(doc.path))
+      await conn.query(
+        `CREATE OR REPLACE VIEW ${quoteIdent(doc.table)} AS SELECT * FROM ${reader}`,
+      )
+    }
+
+    const sql = withLimit(rewritePathLiterals(input.query, input.docs), input.maxRows)
+    const started = performance.now()
+    const table = await conn.query(sql)
+    const elapsedMs = Math.max(1, Math.round(performance.now() - started))
+
+    const columns = table.schema.fields.map((f) => ({
+      name: String(f.name),
+      type: String(f.type),
+    }))
+    const raw = table.toArray()
+    const truncated = raw.length > input.maxRows
+    const rows = (truncated ? raw.slice(0, input.maxRows) : raw).map(
+      (row) => sanitizeValue(row) as Record<string, unknown>,
+    )
+
+    return { columns, rows, rowCount: rows.length, truncated, elapsedMs, engine: "wasm" }
+  } finally {
+    await conn.close()
+  }
+}

--- a/live/src/lib/sql-engine/duckdb.ts
+++ b/live/src/lib/sql-engine/duckdb.ts
@@ -74,7 +74,9 @@ function readerFor(doc: BoundDoc, file: string): string {
 }
 
 /** Fetch + register each doc's bytes, skipping files already registered from
- *  the same org/drive/path. */
+ *  the same org/drive/path *and revision*. Keying on the current version means
+ *  an edited/re-uploaded file at the same path re-registers instead of serving
+ *  a stale buffer. */
 async function ensureRegistered(
   db: duckdb.AsyncDuckDB,
   docs: BoundDoc[],
@@ -82,7 +84,21 @@ async function ensureRegistered(
 ): Promise<void> {
   for (const doc of docs) {
     const name = virtualName(doc.path)
-    const key = `${ctx.orgId}/${ctx.driveId}:${name}`
+    // Resolve a revision token. If stat fails, fall back to a unique value so we
+    // never reuse a possibly-stale buffer.
+    let revision: string
+    try {
+      const stat = await ctx.client.callOp<{ currentVersion?: number; modifiedAt?: string }>(
+        ctx.orgId,
+        "stat",
+        { path: doc.path },
+        ctx.driveId,
+      )
+      revision = String(stat.currentVersion ?? stat.modifiedAt ?? performance.now())
+    } catch {
+      revision = String(performance.now())
+    }
+    const key = `${ctx.orgId}/${ctx.driveId}:${name}@${revision}`
     if (registeredFiles.get(name) === key) continue
 
     const blob = await ctx.client.fetchRaw(ctx.orgId, ctx.driveId, doc.path)

--- a/live/src/lib/sql-engine/duckdb.ts
+++ b/live/src/lib/sql-engine/duckdb.ts
@@ -203,15 +203,33 @@ export async function runInBrowser(
     const table = await conn.query(sql)
     const elapsedMs = Math.max(1, Math.round(performance.now() - started))
 
-    const columns = table.schema.fields.map((f) => ({
-      name: String(f.name),
-      type: String(f.type),
+    // Uniquify duplicate column names and read cells by column index, so a query
+    // projecting two `id`s keeps both instead of colliding on the object key.
+    const fields = table.schema.fields
+    const seenCols = new Map<string, number>()
+    const columnNames = fields.map((f) => {
+      const name = String(f.name)
+      const n = seenCols.get(name) ?? 0
+      seenCols.set(name, n + 1)
+      return n === 0 ? name : `${name}_${n + 1}`
+    })
+    const columns = columnNames.map((name, i) => ({
+      name,
+      type: String(fields[i].type),
     }))
-    const raw = table.toArray()
-    const truncated = raw.length > input.maxRows
-    const rows = (truncated ? raw.slice(0, input.maxRows) : raw).map(
-      (row) => sanitizeValue(row) as Record<string, unknown>,
-    )
+
+    const total = table.numRows
+    const truncated = total > input.maxRows
+    const rowCount = truncated ? input.maxRows : total
+    const vectors = fields.map((_, i) => table.getChildAt(i))
+    const rows: Record<string, unknown>[] = []
+    for (let r = 0; r < rowCount; r++) {
+      const row: Record<string, unknown> = {}
+      for (let c = 0; c < columnNames.length; c++) {
+        row[columnNames[c]] = sanitizeValue(vectors[c]?.get(r))
+      }
+      rows.push(row)
+    }
 
     return { columns, rows, rowCount: rows.length, truncated, elapsedMs, engine: "wasm" }
   } finally {

--- a/live/src/lib/sql-engine/duckdb.ts
+++ b/live/src/lib/sql-engine/duckdb.ts
@@ -86,6 +86,16 @@ async function ensureRegistered(
   docs: BoundDoc[],
   ctx: SqlEngineContext,
 ): Promise<void> {
+  // Drop files registered by earlier runs that aren't bound now (removed docs,
+  // org/drive switch), so a stale buffer can't be read out of scope.
+  const wanted = new Set(docs.map((d) => virtualName(d.path)))
+  for (const name of [...registeredFiles.keys()]) {
+    if (!wanted.has(name)) {
+      await db.dropFile(name).catch(() => {})
+      registeredFiles.delete(name)
+    }
+  }
+
   for (const doc of docs) {
     const name = virtualName(doc.path)
     // Resolve a revision token. If stat fails, fall back to a unique value so we

--- a/live/src/lib/sql-engine/duckdb.ts
+++ b/live/src/lib/sql-engine/duckdb.ts
@@ -15,8 +15,12 @@ import type { BoundDoc, SqlEngineContext, SqlRunInput, SqlRunResult } from "./ty
  *  across runs so repeat queries skip the wasm boot and file re-downloads. */
 let dbPromise: Promise<duckdb.AsyncDuckDB> | null = null
 
-/** Registered virtual file name -> source key (org/drive/path) it was loaded from. */
+/** Registered virtual file name -> source key (org/drive/path@rev) it was loaded from. */
 const registeredFiles = new Map<string, string>()
+
+/** View names created in the persistent db, so stale ones (from removed docs or
+ *  an org/drive switch) can be dropped before each run. */
+const createdViews = new Set<string>()
 
 async function initDb(): Promise<duckdb.AsyncDuckDB> {
   const bundle = await duckdb.selectBundle({
@@ -112,19 +116,19 @@ async function ensureRegistered(
   }
 }
 
-/** Replace exact quoted drive-path literals (with or without leading slash)
- *  with the registered virtual file name so `SELECT * FROM '/data/sales.csv'`
- *  works in the browser too. */
+/** Drive-path literal in table position, e.g. `FROM '/data/sales.csv'`. */
+const FROM_JOIN_PATH_RE = /\b(from|join)\s+(['"])([^'"]+\.[A-Za-z0-9]+(?:\.gz)?)\2/gi
+
+/** Rewrite FROM/JOIN drive-path literals (with or without leading slash) to the
+ *  registered virtual file so `SELECT * FROM '/data/sales.csv'` works in the
+ *  browser. Only table-position literals are touched — a value-position string
+ *  like `WHERE source = '/data/sales.csv'` is left intact. */
 function rewritePathLiterals(query: string, docs: BoundDoc[]): string {
-  let out = query
-  for (const doc of docs) {
-    const name = virtualName(doc.path)
-    const target = quoteString(name)
-    for (const literal of [`'/${name}'`, `"/${name}"`, `"${name}"`, `'${name}'`]) {
-      out = out.split(literal).join(target)
-    }
-  }
-  return out
+  const byName = new Map(docs.map((d) => [virtualName(d.path), d]))
+  return query.replace(FROM_JOIN_PATH_RE, (full, kw: string, _q: string, raw: string) => {
+    const name = raw.replace(/^\/+/, "")
+    return byName.has(name) ? `${kw} ${quoteString(name)}` : full
+  })
 }
 
 /** Wrap plain SELECT-ish statements so the engine never materializes more than
@@ -174,12 +178,24 @@ export async function runInBrowser(
 
   const conn = await db.connect()
   try {
+    // The db instance persists across runs, so drop views from earlier runs
+    // that aren't bound now (removed docs, an org/drive switch, …) — otherwise a
+    // query could read a stale table that's no longer in scope.
+    const current = new Set(input.docs.map((d) => d.table))
+    for (const view of createdViews) {
+      if (!current.has(view)) {
+        await conn.query(`DROP VIEW IF EXISTS ${quoteIdent(view)}`).catch(() => {})
+        createdViews.delete(view)
+      }
+    }
+
     // (Re)create one view per bound doc so `SELECT * FROM <table>` works.
     for (const doc of input.docs) {
       const reader = readerFor(doc, virtualName(doc.path))
       await conn.query(
         `CREATE OR REPLACE VIEW ${quoteIdent(doc.table)} AS SELECT * FROM ${reader}`,
       )
+      createdViews.add(doc.table)
     }
 
     const sql = withLimit(rewritePathLiterals(input.query, input.docs), input.maxRows)

--- a/live/src/lib/sql-engine/index.ts
+++ b/live/src/lib/sql-engine/index.ts
@@ -5,13 +5,24 @@ import type { BoundDoc, SqlEngineContext, SqlRunInput, SqlRunResult } from "./ty
  *  and sqlite/duckdb (flaky sqlite_scanner) must run on the server. */
 const WASM_FORMATS = new Set<string>(["csv", "tsv", "parquet", "json", "ndjson"])
 
+/** Drive-path literal in table position, e.g. `FROM '/data/sales.csv'`. */
+const FROM_JOIN_PATH_RE = /\b(?:from|join)\s+(['"])([^'"]+\.[A-Za-z0-9]+(?:\.gz)?)\1/gi
+
 /**
- * True when every bound doc can be read by DuckDB-WASM in the browser. With no
- * bound docs the query can only reference drive paths directly, which only the
- * server resolves — so an empty doc set also routes to the server.
+ * True when the query can run entirely in the browser (DuckDB-WASM). Requires:
+ * at least one bound doc, every bound doc readable by WASM, and no FROM/JOIN
+ * drive-path literal that isn't a bound doc — only the server auto-binds bare
+ * path literals, so a query referencing an unbound one must run there.
  */
-export function canRunInBrowser(docs: BoundDoc[]): boolean {
-  return docs.length > 0 && docs.every((d) => WASM_FORMATS.has(d.format))
+export function canRunInBrowser(docs: BoundDoc[], query?: string): boolean {
+  if (docs.length === 0 || !docs.every((d) => WASM_FORMATS.has(d.format))) return false
+  if (query) {
+    const bound = new Set(docs.map((d) => d.path.replace(/^\/+/, "")))
+    for (const m of query.matchAll(FROM_JOIN_PATH_RE)) {
+      if (!bound.has(m[2].replace(/^\/+/, ""))) return false
+    }
+  }
+  return true
 }
 
 /**
@@ -25,7 +36,7 @@ export async function runSql(
   ctx: SqlEngineContext,
   opts?: { forceServer?: boolean },
 ): Promise<SqlRunResult> {
-  if (!opts?.forceServer && canRunInBrowser(input.docs)) {
+  if (!opts?.forceServer && canRunInBrowser(input.docs, input.query)) {
     const { runInBrowser } = await import("./duckdb")
     return runInBrowser(input, ctx)
   }

--- a/live/src/lib/sql-engine/index.ts
+++ b/live/src/lib/sql-engine/index.ts
@@ -1,0 +1,35 @@
+import { runOnServer } from "./server"
+import type { BoundDoc, SqlEngineContext, SqlRunInput, SqlRunResult } from "./types"
+
+/** Formats DuckDB-WASM can read in the browser. xlsx (broken excel extension)
+ *  and sqlite/duckdb (flaky sqlite_scanner) must run on the server. */
+const WASM_FORMATS = new Set<string>(["csv", "tsv", "parquet", "json", "ndjson"])
+
+/**
+ * True when every bound doc can be read by DuckDB-WASM in the browser. With no
+ * bound docs the query can only reference drive paths directly, which only the
+ * server resolves — so an empty doc set also routes to the server.
+ */
+export function canRunInBrowser(docs: BoundDoc[]): boolean {
+  return docs.length > 0 && docs.every((d) => WASM_FORMATS.has(d.format))
+}
+
+/**
+ * Run a SQL query against the bound documents, picking the engine
+ * automatically: browser (DuckDB-WASM) when every bound doc supports it,
+ * server otherwise or when `forceServer` is set. The wasm module is
+ * dynamically imported so it never affects initial page load.
+ */
+export async function runSql(
+  input: SqlRunInput,
+  ctx: SqlEngineContext,
+  opts?: { forceServer?: boolean },
+): Promise<SqlRunResult> {
+  if (!opts?.forceServer && canRunInBrowser(input.docs)) {
+    const { runInBrowser } = await import("./duckdb")
+    return runInBrowser(input, ctx)
+  }
+  return runOnServer(input, ctx)
+}
+
+export * from "./types"

--- a/live/src/lib/sql-engine/server.ts
+++ b/live/src/lib/sql-engine/server.ts
@@ -1,0 +1,28 @@
+import type { SqlTableBinding } from "@/api/types"
+import type { SqlEngineContext, SqlRunInput, SqlRunResult } from "./types"
+
+/** Run the query via the server's `sql` op (DuckDB on the daemon). */
+export async function runOnServer(
+  input: SqlRunInput,
+  ctx: SqlEngineContext,
+): Promise<SqlRunResult> {
+  const tables: Record<string, SqlTableBinding> = {}
+  for (const doc of input.docs) {
+    tables[doc.table] = { path: doc.path, format: doc.format }
+  }
+
+  const result = await ctx.client.sqlQuery(ctx.orgId, ctx.driveId, {
+    query: input.query,
+    tables: input.docs.length > 0 ? tables : undefined,
+    maxRows: input.maxRows,
+  })
+
+  return {
+    columns: result.columns,
+    rows: result.rows,
+    rowCount: result.rowCount,
+    truncated: result.truncated,
+    elapsedMs: result.elapsedMs,
+    engine: "server",
+  }
+}

--- a/live/src/lib/sql-engine/types.ts
+++ b/live/src/lib/sql-engine/types.ts
@@ -50,7 +50,21 @@ export interface BoundDoc {
   /** Table name the document is exposed as (user-editable). */
   table: string
   format: SqlFormat
+  /** File size in bytes, when known (drives the "browser will load" hint). */
+  size?: number
 }
+
+/** Formats the browser (DuckDB-WASM) engine can read directly. */
+export const WASM_READABLE_FORMATS = new Set<SqlFormat>([
+  "csv",
+  "tsv",
+  "parquet",
+  "json",
+  "ndjson",
+])
+
+/** Multi-table database formats — referenced as `<table>.<name>`, not by path. */
+export const DATABASE_FORMATS = new Set<SqlFormat>(["sqlite", "duckdb"])
 
 export type SqlEngineKind = "wasm" | "server"
 

--- a/live/src/lib/sql-engine/types.ts
+++ b/live/src/lib/sql-engine/types.ts
@@ -1,0 +1,76 @@
+import type { AgentFsClient } from "@/api/client"
+import type { SqlColumn, SqlFormat } from "@/api/types"
+
+/** File extensions the SQL workbench can query, mapped to their SQL format. */
+export const QUERYABLE_EXTENSIONS: Record<string, SqlFormat> = {
+  csv: "csv",
+  tsv: "tsv",
+  parquet: "parquet",
+  xlsx: "xlsx",
+  json: "json",
+  jsonl: "ndjson",
+  ndjson: "ndjson",
+  db: "sqlite",
+  sqlite: "sqlite",
+  sqlite3: "sqlite",
+  duckdb: "duckdb",
+}
+
+export function formatForPath(path: string): SqlFormat | null {
+  const ext = path.split(".").pop()?.toLowerCase() ?? ""
+  return QUERYABLE_EXTENSIONS[ext] ?? null
+}
+
+export function isQueryablePath(path: string): boolean {
+  return formatForPath(path) !== null
+}
+
+/** Sanitize a user-typed table name into a SQL identifier ("" when nothing survives). */
+export function sanitizeTableName(name: string): string {
+  let cleaned = name.trim().replace(/[^A-Za-z0-9_]/g, "_")
+  if (/^[0-9]/.test(cleaned)) cleaned = `_${cleaned}`
+  return cleaned
+}
+
+/** Derive a SQL-safe table name from a file path stem, unique against `taken`. */
+export function deriveTableName(path: string, taken: Iterable<string>): string {
+  const stem = (path.split("/").pop() ?? path).replace(/\.[^.]+$/, "")
+  const base = sanitizeTableName(stem) || "doc"
+  const set = new Set(taken)
+  if (!set.has(base)) return base
+  let i = 2
+  while (set.has(`${base}_${i}`)) i++
+  return `${base}_${i}`
+}
+
+/** A drive document bound into the query session as a named table. */
+export interface BoundDoc {
+  /** Drive path without leading slash (e.g. "data/sales.csv"). */
+  path: string
+  /** Table name the document is exposed as (user-editable). */
+  table: string
+  format: SqlFormat
+}
+
+export type SqlEngineKind = "wasm" | "server"
+
+export interface SqlRunInput {
+  query: string
+  docs: BoundDoc[]
+  maxRows: number
+}
+
+export interface SqlRunResult {
+  columns: SqlColumn[]
+  rows: Record<string, unknown>[]
+  rowCount: number
+  truncated: boolean
+  elapsedMs: number
+  engine: SqlEngineKind
+}
+
+export interface SqlEngineContext {
+  client: AgentFsClient
+  orgId: string
+  driveId: string
+}

--- a/live/src/lib/sql-engine/types.ts
+++ b/live/src/lib/sql-engine/types.ts
@@ -16,9 +16,22 @@ export const QUERYABLE_EXTENSIONS: Record<string, SqlFormat> = {
   duckdb: "duckdb",
 }
 
+/** Formats that can be read from a gzipped file (`.csv.gz`, `.json.gz`, …). */
+const GZIP_FORMATS = new Set<SqlFormat>(["csv", "tsv", "json", "ndjson"])
+
 export function formatForPath(path: string): SqlFormat | null {
-  const ext = path.split(".").pop()?.toLowerCase() ?? ""
-  return QUERYABLE_EXTENSIONS[ext] ?? null
+  let name = path.toLowerCase()
+  let gzipped = false
+  if (name.endsWith(".gz")) {
+    gzipped = true
+    name = name.slice(0, -3)
+  }
+  const ext = name.split(".").pop() ?? ""
+  const format = QUERYABLE_EXTENSIONS[ext] ?? null
+  if (!format) return null
+  // A .gz suffix only makes sense for the text formats DuckDB decompresses.
+  if (gzipped && !GZIP_FORMATS.has(format)) return null
+  return format
 }
 
 export function isQueryablePath(path: string): boolean {
@@ -34,7 +47,9 @@ export function sanitizeTableName(name: string): string {
 
 /** Derive a SQL-safe table name from a file path stem, unique against `taken`. */
 export function deriveTableName(path: string, taken: Iterable<string>): string {
-  const stem = (path.split("/").pop() ?? path).replace(/\.[^.]+$/, "")
+  const stem = (path.split("/").pop() ?? path)
+    .replace(/\.gz$/i, "")
+    .replace(/\.[^.]+$/, "")
   const base = sanitizeTableName(stem) || "doc"
   const set = new Set(taken)
   if (!set.has(base)) return base

--- a/live/src/pages/FileDetail.tsx
+++ b/live/src/pages/FileDetail.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from "react-router"
 import { useCallback, useRef, useEffect, useState } from "react"
-import { Copy, Link as LinkIcon, Download, Check } from "lucide-react"
+import { Copy, Link as LinkIcon, Download, Check, Database } from "lucide-react"
 import { FileViewer } from "@/components/viewers/FileViewer"
 import { VersionHistory } from "@/components/VersionHistory"
 import { UserName } from "@/components/UserName"
@@ -12,9 +12,11 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { useAuth } from "@/contexts/auth"
 import { useFileStat } from "@/hooks/use-file-stat"
 import { useFileActions } from "@/hooks/use-file-actions"
 import { useDocumentTitle } from "@/hooks/use-document-title"
+import { isQueryablePath } from "@/lib/sql-engine/types"
 import { uiChromeStore } from "@/stores/ui-chrome"
 import type { ScrollToCommentCallback } from "@/pages/FileBrowser"
 import type { OutlineItem } from "@/lib/outline"
@@ -22,6 +24,7 @@ import type { OutlineItem } from "@/lib/outline"
 export function FileDetailPage() {
   const params = useParams()
   const navigate = useNavigate()
+  const { orgId, driveId } = useAuth()
   const scrollToCommentRef = useRef<ScrollToCommentCallback | null>(null)
   const [outline, setOutline] = useState<OutlineItem[]>([])
 
@@ -71,6 +74,26 @@ export function FileDetailPage() {
             )}
           </div>
           <div className="flex items-center gap-1 px-2 shrink-0">
+            {isQueryablePath(filePath) && orgId && driveId && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={() =>
+                        navigate(`/sql/~/${orgId}/${driveId}?path=${encodeURIComponent(filePath)}`)
+                      }
+                      className="text-muted-foreground"
+                      aria-label="Query with SQL"
+                    >
+                      <Database />
+                    </Button>
+                  }
+                />
+                <TooltipContent>Query with SQL</TooltipContent>
+              </Tooltip>
+            )}
             <Tooltip>
               <TooltipTrigger
                 render={

--- a/live/src/pages/SqlPage.tsx
+++ b/live/src/pages/SqlPage.tsx
@@ -185,7 +185,7 @@ export function SqlPage() {
     }
   }, [client, orgId, driveId, query, docs, maxRows, forceServer])
 
-  const wasmEligible = canRunInBrowser(docs)
+  const wasmEligible = canRunInBrowser(docs, query)
   const runsInBrowser = !forceServer && wasmEligible
   const effectiveEngine: "browser" | "server" = runsInBrowser ? "browser" : "server"
   const engineHint = forceServer

--- a/live/src/pages/SqlPage.tsx
+++ b/live/src/pages/SqlPage.tsx
@@ -1,0 +1,222 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useSearchParams } from "react-router"
+import { ChevronDown, Database, Play, Server } from "lucide-react"
+import { useAuth } from "@/contexts/auth"
+import { Button } from "@/components/ui/button"
+import { Kbd } from "@/components/ui/kbd"
+import { Spinner } from "@/components/ui/spinner"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { DocumentPicker } from "@/components/sql/DocumentPicker"
+import { SqlEditor } from "@/components/sql/SqlEditor"
+import { ResultsPanel, type SqlRunError } from "@/components/sql/ResultsPanel"
+import { useDocumentTitle } from "@/hooks/use-document-title"
+import {
+  canRunInBrowser,
+  deriveTableName,
+  formatForPath,
+  runSql,
+  sanitizeTableName,
+  type BoundDoc,
+  type SqlRunResult,
+} from "@/lib/sql-engine"
+import { cn } from "@/lib/utils"
+import { toast } from "@/stores/toast"
+import type { ApiError } from "@/api/client"
+
+const ROW_LIMITS = [100, 1000, 10000]
+
+export function SqlPage() {
+  const { client, orgId, driveId } = useAuth()
+  const [searchParams] = useSearchParams()
+
+  const [docs, setDocs] = useState<BoundDoc[]>([])
+  const [query, setQuery] = useState("")
+  const [maxRows, setMaxRows] = useState(1000)
+  const [forceServer, setForceServer] = useState(false)
+  const [running, setRunning] = useState(false)
+  const [result, setResult] = useState<SqlRunResult | null>(null)
+  const [error, setError] = useState<SqlRunError | null>(null)
+
+  useDocumentTitle("SQL")
+
+  // Pre-bind ?path=... and pre-fill a starter query (once per mount).
+  const seeded = useRef(false)
+  useEffect(() => {
+    if (seeded.current) return
+    seeded.current = true
+    const raw = searchParams.get("path")
+    if (!raw) return
+    const path = raw.replace(/^\/+/, "")
+    const format = formatForPath(path)
+    if (!format) return
+    setDocs((prev) =>
+      prev.some((d) => d.path === path)
+        ? prev
+        : [...prev, { path, table: deriveTableName(path, prev.map((d) => d.table)), format }],
+    )
+    setQuery((q) => q || `SELECT * FROM '/${path}' LIMIT 100`)
+  }, [searchParams])
+
+  const addDoc = useCallback((rawPath: string) => {
+    const path = rawPath.replace(/^\/+/, "")
+    const format = formatForPath(path)
+    if (!format) return
+    setDocs((prev) => {
+      if (prev.some((d) => d.path === path)) return prev
+      return [...prev, { path, table: deriveTableName(path, prev.map((d) => d.table)), format }]
+    })
+  }, [])
+
+  const removeDoc = useCallback((path: string) => {
+    setDocs((prev) => prev.filter((d) => d.path !== path))
+  }, [])
+
+  const renameDoc = useCallback((path: string, table: string) => {
+    setDocs((prev) => {
+      const sanitized = sanitizeTableName(table)
+      if (!sanitized) return prev
+      // Keep table names unique — refuse a rename that collides.
+      if (prev.some((d) => d.path !== path && d.table === sanitized)) {
+        toast.error("Table name already in use", { description: sanitized })
+        return prev
+      }
+      return prev.map((d) => (d.path === path ? { ...d, table: sanitized } : d))
+    })
+  }, [])
+
+  const run = useCallback(async () => {
+    if (!orgId || !driveId) return
+    if (!query.trim()) {
+      toast.error("Nothing to run", { description: "Write a query first." })
+      return
+    }
+    setRunning(true)
+    setError(null)
+    try {
+      const res = await runSql(
+        { query, docs, maxRows },
+        { client, orgId, driveId },
+        { forceServer },
+      )
+      setResult(res)
+    } catch (err) {
+      const apiErr = err as Partial<ApiError> & Error
+      const next: SqlRunError = {
+        message: apiErr.message || "Query failed",
+        suggestion: apiErr.suggestion,
+      }
+      setError(next)
+      setResult(null)
+      toast.error("Query failed", { description: next.message })
+    } finally {
+      setRunning(false)
+    }
+  }, [client, orgId, driveId, query, docs, maxRows, forceServer])
+
+  const wasmEligible = canRunInBrowser(docs)
+  const engineHint = forceServer
+    ? "server engine (forced)"
+    : wasmEligible
+      ? "browser engine (wasm)"
+      : docs.length === 0
+        ? "server engine — path literals resolve on the server"
+        : "server engine — xlsx/sqlite/duckdb need the server"
+
+  return (
+    <div className="flex h-full min-w-0 flex-col">
+      {/* Sub-header */}
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border px-4">
+        <Database className="size-4 shrink-0 text-muted-foreground" />
+        <span className="text-sm font-medium">SQL workbench</span>
+        <span className="hidden truncate text-xs text-muted-foreground sm:inline">
+          Query drive documents with DuckDB
+        </span>
+        <div className="ml-auto shrink-0">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant={forceServer ? "secondary" : "ghost"}
+                  size="xs"
+                  onClick={() => setForceServer((v) => !v)}
+                  aria-pressed={forceServer}
+                  className={cn("gap-1", !forceServer && "text-muted-foreground")}
+                >
+                  <Server />
+                  Run on server
+                </Button>
+              }
+            />
+            <TooltipContent>
+              {forceServer
+                ? "Queries are forced to the server engine"
+                : "Auto: browser (wasm) when every bound document supports it"}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* Bound documents */}
+      <div className="shrink-0 border-b border-border px-4 py-2">
+        <DocumentPicker docs={docs} onAdd={addDoc} onRemove={removeDoc} onRename={renameDoc} />
+      </div>
+
+      {/* Editor */}
+      <div className="flex h-[38%] min-h-44 shrink-0 flex-col border-b border-border">
+        <div className="min-h-0 flex-1">
+          <SqlEditor value={query} onChange={setQuery} onRun={run} />
+        </div>
+        <div className="flex h-9 shrink-0 items-center gap-2 border-t border-border px-2">
+          <Button size="xs" onClick={run} disabled={running} className="gap-1.5">
+            {running ? (
+              <Spinner size="sm" className="size-3 border-primary-foreground/40 border-t-primary-foreground" />
+            ) : (
+              <Play />
+            )}
+            Run
+            <Kbd className="bg-primary-foreground/15 border-primary-foreground/20 text-primary-foreground/80">
+              ⌘⏎
+            </Kbd>
+          </Button>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button variant="ghost" size="xs" className="gap-1 text-muted-foreground">
+                  Limit {maxRows.toLocaleString()}
+                  <ChevronDown />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="start" className="w-36">
+              <DropdownMenuRadioGroup
+                value={String(maxRows)}
+                onValueChange={(value) => setMaxRows(Number(value))}
+              >
+                {ROW_LIMITS.map((n) => (
+                  <DropdownMenuRadioItem key={n} value={String(n)}>
+                    {n.toLocaleString()} rows
+                  </DropdownMenuRadioItem>
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <span className="ml-auto hidden text-[11px] text-muted-foreground md:inline">
+            {engineHint}
+          </span>
+        </div>
+      </div>
+
+      {/* Results */}
+      <ResultsPanel className="min-h-0 flex-1" result={result} error={error} running={running} />
+    </div>
+  )
+}

--- a/live/src/pages/SqlPage.tsx
+++ b/live/src/pages/SqlPage.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router"
-import { ChevronDown, Database, Play, Server } from "lucide-react"
+import { ChevronDown, Cpu, Database, Play, Server } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { Spinner } from "@/components/ui/spinner"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   DropdownMenu,
@@ -14,19 +15,20 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { DocumentPicker } from "@/components/sql/DocumentPicker"
-import { SqlEditor } from "@/components/sql/SqlEditor"
+import { SqlEditor, type SqlCompletion } from "@/components/sql/SqlEditor"
 import { ResultsPanel, type SqlRunError } from "@/components/sql/ResultsPanel"
 import { useDocumentTitle } from "@/hooks/use-document-title"
 import {
   canRunInBrowser,
+  DATABASE_FORMATS,
   deriveTableName,
   formatForPath,
   runSql,
   sanitizeTableName,
   type BoundDoc,
+  type SqlEngineContext,
   type SqlRunResult,
 } from "@/lib/sql-engine"
-import { cn } from "@/lib/utils"
 import { toast } from "@/stores/toast"
 import type { ApiError } from "@/api/client"
 
@@ -46,31 +48,52 @@ export function SqlPage() {
 
   useDocumentTitle("SQL")
 
-  // Pre-bind ?path=... and pre-fill a starter query (once per mount).
+  // Pre-bind ?path=... and pre-fill a starter query (once, after auth resolves).
   const seeded = useRef(false)
   useEffect(() => {
     if (seeded.current) return
-    seeded.current = true
     const raw = searchParams.get("path")
     if (!raw) return
+    if (!orgId || !driveId) return // wait for auth before introspecting
+    seeded.current = true
+
     const path = raw.replace(/^\/+/, "")
     const format = formatForPath(path)
     if (!format) return
-    setDocs((prev) =>
-      prev.some((d) => d.path === path)
-        ? prev
-        : [...prev, { path, table: deriveTableName(path, prev.map((d) => d.table)), format }],
-    )
-    setQuery((q) => q || `SELECT * FROM '/${path}' LIMIT 100`)
-  }, [searchParams])
+    const table = deriveTableName(path, [])
+    const doc: BoundDoc = { path, table, format }
+    setDocs((prev) => (prev.some((d) => d.path === path) ? prev : [...prev, doc]))
 
-  const addDoc = useCallback((rawPath: string) => {
+    if (DATABASE_FORMATS.has(format)) {
+      // SQLite/DuckDB files expose their tables as `<table>.<name>` and can't be
+      // read by path literal — discover the first table and seed a real query.
+      runSql(
+        {
+          query: `SELECT table_name FROM duckdb_tables() WHERE schema_name = '${table}' ORDER BY table_name`,
+          docs: [doc],
+          maxRows: 100,
+        },
+        { client, orgId, driveId },
+      )
+        .then((res) => {
+          const tables = res.rows.map((r) => String(r.table_name))
+          setQuery((q) => q || starterForDatabase(table, tables))
+        })
+        .catch(() => {
+          setQuery((q) => q || `-- ${table} is a database; query its tables as ${table}.<table_name>`)
+        })
+    } else {
+      setQuery((q) => q || `SELECT * FROM '/${path}' LIMIT 100`)
+    }
+  }, [searchParams, client, orgId, driveId])
+
+  const addDoc = useCallback((rawPath: string, size?: number) => {
     const path = rawPath.replace(/^\/+/, "")
     const format = formatForPath(path)
     if (!format) return
     setDocs((prev) => {
       if (prev.some((d) => d.path === path)) return prev
-      return [...prev, { path, table: deriveTableName(path, prev.map((d) => d.table)), format }]
+      return [...prev, { path, table: deriveTableName(path, prev.map((d) => d.table)), format, size }]
     })
   }, [])
 
@@ -90,6 +113,48 @@ export function SqlPage() {
       return prev.map((d) => (d.path === path ? { ...d, table: sanitized } : d))
     })
   }, [])
+
+  // Discovered tables for each bound database doc (keyed by doc path), used for
+  // editor autocompletion of `<schema>.<table>` names.
+  const [dbTables, setDbTables] = useState<Record<string, string[]>>({})
+  useEffect(() => {
+    if (!orgId || !driveId) return
+    const ctx: SqlEngineContext = { client, orgId, driveId }
+    for (const doc of docs) {
+      if (!DATABASE_FORMATS.has(doc.format)) continue
+      if (dbTables[doc.path]) continue
+      runSql(
+        {
+          query: `SELECT table_name FROM duckdb_tables() WHERE schema_name = '${doc.table}' ORDER BY table_name`,
+          docs: [doc],
+          maxRows: 1000,
+        },
+        ctx,
+      )
+        .then((res) => {
+          const tables = res.rows.map((r) => String(r.table_name))
+          setDbTables((prev) => (prev[doc.path] ? prev : { ...prev, [doc.path]: tables }))
+        })
+        .catch(() => {
+          /* introspection is best-effort — autocomplete just omits this db's tables */
+        })
+    }
+  }, [docs, client, orgId, driveId, dbTables])
+
+  const completions = useMemo<SqlCompletion[]>(() => {
+    const out: SqlCompletion[] = []
+    for (const doc of docs) {
+      if (DATABASE_FORMATS.has(doc.format)) {
+        out.push({ label: doc.table, detail: `${doc.format} database`, kind: "schema" })
+        for (const t of dbTables[doc.path] ?? []) {
+          out.push({ label: `${doc.table}.${t}`, detail: `table in ${doc.table}`, kind: "table" })
+        }
+      } else {
+        out.push({ label: doc.table, detail: `${doc.format} · /${doc.path}`, kind: "table" })
+      }
+    }
+    return out
+  }, [docs, dbTables])
 
   const run = useCallback(async () => {
     if (!orgId || !driveId) return
@@ -121,13 +186,22 @@ export function SqlPage() {
   }, [client, orgId, driveId, query, docs, maxRows, forceServer])
 
   const wasmEligible = canRunInBrowser(docs)
+  const runsInBrowser = !forceServer && wasmEligible
+  const effectiveEngine: "browser" | "server" = runsInBrowser ? "browser" : "server"
   const engineHint = forceServer
-    ? "server engine (forced)"
+    ? "Runs on the server (forced)"
     : wasmEligible
-      ? "browser engine (wasm)"
+      ? "Runs in your browser · DuckDB-WASM"
       : docs.length === 0
-        ? "server engine — path literals resolve on the server"
-        : "server engine — xlsx/sqlite/duckdb need the server"
+        ? "Runs on the server · path literals resolve there"
+        : "Runs on the server · xlsx/sqlite/duckdb aren't supported in-browser"
+
+  // Bytes the browser engine will download + parse (known doc sizes only).
+  const browserLoadBytes = runsInBrowser
+    ? docs.reduce((sum, d) => sum + (d.size ?? 0), 0)
+    : 0
+  const browserLoadHint =
+    runsInBrowser && browserLoadBytes > 0 ? ` · loads ~${formatBytes(browserLoadBytes)}` : ""
 
   return (
     <div className="flex h-full min-w-0 flex-col">
@@ -138,28 +212,53 @@ export function SqlPage() {
         <span className="hidden truncate text-xs text-muted-foreground sm:inline">
           Query drive documents with DuckDB
         </span>
-        <div className="ml-auto shrink-0">
+        <div className="ml-auto flex shrink-0 items-center gap-1.5">
           <Tooltip>
             <TooltipTrigger
-              render={
-                <Button
-                  variant={forceServer ? "secondary" : "ghost"}
-                  size="xs"
-                  onClick={() => setForceServer((v) => !v)}
-                  aria-pressed={forceServer}
-                  className={cn("gap-1", !forceServer && "text-muted-foreground")}
-                >
-                  <Server />
-                  Run on server
-                </Button>
-              }
+              render={<span className="cursor-help text-[11px] text-muted-foreground">Engine</span>}
             />
-            <TooltipContent>
-              {forceServer
-                ? "Queries are forced to the server engine"
-                : "Auto: browser (wasm) when every bound document supports it"}
+            <TooltipContent className="max-w-64">
+              Where the query runs. Browser (DuckDB-WASM, no upload) handles
+              csv/tsv/parquet/json; Server handles xlsx/sqlite/duckdb and bare path
+              literals. Pick Server to force it.
             </TooltipContent>
           </Tooltip>
+          <ToggleGroup
+            value={[effectiveEngine]}
+            onValueChange={(v) => {
+              const next = v[0]
+              if (next === "browser") setForceServer(false)
+              else if (next === "server") setForceServer(true)
+            }}
+          >
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <ToggleGroupItem value="browser" disabled={!wasmEligible} aria-label="Run in browser">
+                    <Cpu />
+                  </ToggleGroupItem>
+                }
+              />
+              <TooltipContent className="max-w-56">
+                {wasmEligible
+                  ? "Browser — runs locally with DuckDB-WASM, no upload. Best for csv/tsv/parquet/json."
+                  : "Browser unavailable — xlsx/sqlite/duckdb and path-literal queries must run on the server."}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <ToggleGroupItem value="server" aria-label="Run on server">
+                    <Server />
+                  </ToggleGroupItem>
+                }
+              />
+              <TooltipContent className="max-w-56">
+                Server — runs on the daemon's DuckDB. Required for xlsx/sqlite/duckdb;
+                streams only result rows back.
+              </TooltipContent>
+            </Tooltip>
+          </ToggleGroup>
         </div>
       </div>
 
@@ -171,7 +270,7 @@ export function SqlPage() {
       {/* Editor */}
       <div className="flex h-[38%] min-h-44 shrink-0 flex-col border-b border-border">
         <div className="min-h-0 flex-1">
-          <SqlEditor value={query} onChange={setQuery} onRun={run} />
+          <SqlEditor value={query} onChange={setQuery} onRun={run} completions={completions} />
         </div>
         <div className="flex h-9 shrink-0 items-center gap-2 border-t border-border px-2">
           <Button size="xs" onClick={run} disabled={running} className="gap-1.5">
@@ -209,8 +308,8 @@ export function SqlPage() {
             </DropdownMenuContent>
           </DropdownMenu>
 
-          <span className="ml-auto hidden text-[11px] text-muted-foreground md:inline">
-            {engineHint}
+          <span className="ml-auto truncate text-[11px] text-muted-foreground">
+            {engineHint}{browserLoadHint}
           </span>
         </div>
       </div>
@@ -219,4 +318,19 @@ export function SqlPage() {
       <ResultsPanel className="min-h-0 flex-1" result={result} error={error} running={running} />
     </div>
   )
+}
+
+/** Build a starter query for a bound database, selecting from its first table. */
+function starterForDatabase(table: string, tables: string[]): string {
+  if (tables.length === 0) return `-- ${table} has no tables`
+  const list = tables.map((t) => `${table}.${t}`).join(", ")
+  return `-- tables: ${list}\nSELECT * FROM ${table}.${tables[0]} LIMIT 100`
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B"
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }

--- a/live/src/pages/SqlPage.tsx
+++ b/live/src/pages/SqlPage.tsx
@@ -156,12 +156,16 @@ export function SqlPage() {
     return out
   }, [docs, dbTables])
 
+  // Monotonic run token: only the most recent run may update results, so a slow
+  // earlier run can't clobber a newer one (rapid re-runs / edited query).
+  const runReqRef = useRef(0)
   const run = useCallback(async () => {
     if (!orgId || !driveId) return
     if (!query.trim()) {
       toast.error("Nothing to run", { description: "Write a query first." })
       return
     }
+    const reqId = ++runReqRef.current
     setRunning(true)
     setError(null)
     try {
@@ -170,8 +174,10 @@ export function SqlPage() {
         { client, orgId, driveId },
         { forceServer },
       )
+      if (runReqRef.current !== reqId) return
       setResult(res)
     } catch (err) {
+      if (runReqRef.current !== reqId) return
       const apiErr = err as Partial<ApiError> & Error
       const next: SqlRunError = {
         message: apiErr.message || "Query failed",
@@ -181,7 +187,7 @@ export function SqlPage() {
       setResult(null)
       toast.error("Query failed", { description: next.message })
     } finally {
-      setRunning(false)
+      if (runReqRef.current === reqId) setRunning(false)
     }
   }, [client, orgId, driveId, query, docs, maxRows, forceServer])
 

--- a/live/vite.config.ts
+++ b/live/vite.config.ts
@@ -10,4 +10,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  optimizeDeps: {
+    // DuckDB-WASM selects its own worker/wasm bundles via ?url imports —
+    // pre-bundling breaks the worker URL resolution.
+    exclude: ["@duckdb/duckdb-wasm"],
+  },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -15,6 +15,7 @@
     "deploy:fly": "fly deploy -a agent-fs-taras"
   },
   "devDependencies": {
+    "@duckdb/node-api": "1.5.3-r.3",
     "bun-types": "^1.2.0",
     "typescript": "^5.7.0",
     "yaml": "^2.8.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.2",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.2"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.9.0",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.9.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "scripts": {
-    "build:npm": "bun build src/index.ts --outfile dist/cli.js --target bun --minify --external sqlite-vec --external node-llama-cpp --external @aws-sdk/client-s3 --external @google/genai --external openai --external commander --external diff --external drizzle-orm --external chonkie --external zod --external @modelcontextprotocol/sdk --external hono --external msgpackr",
+    "build:npm": "bun build src/index.ts --outfile dist/cli.js --target bun --minify --external sqlite-vec --external node-llama-cpp --external @aws-sdk/client-s3 --external @google/genai --external openai --external commander --external diff --external drizzle-orm --external chonkie --external zod --external @modelcontextprotocol/sdk --external hono --external msgpackr --external @duckdb/node-api",
     "prepublishOnly": "bun run build:npm"
   },
   "optionalDependencies": {
@@ -35,22 +35,23 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.1",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.1"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.8.2",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.8.2"
   },
   "dependencies": {
-    "commander": "^14.0.3",
     "@aws-sdk/client-s3": "^3.750.0",
+    "@duckdb/node-api": "1.5.3-r.3",
     "@google/genai": "^1.45.0",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "chonkie": "^0.3.0",
+    "commander": "^14.0.3",
     "diff": "^8.0.3",
     "drizzle-orm": "^0.44.0",
+    "hono": "^4.12.8",
+    "msgpackr": "^1",
     "node-llama-cpp": "^3.17.1",
     "openai": "^6.29.0",
     "sqlite-vec": "^0.1.9",
-    "zod": "^3.24.0",
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "hono": "^4.12.8",
-    "msgpackr": "^1"
+    "zod": "^3.24.0"
   }
 }

--- a/packages/cli/src/__tests__/sql-command.test.ts
+++ b/packages/cli/src/__tests__/sql-command.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { parseTableBinding } from "../commands/sql.js";
+
+describe("parseTableBinding", () => {
+  test("plain name=path", () => {
+    expect(parseTableBinding("sales=/data/sales.csv")).toEqual({
+      name: "sales",
+      value: "/data/sales.csv",
+    });
+  });
+
+  test("format override via :format suffix", () => {
+    expect(parseTableBinding("logs=/raw/data.txt:csv")).toEqual({
+      name: "logs",
+      value: { path: "/raw/data.txt", format: "csv" },
+    });
+    expect(parseTableBinding("app=/backups/dump:sqlite")).toEqual({
+      name: "app",
+      value: { path: "/backups/dump", format: "sqlite" },
+    });
+  });
+
+  test("unknown suffix after colon is kept as part of the path", () => {
+    expect(parseTableBinding("t=/odd/file:v2.csv")).toEqual({
+      name: "t",
+      value: "/odd/file:v2.csv",
+    });
+  });
+
+  test("path may contain = after the first one", () => {
+    expect(parseTableBinding("t=/a/b=c.csv")).toEqual({
+      name: "t",
+      value: "/a/b=c.csv",
+    });
+  });
+
+  test("rejects bindings without a name", () => {
+    expect(() => parseTableBinding("/data/sales.csv")).toThrow(/Invalid --table/);
+    expect(() => parseTableBinding("=x.csv")).toThrow(/Invalid --table/);
+  });
+});

--- a/packages/cli/src/commands/sql.ts
+++ b/packages/cli/src/commands/sql.ts
@@ -1,0 +1,117 @@
+import { Command } from "commander";
+import type { ApiClient } from "../api-client.js";
+import { getConfig, getOpDefinition } from "@/core";
+import { outputResult } from "../formatters.js";
+
+const FORMATS = new Set(["csv", "tsv", "parquet", "xlsx", "json", "ndjson", "sqlite", "duckdb"]);
+
+/**
+ * Parse a `--table name=path[:format]` binding. The trailing `:format` is only
+ * treated as a format override when it matches a known format name, so paths
+ * containing colons keep working.
+ */
+export function parseTableBinding(
+  raw: string
+): { name: string; value: string | { path: string; format: string } } {
+  const eq = raw.indexOf("=");
+  if (eq <= 0) {
+    throw new Error(`Invalid --table binding: ${raw} (expected name=path[:format])`);
+  }
+  const name = raw.slice(0, eq);
+  const rest = raw.slice(eq + 1);
+  const colon = rest.lastIndexOf(":");
+  if (colon > 0) {
+    const maybeFormat = rest.slice(colon + 1).toLowerCase();
+    if (FORMATS.has(maybeFormat)) {
+      return { name, value: { path: rest.slice(0, colon), format: maybeFormat } };
+    }
+  }
+  return { name, value: rest };
+}
+
+export function sqlCommand(
+  program: Command,
+  client: ApiClient,
+  getOrgId: () => string | Promise<string>
+): Command {
+  const cmd = new Command("sql")
+    .description(
+      getOpDefinition("sql")?.description ??
+        "Run a DuckDB SQL query over documents stored in the drive"
+    )
+    .argument("[query]", "SQL query (reads stdin if omitted)")
+    .option(
+      "-t, --table <name=path[:format]>",
+      "Bind a document as a named table (repeatable). Append :format to override detection, e.g. logs=/raw/data.txt:csv",
+      (value: string, prev: string[]) => [...prev, value],
+      [] as string[]
+    )
+    .option("--max-rows <n>", "Max rows to return (default: 1000, max: 10000)")
+    .addHelpText(
+      "after",
+      `
+Examples:
+  agent-fs sql "SELECT * FROM '/data/sales.csv' LIMIT 10"
+  agent-fs sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id" \\
+    -t sales=/data/sales.csv -t tags=/data/tags.parquet
+  agent-fs sql "SELECT * FROM app.users" -t app=/backups/app.db
+  agent-fs sql "SELECT sum(a) FROM logs" -t logs=/raw/data.txt:csv
+  echo "SELECT count(*) FROM '/data/events.ndjson'" | agent-fs sql
+`
+    )
+    .action(async (queryArg: string | undefined, opts: { table: string[]; maxRows?: string }) => {
+      let query = queryArg;
+      if (query === undefined) {
+        if (!process.stdin.isTTY) {
+          query = (await Bun.stdin.text()).trim();
+        }
+        if (!query) {
+          console.error("Error: query required (as argument or via stdin)");
+          process.exit(1);
+        }
+      }
+
+      const params: Record<string, any> = { query };
+
+      if (opts.table.length > 0) {
+        const tables: Record<string, unknown> = {};
+        for (const raw of opts.table) {
+          try {
+            const { name, value } = parseTableBinding(raw);
+            tables[name] = value;
+          } catch (err: any) {
+            console.error(`Error: ${err.message}`);
+            process.exit(1);
+          }
+        }
+        params.tables = tables;
+      }
+
+      if (opts.maxRows !== undefined) {
+        params.maxRows = parseInt(opts.maxRows);
+      }
+
+      try {
+        const orgId = await getOrgId();
+        const driveId = program.opts().drive ?? getConfig().defaultDrive;
+        if (driveId) {
+          params.driveId = driveId;
+        }
+        const result = await client.callOp(orgId, "sql", params);
+        outputResult("sql", result, program.opts().json);
+      } catch (err: any) {
+        if (err?.cause?.code === "ECONNREFUSED" || err?.message?.includes("fetch failed")) {
+          console.error(
+            "Cannot connect to agent-fs daemon.\n" +
+            "Start with: agent-fs daemon start\n" +
+            "Or set AGENT_FS_API_URL to connect to a remote server."
+          );
+          process.exit(1);
+        }
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  return cmd;
+}

--- a/packages/cli/src/formatters.ts
+++ b/packages/cli/src/formatters.ts
@@ -248,6 +248,43 @@ function formatReindex(result: any): string {
   return parts.join(", ");
 }
 
+const SQL_CELL_MAX = 80;
+
+function formatSqlCell(v: unknown): string {
+  let s: string;
+  if (v === null || v === undefined) s = "NULL";
+  else if (typeof v === "object") s = JSON.stringify(v);
+  else s = String(v);
+  s = s.replace(/\s+/g, " ");
+  return s.length > SQL_CELL_MAX ? s.slice(0, SQL_CELL_MAX - 1) + "…" : s;
+}
+
+function formatSql(result: any): string {
+  const columns: any[] = result.columns ?? [];
+  const rows: any[] = result.rows ?? [];
+
+  const lines: string[] = [];
+  if (columns.length > 0) {
+    const names = columns.map((c: any) => String(c.name));
+    const cells = rows.map((row: any) => names.map((n) => formatSqlCell(row[n])));
+    const widths = names.map((n, i) =>
+      Math.max(n.length, ...cells.map((r) => r[i].length))
+    );
+    lines.push(names.map((n, i) => padRight(n, widths[i])).join("  "));
+    lines.push(widths.map((w) => "-".repeat(w)).join("  "));
+    for (const row of cells) {
+      lines.push(row.map((c, i) => padRight(c, widths[i])).join("  "));
+    }
+  }
+
+  let footer = `${result.rowCount ?? rows.length} row${rows.length !== 1 ? "s" : ""}`;
+  if (result.elapsedMs != null) footer += ` in ${result.elapsedMs}ms`;
+  if (result.truncated) footer += " (truncated — raise --max-rows to fetch more)";
+  if (lines.length > 0) lines.push("");
+  lines.push(footer);
+  return lines.join("\n");
+}
+
 function formatSignedUrl(result: any): string {
   let out = `${result.url}\n\nExpires: ${formatDate(result.expiresAt)} (${result.expiresIn}s)`;
   if (result.appUrl) out += `\nApp:     ${result.appUrl}`;
@@ -278,6 +315,7 @@ const formatters: Record<string, (result: any) => string> = {
   revert: formatRevert,
   recent: formatRecent,
   reindex: formatReindex,
+  sql: formatSql,
   "signed-url": formatSignedUrl,
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import { memberCommands } from "./commands/member.js";
 import { docsCommand } from "./commands/docs.js";
 import { mountCommand, umountCommand } from "./commands/mount.js";
 import { downloadCommand } from "./commands/download.js";
+import { sqlCommand } from "./commands/sql.js";
 
 const program = new Command();
 
@@ -77,6 +78,7 @@ async function getDriveId(orgId?: string): Promise<string> {
 program.addCommand(docsCommand());
 registerOpCommands(program, client, getOrgId, getDriveId);
 program.addCommand(downloadCommand(client, getOrgId, getDriveId));
+program.addCommand(sqlCommand(program, client, getOrgId));
 program.addCommand(authCommands(client));
 program.addCommand(daemonCommands());
 program.addCommand(configCommands());

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",
     "@aws-sdk/s3-request-presigner": "^3.750.0",
+    "@duckdb/node-api": "1.5.3-r.3",
     "@google/genai": "^1.45.0",
     "chonkie": "^0.3.0",
     "diff": "^8.0.3",

--- a/packages/core/src/identity/rbac.ts
+++ b/packages/core/src/identity/rbac.ts
@@ -26,6 +26,7 @@ const OP_ROLES: Record<string, Role> = {
   recent: "viewer",
   tree: "viewer",
   glob: "viewer",
+  sql: "viewer",
   "signed-url": "viewer",
   write: "editor",
   edit: "editor",

--- a/packages/core/src/ops/__tests__/mime.test.ts
+++ b/packages/core/src/ops/__tests__/mime.test.ts
@@ -48,9 +48,15 @@ describe("detectMimeType", () => {
 
   // Unknown extensions
   it("returns octet-stream for unknown extensions", () => {
-    expect(detectMimeType("data.parquet")).toBe("application/octet-stream");
     expect(detectMimeType("model.onnx")).toBe("application/octet-stream");
     expect(detectMimeType("file.xyz")).toBe("application/octet-stream");
+  });
+
+  it("detects data file types", () => {
+    expect(detectMimeType("data.parquet")).toBe("application/vnd.apache.parquet");
+    expect(detectMimeType("data.tsv")).toBe("text/tab-separated-values");
+    expect(detectMimeType("app.db")).toBe("application/vnd.sqlite3");
+    expect(detectMimeType("rows.ndjson")).toBe("application/x-ndjson");
   });
 
   // Empty/edge cases

--- a/packages/core/src/ops/__tests__/ops.test.ts
+++ b/packages/core/src/ops/__tests__/ops.test.ts
@@ -328,7 +328,7 @@ describe.skipIf(SKIP)("recent", () => {
 describe.skipIf(SKIP)("op registry", () => {
   test("all ops are registered", () => {
     const ops = getRegisteredOps();
-    expect(ops.length).toBe(26);
+    expect(ops.length).toBe(29);
     expect(ops).toContain("write");
     expect(ops).toContain("cat");
     expect(ops).toContain("edit");
@@ -339,6 +339,7 @@ describe.skipIf(SKIP)("op registry", () => {
     expect(ops).toContain("reindex");
     expect(ops).toContain("tree");
     expect(ops).toContain("glob");
+    expect(ops).toContain("sql");
   });
 
   test("dispatchOp validates and dispatches", async () => {

--- a/packages/core/src/ops/__tests__/registry.test.ts
+++ b/packages/core/src/ops/__tests__/registry.test.ts
@@ -5,13 +5,13 @@ describe("Op Registry", () => {
   const expectedOps = [
     "write", "cat", "edit", "append", "ls", "stat", "rm", "mv", "cp",
     "tail", "log", "diff", "revert", "recent",
-    "grep", "fts", "search", "vec-search", "reindex", "tree", "glob", "signed-url",
+    "grep", "fts", "search", "vec-search", "reindex", "tree", "glob", "sql", "signed-url",
     "comment-add", "comment-list", "comment-get", "comment-update", "comment-delete", "comment-resolve",
   ];
 
-  test("getRegisteredOps returns all 28 ops", () => {
+  test("getRegisteredOps returns all 29 ops", () => {
     const ops = getRegisteredOps();
-    expect(ops.length).toBe(28);
+    expect(ops.length).toBe(29);
     for (const op of expectedOps) {
       expect(ops).toContain(op);
     }

--- a/packages/core/src/ops/__tests__/sql.test.ts
+++ b/packages/core/src/ops/__tests__/sql.test.ts
@@ -324,4 +324,34 @@ describe("sql op", () => {
     });
     expect(result.rows).toEqual([{ n: 3 }]);
   });
+
+  test("a bound path used as a value (not a table) is not rewritten", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    // '/data/sales.csv' appears in both FROM (table) and WHERE (value) position.
+    // Only the FROM occurrence must become the table; the predicate stays a string.
+    const result = await sql(ctx, {
+      query:
+        "SELECT count(*) AS n FROM '/data/sales.csv' WHERE name <> '/data/sales.csv'",
+    });
+    expect(result.rows).toEqual([{ n: 3 }]);
+  });
+
+  test("gzip suffix is honored even when the format is overridden", async () => {
+    const { ctx } = createTestContext();
+    const gz = Bun.gzipSync(new TextEncoder().encode("a,b\n1,2\n3,4\n"));
+    await writeRaw(ctx, { path: "/d/log.txt.gz", bytes: new Uint8Array(gz) });
+    const result = await sql(ctx, {
+      query: "SELECT sum(a) AS s FROM t",
+      tables: { t: { path: "/d/log.txt.gz", format: "csv" } },
+    });
+    expect(result.rows).toEqual([{ s: 4 }]);
+  });
+
+  test("duplicate result columns are preserved (uniquified)", async () => {
+    const { ctx } = createTestContext();
+    const result = await sql(ctx, { query: "SELECT 1 AS id, 2 AS id" });
+    expect(result.columns.map((c) => c.name)).toEqual(["id", "id_2"]);
+    expect(result.rows).toEqual([{ id: 1, id_2: 2 }]);
+  });
 });

--- a/packages/core/src/ops/__tests__/sql.test.ts
+++ b/packages/core/src/ops/__tests__/sql.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { createTestContext } from "../../test-utils.js";
+import { write, writeRaw } from "../write.js";
+import { sql, detectSqlFormat } from "../sql.js";
+import type { OpContext } from "../types.js";
+
+const CSV = "id,name,amount\n1,alpha,10.5\n2,beta,20.25\n3,gamma,30\n";
+
+async function seedCsv(ctx: OpContext, path = "/data/sales.csv") {
+  await write(ctx, { path, content: CSV });
+  return path;
+}
+
+/** Build binary fixtures (parquet, xlsx, sqlite) in a local temp dir. */
+async function makeBinaryFixtures(): Promise<{
+  parquet: Uint8Array;
+  xlsx: Uint8Array;
+  sqlite: Uint8Array;
+  cleanup: () => void;
+}> {
+  const dir = mkdtempSync(join(tmpdir(), "agent-fs-sql-fixtures-"));
+  const { DuckDBInstance } = await import("@duckdb/node-api");
+  const instance = await DuckDBInstance.create(":memory:");
+  const conn = await instance.connect();
+  await conn.run(
+    `COPY (SELECT * FROM (VALUES (1, 'aa'), (2, 'bb'), (3, 'cc')) t(id, tag)) TO '${dir}/f.parquet' (FORMAT parquet)`
+  );
+  await conn.run("INSTALL excel");
+  await conn.run("LOAD excel");
+  await conn.run(
+    `COPY (SELECT * FROM (VALUES (1, 'x'), (2, 'y')) t(num, label)) TO '${dir}/f.xlsx' WITH (FORMAT xlsx, HEADER true)`
+  );
+  conn.closeSync();
+  instance.closeSync();
+
+  const db = new Database(join(dir, "f.db"));
+  db.run("CREATE TABLE users (id INTEGER, email TEXT)");
+  db.run("INSERT INTO users VALUES (1,'a@x.com'),(2,'b@x.com')");
+  db.run("CREATE TABLE tags (id INTEGER, tag TEXT)");
+  db.run("INSERT INTO tags VALUES (1,'red')");
+  db.close();
+
+  return {
+    parquet: new Uint8Array(readFileSync(join(dir, "f.parquet"))),
+    xlsx: new Uint8Array(readFileSync(join(dir, "f.xlsx"))),
+    sqlite: new Uint8Array(readFileSync(join(dir, "f.db"))),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("detectSqlFormat", () => {
+  test("maps extensions to formats", () => {
+    expect(detectSqlFormat("/a/b.csv")).toEqual({ format: "csv", gzip: false });
+    expect(detectSqlFormat("/a/b.CSV")).toEqual({ format: "csv", gzip: false });
+    expect(detectSqlFormat("/a/b.tsv")).toEqual({ format: "tsv", gzip: false });
+    expect(detectSqlFormat("/a/b.parquet")).toEqual({ format: "parquet", gzip: false });
+    expect(detectSqlFormat("/a/b.xlsx")).toEqual({ format: "xlsx", gzip: false });
+    expect(detectSqlFormat("/a/b.jsonl")).toEqual({ format: "ndjson", gzip: false });
+    expect(detectSqlFormat("/a/b.csv.gz")).toEqual({ format: "csv", gzip: true });
+    expect(detectSqlFormat("/a/b.sqlite3")).toEqual({ format: "sqlite", gzip: false });
+    expect(detectSqlFormat("/a/b.duckdb")).toEqual({ format: "duckdb", gzip: false });
+  });
+
+  test("rejects unknown and invalid combinations", () => {
+    expect(detectSqlFormat("/a/b.txt")).toBeNull();
+    expect(detectSqlFormat("/a/noext")).toBeNull();
+    expect(detectSqlFormat("/a/b.parquet.gz")).toBeNull();
+    expect(detectSqlFormat("/a/b.gz")).toBeNull();
+  });
+});
+
+describe("sql op", () => {
+  test("queries a csv referenced by path literal", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+
+    const result = await sql(ctx, {
+      query: "SELECT count(*) AS n, sum(amount) AS total FROM '/data/sales.csv'",
+    });
+    expect(result.rows).toEqual([{ n: 3, total: 60.75 }]);
+    expect(result.columns.map((c) => c.name)).toEqual(["n", "total"]);
+    expect(result.truncated).toBe(false);
+    expect(result.files).toEqual([
+      { table: "doc_1", path: "/data/sales.csv", format: "csv" },
+    ]);
+  });
+
+  test("path literal without leading slash resolves too", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    const result = await sql(ctx, {
+      query: "SELECT name FROM 'data/sales.csv' ORDER BY id LIMIT 1",
+    });
+    expect(result.rows).toEqual([{ name: "alpha" }]);
+  });
+
+  test("named table bindings and cross-format join", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    const fixtures = await makeBinaryFixtures();
+    try {
+      await writeRaw(ctx, { path: "/data/tags.parquet", bytes: fixtures.parquet });
+      const result = await sql(ctx, {
+        query:
+          "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id ORDER BY s.id",
+        tables: { sales: "/data/sales.csv", tags: "/data/tags.parquet" },
+      });
+      expect(result.rows).toEqual([
+        { name: "alpha", tag: "aa" },
+        { name: "beta", tag: "bb" },
+        { name: "gamma", tag: "cc" },
+      ]);
+    } finally {
+      fixtures.cleanup();
+    }
+  });
+
+  test("tsv, json and ndjson formats", async () => {
+    const { ctx } = createTestContext();
+    await write(ctx, { path: "/d/x.tsv", content: "id\tname\n1\taa\n2\tbb\n" });
+    await write(ctx, { path: "/d/x.json", content: '[{"id":1},{"id":2},{"id":3}]' });
+    await write(ctx, { path: "/d/x.ndjson", content: '{"id":1}\n{"id":2}\n' });
+
+    const tsv = await sql(ctx, { query: "SELECT count(*) AS n FROM '/d/x.tsv'" });
+    expect(tsv.rows).toEqual([{ n: 2 }]);
+    const json = await sql(ctx, { query: "SELECT count(*) AS n FROM '/d/x.json'" });
+    expect(json.rows).toEqual([{ n: 3 }]);
+    const ndjson = await sql(ctx, { query: "SELECT count(*) AS n FROM '/d/x.ndjson'" });
+    expect(ndjson.rows).toEqual([{ n: 2 }]);
+  });
+
+  test("xlsx via excel extension", async () => {
+    const { ctx } = createTestContext();
+    const fixtures = await makeBinaryFixtures();
+    try {
+      await writeRaw(ctx, { path: "/d/report.xlsx", bytes: fixtures.xlsx });
+      const result = await sql(ctx, {
+        query: "SELECT * FROM '/d/report.xlsx' ORDER BY num",
+      });
+      expect(result.rows).toEqual([
+        { num: 1, label: "x" },
+        { num: 2, label: "y" },
+      ]);
+    } finally {
+      fixtures.cleanup();
+    }
+  });
+
+  test("sqlite database exposes tables under the binding name", async () => {
+    const { ctx } = createTestContext();
+    const fixtures = await makeBinaryFixtures();
+    try {
+      await writeRaw(ctx, { path: "/d/app.db", bytes: fixtures.sqlite });
+      const result = await sql(ctx, {
+        query:
+          "SELECT u.email, t.tag FROM app.users u LEFT JOIN app.tags t ON u.id = t.id ORDER BY u.id",
+        tables: { app: "/d/app.db" },
+      });
+      expect(result.rows).toEqual([
+        { email: "a@x.com", tag: "red" },
+        { email: "b@x.com", tag: null },
+      ]);
+    } finally {
+      fixtures.cleanup();
+    }
+  });
+
+  test("format override makes a .txt document queryable", async () => {
+    const { ctx } = createTestContext();
+    await write(ctx, { path: "/logs/data.txt", content: "a,b\n1,2\n3,4\n" });
+    const result = await sql(ctx, {
+      query: "SELECT sum(a) AS s FROM logs",
+      tables: { logs: { path: "/logs/data.txt", format: "csv" } },
+    });
+    expect(result.rows).toEqual([{ s: 4 }]);
+  });
+
+  test("gzipped csv", async () => {
+    const { ctx } = createTestContext();
+    const gz = Bun.gzipSync(new TextEncoder().encode(CSV));
+    await writeRaw(ctx, { path: "/d/sales.csv.gz", bytes: new Uint8Array(gz) });
+    const result = await sql(ctx, {
+      query: "SELECT count(*) AS n FROM '/d/sales.csv.gz'",
+    });
+    expect(result.rows).toEqual([{ n: 3 }]);
+  });
+
+  test("maxRows truncation", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    const result = await sql(ctx, {
+      query: "SELECT * FROM '/data/sales.csv'",
+      maxRows: 2,
+    });
+    expect(result.rowCount).toBe(2);
+    expect(result.rows).toHaveLength(2);
+    expect(result.truncated).toBe(true);
+  });
+
+  test("queries without any document references work", async () => {
+    const { ctx } = createTestContext();
+    const result = await sql(ctx, { query: "SELECT 1 + 1 AS two" });
+    expect(result.rows).toEqual([{ two: 2 }]);
+    expect(result.files).toEqual([]);
+  });
+
+  test("multi-statement queries return the last result", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    const result = await sql(ctx, {
+      query:
+        "CREATE TABLE top AS SELECT * FROM '/data/sales.csv' WHERE amount > 15; SELECT count(*) AS n FROM top",
+    });
+    expect(result.rows).toEqual([{ n: 2 }]);
+  });
+
+  test("value conversion: bigint, decimal, timestamp, list, struct, blob", async () => {
+    const { ctx } = createTestContext();
+    const result = await sql(ctx, {
+      query:
+        "SELECT 9007199254740993::BIGINT AS big, 42::BIGINT AS small, 1.5::DECIMAL(10,2) AS dec, " +
+        "TIMESTAMP '2024-01-01 12:00:00' AS ts, [1,2] AS lst, {'a': 1} AS st, 'x'::BLOB AS blb",
+    });
+    const row = result.rows[0];
+    expect(row.big).toBe("9007199254740993");
+    expect(row.small).toBe(42);
+    expect(row.dec).toBe(1.5);
+    expect(row.ts).toBe("2024-01-01 12:00:00");
+    expect(row.lst).toEqual([1, 2]);
+    expect(row.st).toEqual({ a: 1 });
+    expect(String(row.blb)).toContain("blob");
+  });
+
+  test("binding a missing file throws NotFound", async () => {
+    const { ctx } = createTestContext();
+    await expect(
+      sql(ctx, { query: "SELECT * FROM x", tables: { x: "/nope.csv" } })
+    ).rejects.toThrow(/File not found/);
+  });
+
+  test("invalid table names are rejected", async () => {
+    const { ctx } = createTestContext();
+    await expect(
+      sql(ctx, { query: "SELECT 1", tables: { "bad-name": "/a.csv" } })
+    ).rejects.toThrow(/Invalid table name/);
+  });
+
+  test("sandbox: local filesystem reads are blocked", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    await expect(
+      sql(ctx, { query: "SELECT * FROM read_csv('/etc/passwd')" })
+    ).rejects.toThrow(/disabled|access/i);
+  });
+
+  test("sandbox: COPY out is blocked", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    await expect(
+      sql(ctx, {
+        query: "COPY (SELECT * FROM '/data/sales.csv') TO '/tmp/exfil.csv'",
+      })
+    ).rejects.toThrow(/disabled|access/i);
+  });
+
+  test("sandbox: configuration cannot be unlocked", async () => {
+    const { ctx } = createTestContext();
+    await expect(
+      sql(ctx, { query: "SET enable_external_access=true; SELECT 1" })
+    ).rejects.toThrow(/locked/i);
+  });
+
+  test("sandbox: sqlite escape via ATTACH is blocked even when sqlite docs are bound", async () => {
+    const { ctx } = createTestContext();
+    const fixtures = await makeBinaryFixtures();
+    try {
+      await writeRaw(ctx, { path: "/d/app.db", bytes: fixtures.sqlite });
+      // The bound sqlite doc works, but the executing instance never loads the
+      // sqlite extension, so attaching arbitrary host paths must fail.
+      await expect(
+        sql(ctx, {
+          query: "ATTACH '/tmp/whatever.db' AS evil (TYPE sqlite); SELECT 1",
+          tables: { app: "/d/app.db" },
+        })
+      ).rejects.toThrow();
+      await expect(
+        sql(ctx, {
+          query: "SELECT * FROM sqlite_scan('/tmp/whatever.db', 'x')",
+          tables: { app: "/d/app.db" },
+        })
+      ).rejects.toThrow();
+    } finally {
+      fixtures.cleanup();
+    }
+  });
+
+  test("sandbox: http(s) reads are blocked", async () => {
+    const { ctx } = createTestContext();
+    await expect(
+      sql(ctx, { query: "SELECT * FROM read_csv('https://example.com/x.csv')" })
+    ).rejects.toThrow();
+  });
+
+  test("unknown path literals are left alone and fail with a helpful suggestion", async () => {
+    const { ctx } = createTestContext();
+    try {
+      await sql(ctx, { query: "SELECT * FROM '/missing/file.csv'" });
+      throw new Error("expected sql to throw");
+    } catch (err: any) {
+      expect(err.message).toMatch(/disabled|access/i);
+      expect(err.suggestion).toMatch(/drive path/i);
+    }
+  });
+
+  test("string literals that are not documents stay untouched", async () => {
+    const { ctx } = createTestContext();
+    await seedCsv(ctx);
+    const result = await sql(ctx, {
+      query: "SELECT count(*) AS n FROM '/data/sales.csv' WHERE name <> 'other.csv'",
+    });
+    expect(result.rows).toEqual([{ n: 3 }]);
+  });
+});

--- a/packages/core/src/ops/index.ts
+++ b/packages/core/src/ops/index.ts
@@ -22,6 +22,7 @@ import { search } from "./search.js";
 import { reindex } from "./reindex.js";
 import { tree } from "./tree.js";
 import { glob } from "./glob.js";
+import { sql } from "./sql.js";
 import { signedUrl } from "./signed-url.js";
 import { buildAppUrl } from "./urls.js";
 import {
@@ -215,6 +216,27 @@ const opRegistry: Record<string, OpDefinition> = {
       path: z.string().optional(),
     }),
   },
+  sql: {
+    description: "Run a DuckDB SQL query over documents stored in the drive. Reference documents directly by path string literal (e.g. SELECT * FROM '/data/sales.csv') or bind them as named tables via `tables` ({ name: path } or { name: { path, format } } to override format detection). Supports csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also .gz except parquet/xlsx), sqlite (.db/.sqlite/.sqlite3, tables exposed as name.tablename), and .duckdb files. Queries run sandboxed: no filesystem or network access beyond the bound documents. Returns { columns, rows, rowCount, truncated, files, elapsedMs }.",
+    handler: sql,
+    schema: z.object({
+      query: z.string(),
+      tables: z
+        .record(
+          z.union([
+            z.string(),
+            z.object({
+              path: z.string(),
+              format: z
+                .enum(["csv", "tsv", "parquet", "xlsx", "json", "ndjson", "sqlite", "duckdb"])
+                .optional(),
+            }),
+          ])
+        )
+        .optional(),
+      maxRows: z.number().int().min(1).max(10000).optional(),
+    }),
+  },
   "signed-url": {
     description: "Generate a temporary presigned URL for direct file download. Default expiry is 24 hours (86400 seconds). The URL requires no authentication. Returns { url, path, expiresIn, expiresAt }.",
     handler: signedUrl,
@@ -324,5 +346,5 @@ export function getOpDefinition(name: string): OpDefinition | undefined {
 }
 
 // Re-export individual ops for direct use
-export { write, writeRaw, cat, edit, append, ls, stat, rm, mv, cp, tail, log, diff, revert, recent, grep, fts, search, vecSearch, reindex, tree, glob, signedUrl, commentAdd, commentList, commentGet, commentUpdate, commentDelete, commentResolve };
+export { write, writeRaw, cat, edit, append, ls, stat, rm, mv, cp, tail, log, diff, revert, recent, grep, fts, search, vecSearch, reindex, tree, glob, sql, signedUrl, commentAdd, commentList, commentGet, commentUpdate, commentDelete, commentResolve };
 export type * from "./types.js";

--- a/packages/core/src/ops/mime.ts
+++ b/packages/core/src/ops/mime.ts
@@ -16,8 +16,11 @@ const MIME_MAP: Record<string, string> = {
   html: "text/html",
   css: "text/css",
   csv: "text/csv",
+  tsv: "text/tab-separated-values",
   xml: "application/xml",
   json: "application/json",
+  jsonl: "application/x-ndjson",
+  ndjson: "application/x-ndjson",
   yaml: "application/x-yaml",
   yml: "application/x-yaml",
   toml: "application/toml",
@@ -38,6 +41,12 @@ const MIME_MAP: Record<string, string> = {
   sh: "text/x-shellscript",
   sql: "text/x-sql",
   graphql: "text/x-graphql",
+  // Data files
+  parquet: "application/vnd.apache.parquet",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  db: "application/vnd.sqlite3",
+  sqlite: "application/vnd.sqlite3",
+  sqlite3: "application/vnd.sqlite3",
   // Archives
   zip: "application/zip",
   tar: "application/x-tar",
@@ -54,6 +63,7 @@ export function isIndexableMimeType(contentType: string): boolean {
   return (
     normalized.startsWith("text/") ||
     normalized === "application/json" ||
+    normalized === "application/x-ndjson" ||
     normalized === "application/xml" ||
     normalized === "application/x-yaml" ||
     normalized === "application/toml" ||

--- a/packages/core/src/ops/sql.ts
+++ b/packages/core/src/ops/sql.ts
@@ -322,20 +322,25 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
   let tempDir: string | null = null;
   let instance: Awaited<ReturnType<typeof DuckDBInstance.create>> | null = null;
   let conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>> | null = null;
+  // The bridge runs on its own connection; track it so the deadline can
+  // interrupt an in-flight sqlite -> parquet COPY too.
+  let bridgeConn: { interrupt: () => void } | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   // Arm the deadline before any work so it covers the whole operation —
   // downloads, extension loads, the sqlite bridge, and materialization — not
-  // just the final query. Interrupting the connection stops in-flight DuckDB
-  // work; the boundary checks below stop between phases (e.g. during S3 I/O,
-  // where there is no connection to interrupt).
+  // just the final query. Interrupting the active connection stops in-flight
+  // DuckDB work; the boundary checks below stop between phases (e.g. during S3
+  // I/O, where there is no connection to interrupt).
   let timedOut = false;
   timer = setTimeout(() => {
     timedOut = true;
-    try {
-      conn?.interrupt();
-    } catch {
-      // ignore — not connected yet, or already closed
+    for (const c of [conn, bridgeConn]) {
+      try {
+        c?.interrupt();
+      } catch {
+        // ignore — not connected yet, or already closed
+      }
     }
   }, timeoutMs);
   const checkTimeout = () => {
@@ -386,7 +391,10 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
         DuckDBInstance,
         sqliteBindings,
         tempDir,
-        checkTimeout
+        checkTimeout,
+        (c) => {
+          bridgeConn = c;
+        }
       );
     }
     checkTimeout();
@@ -542,11 +550,13 @@ async function bridgeSqliteToParquet(
   DuckDBInstance: typeof import("@duckdb/node-api").DuckDBInstance,
   bindings: Binding[],
   tempDir: string,
-  checkTimeout: () => void
+  checkTimeout: () => void,
+  registerConn: (conn: { interrupt: () => void } | null) => void
 ): Promise<Map<string, Array<{ table: string; parquetFile: string }>>> {
   const result = new Map<string, Array<{ table: string; parquetFile: string }>>();
   const bridge = await DuckDBInstance.create(":memory:");
   const conn = await bridge.connect();
+  registerConn(conn);
   try {
     await conn.run("INSTALL sqlite");
     await conn.run("LOAD sqlite");
@@ -575,11 +585,15 @@ async function bridgeSqliteToParquet(
         await conn.run("DETACH src");
       } catch (err: unknown) {
         if (err instanceof ValidationError) throw err;
+        // A timeout interrupt surfaces as a clean timeout error.
+        checkTimeout();
         const message = err instanceof Error ? err.message : String(err);
         throw new ValidationError(`Failed to load ${b.path} as sqlite: ${message}`);
       }
     }
   } finally {
+    // Stop the deadline from touching a connection we're about to close.
+    registerConn(null);
     try {
       conn.closeSync();
     } catch {

--- a/packages/core/src/ops/sql.ts
+++ b/packages/core/src/ops/sql.ts
@@ -1,0 +1,546 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq, and } from "drizzle-orm";
+import { schema } from "../db/index.js";
+import type {
+  OpContext,
+  SqlParams,
+  SqlResult,
+  SqlColumn,
+  SqlBoundFile,
+  SqlFormat,
+} from "./types.js";
+import { getS3Key } from "./versioning.js";
+import { normalizePath } from "./paths.js";
+import { NotFoundError, ValidationError } from "../errors.js";
+
+const DEFAULT_MAX_ROWS = 1000;
+
+const EXT_FORMATS: Record<string, SqlFormat> = {
+  csv: "csv",
+  tsv: "tsv",
+  tab: "tsv",
+  parquet: "parquet",
+  xlsx: "xlsx",
+  json: "json",
+  jsonl: "ndjson",
+  ndjson: "ndjson",
+  db: "sqlite",
+  sqlite: "sqlite",
+  sqlite3: "sqlite",
+  duckdb: "duckdb",
+};
+
+/** Formats DuckDB reads as plain files (referenceable as path literals in FROM). */
+const FILE_FORMATS = new Set<SqlFormat>(["csv", "tsv", "parquet", "xlsx", "json", "ndjson"]);
+/** Text formats DuckDB transparently decompresses when the file ends in .gz. */
+const GZIPPABLE = new Set<SqlFormat>(["csv", "tsv", "json", "ndjson"]);
+
+const LOCAL_EXT: Record<SqlFormat, string> = {
+  csv: ".csv",
+  tsv: ".tsv",
+  parquet: ".parquet",
+  xlsx: ".xlsx",
+  json: ".json",
+  ndjson: ".ndjson",
+  sqlite: ".db",
+  duckdb: ".duckdb",
+};
+
+export function detectSqlFormat(
+  path: string
+): { format: SqlFormat; gzip: boolean } | null {
+  const name = path.toLowerCase().split("/").pop() ?? "";
+  const parts = name.split(".");
+  if (parts.length < 2) return null;
+  let gzip = false;
+  let ext = parts.pop()!;
+  if (ext === "gz" && parts.length >= 2) {
+    gzip = true;
+    ext = parts.pop()!;
+  }
+  const format = EXT_FORMATS[ext];
+  if (!format) return null;
+  if (gzip && !GZIPPABLE.has(format)) return null;
+  return { format, gzip };
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function memoryLimit(): string {
+  const raw = process.env.AGENT_FS_SQL_MEMORY_LIMIT?.trim();
+  if (raw && /^[0-9]+(\.[0-9]+)?\s*(B|KB|MB|GB|TB|KiB|MiB|GiB)?$/i.test(raw)) {
+    return raw;
+  }
+  return "512MB";
+}
+
+/** SQL single-quoted string literal (paths we generate never contain quotes, but escape anyway). */
+function lit(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+/** SQL double-quoted identifier. */
+function qid(s: string): string {
+  return `"${s.replace(/"/g, '""')}"`;
+}
+
+function readerExpr(format: SqlFormat, filePath: string): string {
+  switch (format) {
+    case "csv":
+      return `read_csv(${lit(filePath)})`;
+    case "tsv":
+      return `read_csv(${lit(filePath)}, delim=E'\\t')`;
+    case "parquet":
+      return `read_parquet(${lit(filePath)})`;
+    case "json":
+    case "ndjson":
+      return `read_json_auto(${lit(filePath)})`;
+    case "xlsx":
+      return `read_xlsx(${lit(filePath)})`;
+    default:
+      throw new ValidationError(`Format ${format} is not file-readable`);
+  }
+}
+
+interface Binding {
+  table: string;
+  path: string;
+  format: SqlFormat;
+  gzip: boolean;
+  /** Exact quoted literal in the query to substitute with the table identifier. */
+  literal?: string;
+  localFile?: string;
+  size: number;
+}
+
+const TABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+// Quoted literal whose content has a queryable file extension, e.g. '/data/sales.csv'
+const PATH_LITERAL_RE = /'([^']+\.[A-Za-z0-9]+(?:\.gz)?)'/g;
+
+function findFile(
+  ctx: OpContext,
+  path: string
+): { path: string; size: number } | null {
+  const row = ctx.db
+    .select({ path: schema.files.path, size: schema.files.size })
+    .from(schema.files)
+    .where(
+      and(
+        eq(schema.files.driveId, ctx.driveId),
+        eq(schema.files.path, path),
+        eq(schema.files.isDeleted, false)
+      )
+    )
+    .get();
+  return row ?? null;
+}
+
+function collectBindings(ctx: OpContext, params: SqlParams): Binding[] {
+  const bindings: Binding[] = [];
+  const usedNames = new Set<string>();
+
+  for (const [name, value] of Object.entries(params.tables ?? {})) {
+    if (!TABLE_NAME_RE.test(name)) {
+      throw new ValidationError(`Invalid table name: ${name}`, {
+        field: "tables",
+        suggestion: "Table names must match [A-Za-z_][A-Za-z0-9_]*",
+      });
+    }
+    if (usedNames.has(name.toLowerCase())) {
+      throw new ValidationError(`Duplicate table name: ${name}`, { field: "tables" });
+    }
+    usedNames.add(name.toLowerCase());
+
+    const path = normalizePath(typeof value === "string" ? value : value.path);
+    const explicitFormat = typeof value === "string" ? undefined : value.format;
+    const detected = detectSqlFormat(path);
+    const format = explicitFormat ?? detected?.format;
+    if (!format) {
+      throw new ValidationError(
+        `Cannot infer format for ${path}`,
+        {
+          field: "tables",
+          suggestion:
+            "Pass an explicit format: { path, format: \"csv\" | \"tsv\" | \"parquet\" | \"xlsx\" | \"json\" | \"ndjson\" | \"sqlite\" | \"duckdb\" }",
+        }
+      );
+    }
+
+    const file = findFile(ctx, path);
+    if (!file) {
+      throw new NotFoundError(`File not found: ${path}`, { path });
+    }
+    bindings.push({
+      table: name,
+      path,
+      format,
+      gzip: explicitFormat ? false : detected?.gzip ?? false,
+      size: file.size,
+    });
+  }
+
+  // Auto-bind quoted drive-path literals like SELECT * FROM '/data/sales.csv'.
+  // Only literals that resolve to an existing document are bound; anything else
+  // is left untouched so plain string values are never misinterpreted.
+  const seenLiterals = new Set<string>();
+  let docIdx = 1;
+  for (const match of params.query.matchAll(PATH_LITERAL_RE)) {
+    const raw = match[1];
+    if (seenLiterals.has(raw)) continue;
+    seenLiterals.add(raw);
+
+    const detected = detectSqlFormat(raw);
+    if (!detected || !FILE_FORMATS.has(detected.format)) continue;
+
+    const path = normalizePath(raw);
+    const file = findFile(ctx, path);
+    if (!file) continue;
+
+    let name = `doc_${docIdx++}`;
+    while (usedNames.has(name)) name = `doc_${docIdx++}`;
+    usedNames.add(name);
+
+    bindings.push({
+      table: name,
+      path,
+      format: detected.format,
+      gzip: detected.gzip,
+      literal: match[0],
+      size: file.size,
+    });
+  }
+
+  return bindings;
+}
+
+/**
+ * Convert DuckDB result values into JSON-safe values:
+ * BIGINT -> number (or string when outside the safe integer range),
+ * DECIMAL -> number, LIST/ARRAY -> array, STRUCT -> object, MAP -> entry list,
+ * BLOB -> placeholder, everything else (timestamps, dates, uuid, ...) -> string.
+ */
+function toJsonValue(v: unknown): unknown {
+  if (v === null || v === undefined) return null;
+  const t = typeof v;
+  if (t === "bigint") {
+    const b = v as bigint;
+    return b >= BigInt(Number.MIN_SAFE_INTEGER) && b <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(b)
+      : b.toString();
+  }
+  if (t === "number" || t === "string" || t === "boolean") return v;
+  if (v instanceof Uint8Array) return `<blob ${v.byteLength} bytes>`;
+  const obj = v as Record<string, unknown>;
+  if (typeof (obj as { toDouble?: unknown }).toDouble === "function") {
+    return (obj as { toDouble: () => number }).toDouble();
+  }
+  if (obj.bytes instanceof Uint8Array) {
+    return `<blob ${obj.bytes.byteLength} bytes>`;
+  }
+  if (Array.isArray(obj.items)) {
+    return obj.items.map(toJsonValue);
+  }
+  if (Array.isArray(obj.entries)) {
+    return obj.entries.map((e: { key: unknown; value: unknown }) => ({
+      key: toJsonValue(e.key),
+      value: toJsonValue(e.value),
+    }));
+  }
+  if (obj.entries && typeof obj.entries === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(obj.entries as Record<string, unknown>)) {
+      out[k] = toJsonValue(val);
+    }
+    return out;
+  }
+  return String(v);
+}
+
+function wrapDuckDbError(err: unknown, timedOut: boolean, timeoutMs: number): ValidationError {
+  if (timedOut) {
+    return new ValidationError(`Query timed out after ${timeoutMs}ms`, {
+      suggestion: "Simplify the query or reduce the amount of data it scans",
+    });
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  if (/disabled by configuration|has been locked|external access/i.test(message)) {
+    return new ValidationError(message, {
+      suggestion:
+        "Queries can only access bound documents. Reference documents by drive path (e.g. FROM '/data/sales.csv') or bind them via `tables` — and check the path exists with `ls`.",
+    });
+  }
+  return new ValidationError(message);
+}
+
+/**
+ * Run a DuckDB SQL query over documents stored in the drive.
+ *
+ * Security model (the hosted API is multitenant, so user SQL is untrusted):
+ * all referenced documents are materialized into in-memory tables during a
+ * setup phase, then the local filesystem is disabled and the configuration is
+ * locked BEFORE any user SQL runs. SQLite databases are converted through a
+ * separate bridge instance because the sqlite extension performs its own file
+ * I/O and bypasses DuckDB's filesystem sandbox — the instance that executes
+ * user SQL never loads it.
+ */
+export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult> {
+  const started = Date.now();
+  const maxRows = params.maxRows ?? DEFAULT_MAX_ROWS;
+  const timeoutMs = envInt("AGENT_FS_SQL_TIMEOUT_MS", 30_000);
+  const maxFileBytes = envInt("AGENT_FS_SQL_MAX_FILE_BYTES", 256 * 1024 * 1024);
+
+  const bindings = collectBindings(ctx, params);
+  for (const b of bindings) {
+    if (b.size > maxFileBytes) {
+      throw new ValidationError(
+        `File too large for SQL: ${b.path} (${b.size} bytes, limit ${maxFileBytes})`,
+        { suggestion: "Raise AGENT_FS_SQL_MAX_FILE_BYTES on the server if needed" }
+      );
+    }
+  }
+
+  const { DuckDBInstance } = await import("@duckdb/node-api");
+
+  let tempDir: string | null = null;
+  let instance: Awaited<ReturnType<typeof DuckDBInstance.create>> | null = null;
+  let conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>> | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  try {
+    // --- Download phase ---
+    if (bindings.length > 0) {
+      tempDir = await mkdtemp(join(tmpdir(), "agent-fs-sql-"));
+      for (let i = 0; i < bindings.length; i++) {
+        const b = bindings[i];
+        const ext = LOCAL_EXT[b.format] + (b.gzip ? ".gz" : "");
+        const localFile = join(tempDir, `t${i}${ext}`);
+        try {
+          const obj = await ctx.s3.getObject(getS3Key(ctx.orgId, ctx.driveId, b.path));
+          await writeFile(localFile, obj.body);
+        } catch (err: unknown) {
+          const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
+          if (e?.name === "NoSuchKey" || e?.$metadata?.httpStatusCode === 404) {
+            throw new NotFoundError(`File not found: ${b.path}`, { path: b.path });
+          }
+          throw err;
+        }
+        b.localFile = localFile;
+      }
+    }
+
+    // --- Setup phase: materialize every binding into in-memory tables ---
+    instance = await DuckDBInstance.create(":memory:");
+    conn = await instance.connect();
+    await conn.run(`SET memory_limit=${lit(memoryLimit())}`);
+
+    if (bindings.some((b) => b.format === "xlsx")) {
+      await conn.run("INSTALL excel");
+      await conn.run("LOAD excel");
+    }
+
+    const sqliteBindings = bindings.filter((b) => b.format === "sqlite");
+    let sqliteTables = new Map<string, Array<{ table: string; parquetFile: string }>>();
+    if (sqliteBindings.length > 0 && tempDir) {
+      sqliteTables = await bridgeSqliteToParquet(DuckDBInstance, sqliteBindings, tempDir);
+    }
+
+    for (const b of bindings) {
+      try {
+        if (b.format === "sqlite") {
+          await conn.run(`CREATE SCHEMA ${qid(b.table)}`);
+          for (const { table, parquetFile } of sqliteTables.get(b.table) ?? []) {
+            await conn.run(
+              `CREATE TABLE ${qid(b.table)}.${qid(table)} AS SELECT * FROM read_parquet(${lit(parquetFile)})`
+            );
+          }
+        } else if (b.format === "duckdb") {
+          const alias = `src_${b.table}`;
+          await conn.run(`ATTACH ${lit(b.localFile!)} AS ${qid(alias)} (READ_ONLY)`);
+          const reader = await conn.runAndReadAll(
+            `SELECT table_name FROM duckdb_tables() WHERE database_name = ${lit(alias)} AND schema_name = 'main'`
+          );
+          const tables = reader
+            .getRowObjectsJson()
+            .map((r) => String(r.table_name));
+          if (tables.length === 0) {
+            throw new ValidationError(`No tables found in ${b.path}`);
+          }
+          await conn.run(`CREATE SCHEMA ${qid(b.table)}`);
+          for (const table of tables) {
+            await conn.run(
+              `CREATE TABLE ${qid(b.table)}.${qid(table)} AS SELECT * FROM ${qid(alias)}.main.${qid(table)}`
+            );
+          }
+          await conn.run(`DETACH ${qid(alias)}`);
+        } else {
+          await conn.run(
+            `CREATE TABLE ${qid(b.table)} AS SELECT * FROM ${readerExpr(b.format, b.localFile!)}`
+          );
+        }
+      } catch (err: unknown) {
+        if (err instanceof ValidationError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ValidationError(`Failed to load ${b.path} as ${b.format}: ${message}`);
+      }
+    }
+
+    // --- Lockdown phase: no file or network access for user SQL ---
+    await conn.run("SET enable_external_access=false");
+    await conn.run("SET disabled_filesystems='LocalFileSystem'");
+    await conn.run("SET lock_configuration=true");
+
+    // Everything is materialized in memory — drop the temp files before
+    // running any user SQL.
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+
+    // --- Query phase ---
+    let query = params.query;
+    for (const b of bindings) {
+      if (b.literal) {
+        query = query.split(b.literal).join(qid(b.table));
+      }
+    }
+
+    let timedOut = false;
+    timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        conn?.interrupt();
+      } catch {
+        // ignore — connection may already be closed
+      }
+    }, timeoutMs);
+
+    try {
+      const extracted = await conn.extractStatements(query);
+      if (extracted.count === 0) {
+        throw new ValidationError("Query contains no statements", { field: "query" });
+      }
+      for (let i = 0; i < extracted.count - 1; i++) {
+        const prepared = await extracted.prepare(i);
+        await prepared.run();
+      }
+      const prepared = await extracted.prepare(extracted.count - 1);
+      const reader = await prepared.runAndReadUntil(maxRows + 1);
+
+      const columnNames = reader.columnNames();
+      const columnTypes = reader.columnTypes();
+      const columns: SqlColumn[] = columnNames.map((name, i) => ({
+        name,
+        type: String(columnTypes[i] ?? "UNKNOWN"),
+      }));
+
+      const raw = reader.getRows();
+      const truncated = raw.length > maxRows || !reader.done;
+      const rows = raw.slice(0, maxRows).map((values) => {
+        const row: Record<string, unknown> = {};
+        for (let i = 0; i < columnNames.length; i++) {
+          row[columnNames[i]] = toJsonValue(values[i]);
+        }
+        return row;
+      });
+
+      const files: SqlBoundFile[] = bindings.map((b) => ({
+        table: b.table,
+        path: b.path,
+        format: b.format,
+      }));
+
+      return {
+        columns,
+        rows,
+        rowCount: rows.length,
+        truncated,
+        files,
+        elapsedMs: Date.now() - started,
+      };
+    } catch (err: unknown) {
+      if (err instanceof ValidationError) throw err;
+      throw wrapDuckDbError(err, timedOut, timeoutMs);
+    }
+  } finally {
+    if (timer) clearTimeout(timer);
+    try {
+      conn?.closeSync();
+    } catch {
+      // ignore
+    }
+    try {
+      instance?.closeSync();
+    } catch {
+      // ignore
+    }
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
+}
+
+/**
+ * Convert each table of the given SQLite databases to Parquet files using a
+ * throwaway DuckDB instance. Returns binding table name -> entries consumed by
+ * the main instance. The bridge instance is the only place the sqlite
+ * extension is ever loaded.
+ */
+async function bridgeSqliteToParquet(
+  DuckDBInstance: typeof import("@duckdb/node-api").DuckDBInstance,
+  bindings: Binding[],
+  tempDir: string
+): Promise<Map<string, Array<{ table: string; parquetFile: string }>>> {
+  const result = new Map<string, Array<{ table: string; parquetFile: string }>>();
+  const bridge = await DuckDBInstance.create(":memory:");
+  const conn = await bridge.connect();
+  try {
+    await conn.run("INSTALL sqlite");
+    await conn.run("LOAD sqlite");
+    for (let i = 0; i < bindings.length; i++) {
+      const b = bindings[i];
+      try {
+        await conn.run(`ATTACH ${lit(b.localFile!)} AS src (TYPE sqlite, READ_ONLY)`);
+        const reader = await conn.runAndReadAll(
+          "SELECT table_name FROM duckdb_tables() WHERE database_name = 'src'"
+        );
+        const tables = reader.getRowObjectsJson().map((r) => String(r.table_name));
+        if (tables.length === 0) {
+          throw new ValidationError(`No tables found in ${b.path}`);
+        }
+        const entries: Array<{ table: string; parquetFile: string }> = [];
+        for (let j = 0; j < tables.length; j++) {
+          const parquetFile = join(tempDir, `sq_${i}_${j}.parquet`);
+          await conn.run(
+            `COPY (SELECT * FROM src.${qid(tables[j])}) TO ${lit(parquetFile)} (FORMAT parquet)`
+          );
+          entries.push({ table: tables[j], parquetFile });
+        }
+        result.set(b.table, entries);
+        await conn.run("DETACH src");
+      } catch (err: unknown) {
+        if (err instanceof ValidationError) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ValidationError(`Failed to load ${b.path} as sqlite: ${message}`);
+      }
+    }
+  } finally {
+    try {
+      conn.closeSync();
+    } catch {
+      // ignore
+    }
+    try {
+      bridge.closeSync();
+    } catch {
+      // ignore
+    }
+  }
+  return result;
+}

--- a/packages/core/src/ops/sql.ts
+++ b/packages/core/src/ops/sql.ts
@@ -324,6 +324,28 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
   let conn: Awaited<ReturnType<Awaited<ReturnType<typeof DuckDBInstance.create>>["connect"]>> | null = null;
   let timer: ReturnType<typeof setTimeout> | null = null;
 
+  // Arm the deadline before any work so it covers the whole operation —
+  // downloads, extension loads, the sqlite bridge, and materialization — not
+  // just the final query. Interrupting the connection stops in-flight DuckDB
+  // work; the boundary checks below stop between phases (e.g. during S3 I/O,
+  // where there is no connection to interrupt).
+  let timedOut = false;
+  timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      conn?.interrupt();
+    } catch {
+      // ignore — not connected yet, or already closed
+    }
+  }, timeoutMs);
+  const checkTimeout = () => {
+    if (timedOut) {
+      throw new ValidationError(`Query timed out after ${timeoutMs}ms`, {
+        suggestion: "Reduce the amount of data the query loads or scans",
+      });
+    }
+  };
+
   try {
     // --- Download phase ---
     if (bindings.length > 0) {
@@ -343,6 +365,7 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
           throw err;
         }
         b.localFile = localFile;
+        checkTimeout();
       }
     }
 
@@ -359,8 +382,14 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
     const sqliteBindings = bindings.filter((b) => b.format === "sqlite");
     let sqliteTables = new Map<string, Array<{ table: string; parquetFile: string }>>();
     if (sqliteBindings.length > 0 && tempDir) {
-      sqliteTables = await bridgeSqliteToParquet(DuckDBInstance, sqliteBindings, tempDir);
+      sqliteTables = await bridgeSqliteToParquet(
+        DuckDBInstance,
+        sqliteBindings,
+        tempDir,
+        checkTimeout
+      );
     }
+    checkTimeout();
 
     for (const b of bindings) {
       try {
@@ -397,10 +426,13 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
         }
       } catch (err: unknown) {
         if (err instanceof ValidationError) throw err;
+        // A timeout fired mid-materialization surfaces as a clean timeout error.
+        checkTimeout();
         const message = err instanceof Error ? err.message : String(err);
         throw new ValidationError(`Failed to load ${b.path} as ${b.format}: ${message}`);
       }
     }
+    checkTimeout();
 
     // --- Lockdown phase: no file or network access for user SQL ---
     await conn.run("SET enable_external_access=false");
@@ -427,16 +459,6 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
         return table ? `${kw} ${qid(table)}` : full;
       }
     );
-
-    let timedOut = false;
-    timer = setTimeout(() => {
-      timedOut = true;
-      try {
-        conn?.interrupt();
-      } catch {
-        // ignore — connection may already be closed
-      }
-    }, timeoutMs);
 
     try {
       const extracted = await conn.extractStatements(query);
@@ -519,7 +541,8 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
 async function bridgeSqliteToParquet(
   DuckDBInstance: typeof import("@duckdb/node-api").DuckDBInstance,
   bindings: Binding[],
-  tempDir: string
+  tempDir: string,
+  checkTimeout: () => void
 ): Promise<Map<string, Array<{ table: string; parquetFile: string }>>> {
   const result = new Map<string, Array<{ table: string; parquetFile: string }>>();
   const bridge = await DuckDBInstance.create(":memory:");
@@ -530,6 +553,7 @@ async function bridgeSqliteToParquet(
     for (let i = 0; i < bindings.length; i++) {
       const b = bindings[i];
       try {
+        checkTimeout();
         await conn.run(`ATTACH ${lit(b.localFile!)} AS src (TYPE sqlite, READ_ONLY)`);
         const reader = await conn.runAndReadAll(
           "SELECT table_name FROM duckdb_tables() WHERE database_name = 'src'"
@@ -540,6 +564,7 @@ async function bridgeSqliteToParquet(
         }
         const entries: Array<{ table: string; parquetFile: string }> = [];
         for (let j = 0; j < tables.length; j++) {
+          checkTimeout();
           const parquetFile = join(tempDir, `sq_${i}_${j}.parquet`);
           await conn.run(
             `COPY (SELECT * FROM src.${qid(tables[j])}) TO ${lit(parquetFile)} (FORMAT parquet)`

--- a/packages/core/src/ops/sql.ts
+++ b/packages/core/src/ops/sql.ts
@@ -333,8 +333,11 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
   // DuckDB work; the boundary checks below stop between phases (e.g. during S3
   // I/O, where there is no connection to interrupt).
   let timedOut = false;
+  const downloadAbort = new AbortController();
   timer = setTimeout(() => {
     timedOut = true;
+    // Abort in-flight S3 downloads and interrupt active DuckDB connections.
+    downloadAbort.abort();
     for (const c of [conn, bridgeConn]) {
       try {
         c?.interrupt();
@@ -360,9 +363,15 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
         const ext = LOCAL_EXT[b.format] + (b.gzip ? ".gz" : "");
         const localFile = join(tempDir, `t${i}${ext}`);
         try {
-          const obj = await ctx.s3.getObject(getS3Key(ctx.orgId, ctx.driveId, b.path));
+          const obj = await ctx.s3.getObject(
+            getS3Key(ctx.orgId, ctx.driveId, b.path),
+            undefined,
+            { abortSignal: downloadAbort.signal }
+          );
           await writeFile(localFile, obj.body);
         } catch (err: unknown) {
+          // A timeout aborts the download — surface it as a clean timeout.
+          checkTimeout();
           const e = err as { name?: string; $metadata?: { httpStatusCode?: number } };
           if (e?.name === "NoSuchKey" || e?.$metadata?.httpStatusCode === 404) {
             throw new NotFoundError(`File not found: ${b.path}`, { path: b.path });

--- a/packages/core/src/ops/sql.ts
+++ b/packages/core/src/ops/sql.ts
@@ -114,15 +114,23 @@ interface Binding {
   path: string;
   format: SqlFormat;
   gzip: boolean;
-  /** Exact quoted literal in the query to substitute with the table identifier. */
-  literal?: string;
+  /** True when bound from a FROM/JOIN path literal (rewritten to the table id). */
+  autoBound?: boolean;
   localFile?: string;
   size: number;
 }
 
 const TABLE_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-// Quoted literal whose content has a queryable file extension, e.g. '/data/sales.csv'
-const PATH_LITERAL_RE = /'([^']+\.[A-Za-z0-9]+(?:\.gz)?)'/g;
+// A quoted path literal in table position (after FROM or JOIN), e.g.
+// `FROM '/data/sales.csv'`. Restricting to table position means an ordinary
+// string value like `WHERE source = '/data/sales.csv'` is never rewritten.
+const FROM_JOIN_PATH_RE =
+  /\b(from|join)\s+(['"])([^'"]+\.[A-Za-z0-9]+(?:\.gz)?)\2/gi;
+
+/** True when `path` is a gzipped file and `format` can read gzip. */
+function isGzip(path: string, format: SqlFormat): boolean {
+  return /\.gz$/i.test(path) && GZIPPABLE.has(format);
+}
 
 function findFile(
   ctx: OpContext,
@@ -181,25 +189,28 @@ function collectBindings(ctx: OpContext, params: SqlParams): Binding[] {
       table: name,
       path,
       format,
-      gzip: explicitFormat ? false : detected?.gzip ?? false,
+      // Honor a real .gz suffix even when the format is overridden, so the temp
+      // file keeps its .gz extension and DuckDB decompresses it.
+      gzip: isGzip(path, format),
       size: file.size,
     });
   }
 
-  // Auto-bind quoted drive-path literals like SELECT * FROM '/data/sales.csv'.
-  // Only literals that resolve to an existing document are bound; anything else
-  // is left untouched so plain string values are never misinterpreted.
-  const seenLiterals = new Set<string>();
+  // Auto-bind drive-path literals that sit in table position, like
+  // `SELECT * FROM '/data/sales.csv'`. Only literals that resolve to an existing
+  // document are bound; a path that merely appears as a string value elsewhere
+  // (e.g. `WHERE source = '/data/sales.csv'`) is never matched here.
+  const seenPaths = new Set<string>();
   let docIdx = 1;
-  for (const match of params.query.matchAll(PATH_LITERAL_RE)) {
-    const raw = match[1];
-    if (seenLiterals.has(raw)) continue;
-    seenLiterals.add(raw);
-
+  for (const match of params.query.matchAll(FROM_JOIN_PATH_RE)) {
+    const raw = match[3];
     const detected = detectSqlFormat(raw);
     if (!detected || !FILE_FORMATS.has(detected.format)) continue;
 
     const path = normalizePath(raw);
+    if (seenPaths.has(path)) continue;
+    seenPaths.add(path);
+
     const file = findFile(ctx, path);
     if (!file) continue;
 
@@ -212,7 +223,7 @@ function collectBindings(ctx: OpContext, params: SqlParams): Binding[] {
       path,
       format: detected.format,
       gzip: detected.gzip,
-      literal: match[0],
+      autoBound: true,
       size: file.size,
     });
   }
@@ -404,12 +415,18 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
     }
 
     // --- Query phase ---
-    let query = params.query;
-    for (const b of bindings) {
-      if (b.literal) {
-        query = query.split(b.literal).join(qid(b.table));
+    // Rewrite only FROM/JOIN path literals (never value-position strings) to the
+    // in-memory table they were bound to.
+    const autoBound = new Map(
+      bindings.filter((b) => b.autoBound).map((b) => [b.path, b.table])
+    );
+    const query = params.query.replace(
+      FROM_JOIN_PATH_RE,
+      (full, kw: string, _q: string, raw: string) => {
+        const table = autoBound.get(normalizePath(raw));
+        return table ? `${kw} ${qid(table)}` : full;
       }
-    }
+    );
 
     let timedOut = false;
     timer = setTimeout(() => {
@@ -433,7 +450,14 @@ export async function sql(ctx: OpContext, params: SqlParams): Promise<SqlResult>
       const prepared = await extracted.prepare(extracted.count - 1);
       const reader = await prepared.runAndReadUntil(maxRows + 1);
 
-      const columnNames = reader.columnNames();
+      // Uniquify duplicate column names (e.g. a join projecting two `id`s) so
+      // building row objects never drops data by key collision.
+      const seenCols = new Map<string, number>();
+      const columnNames = reader.columnNames().map((name) => {
+        const n = seenCols.get(name) ?? 0;
+        seenCols.set(name, n + 1);
+        return n === 0 ? name : `${name}_${n + 1}`;
+      });
       const columnTypes = reader.columnTypes();
       const columns: SqlColumn[] = columnNames.map((name, i) => ({
         name,

--- a/packages/core/src/ops/types.ts
+++ b/packages/core/src/ops/types.ts
@@ -330,6 +330,47 @@ export interface TreeResult {
   tree: TreeEntry[];
 }
 
+// --- SQL types ---
+
+export type SqlFormat =
+  | "csv"
+  | "tsv"
+  | "parquet"
+  | "xlsx"
+  | "json"
+  | "ndjson"
+  | "sqlite"
+  | "duckdb";
+
+export type SqlTableBinding = string | { path: string; format?: SqlFormat };
+
+export interface SqlParams {
+  query: string;
+  /** Named table bindings: table name -> document path (or { path, format } to override format detection). */
+  tables?: Record<string, SqlTableBinding>;
+  maxRows?: number;
+}
+
+export interface SqlColumn {
+  name: string;
+  type: string;
+}
+
+export interface SqlBoundFile {
+  table: string;
+  path: string;
+  format: SqlFormat;
+}
+
+export interface SqlResult {
+  columns: SqlColumn[];
+  rows: Record<string, unknown>[];
+  rowCount: number;
+  truncated: boolean;
+  files: SqlBoundFile[];
+  elapsedMs: number;
+}
+
 // --- Glob types ---
 
 export interface GlobParams {

--- a/packages/core/src/s3/client.ts
+++ b/packages/core/src/s3/client.ts
@@ -96,13 +96,18 @@ export class AgentS3Client {
     };
   }
 
-  async getObject(key: string, versionId?: string): Promise<GetObjectResult> {
+  async getObject(
+    key: string,
+    versionId?: string,
+    opts?: { abortSignal?: AbortSignal }
+  ): Promise<GetObjectResult> {
     const result = await this.client.send(
       new GetObjectCommand({
         Bucket: this.bucket,
         Key: key,
         ...(versionId && { VersionId: versionId }),
-      })
+      }),
+      { abortSignal: opts?.abortSignal }
     );
     const body = await result.Body!.transformToByteArray();
     return {

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1008,6 +1008,201 @@ async function runStandardTests(daemonUrl: string) {
     assert(ct, "image/png", `Expected image/png, got ${ct}`);
   });
 
+  // -- sql (DuckDB) --
+
+  await test("sql fixtures: upload csv/tsv/ndjson/parquet/xlsx/sqlite", async () => {
+    // All fixtures are written to local files and uploaded via --file so
+    // newlines/tabs survive without shell-escaping games.
+    const { mkdtempSync } = await import("node:fs");
+    const fixDir = mkdtempSync(join(tmpdir(), "agent-fs-e2e-sql-"));
+
+    writeFileSync(join(fixDir, "sales.csv"), "id,name,amount\n1,alpha,10.5\n2,beta,20.25\n3,gamma,30\n");
+    writeFileSync(join(fixDir, "pets.tsv"), "id\tpet\n1\tcat\n2\tdog\n");
+    writeFileSync(join(fixDir, "events.ndjson"), '{"id":1,"kind":"login"}\n{"id":2,"kind":"logout"}\n');
+    writeFileSync(join(fixDir, "raw.txt"), "a,b\n1,2\n3,4\n");
+    runJson(`write /sql/sales.csv --file ${join(fixDir, "sales.csv")}`);
+    runJson(`write /sql/pets.tsv --file ${join(fixDir, "pets.tsv")}`);
+    runJson(`write /sql/events.ndjson --file ${join(fixDir, "events.ndjson")}`);
+    runJson(`write /sql/raw.txt --file ${join(fixDir, "raw.txt")}`);
+
+    const { DuckDBInstance } = await import("@duckdb/node-api");
+    const instance = await DuckDBInstance.create(":memory:");
+    const conn = await instance.connect();
+    await conn.run(`COPY (SELECT * FROM (VALUES (1, 'aa'), (2, 'bb'), (3, 'cc')) t(id, tag)) TO '${fixDir}/tags.parquet' (FORMAT parquet)`);
+    await conn.run("INSTALL excel");
+    await conn.run("LOAD excel");
+    await conn.run(`COPY (SELECT * FROM (VALUES (1, 'x'), (2, 'y')) t(num, label)) TO '${fixDir}/report.xlsx' WITH (FORMAT xlsx, HEADER true)`);
+    conn.closeSync();
+    instance.closeSync();
+
+    const { Database } = await import("bun:sqlite");
+    const sqlite = new Database(join(fixDir, "app.db"));
+    sqlite.run("CREATE TABLE users (id INTEGER, email TEXT)");
+    sqlite.run("INSERT INTO users VALUES (1,'a@x.com'),(2,'b@x.com')");
+    sqlite.close();
+
+    runJson(`write /sql/tags.parquet --file ${fixDir}/tags.parquet`);
+    runJson(`write /sql/report.xlsx --file ${fixDir}/report.xlsx`);
+    runJson(`write /sql/app.db --file ${fixDir}/app.db`);
+    rmSync(fixDir, { recursive: true, force: true });
+
+    const stat = runJson("stat /sql/tags.parquet");
+    assert(stat.contentType, "application/vnd.apache.parquet");
+  });
+
+  await test("sql: csv via path literal", () => {
+    const result = runJson(`sql "SELECT count(*) AS n, sum(amount) AS total FROM '/sql/sales.csv'"`);
+    assert(result.rows.length, 1);
+    assert(result.rows[0].n, 3);
+    assert(result.rows[0].total, 60.75);
+    assert(result.truncated, false);
+    assert(result.files.length, 1);
+    assert(result.files[0].path, "/sql/sales.csv");
+    assert(result.files[0].format, "csv");
+  });
+
+  await test("sql: tsv and ndjson via path literal", () => {
+    const tsv = runJson(`sql "SELECT pet FROM '/sql/pets.tsv' ORDER BY id"`);
+    assert(tsv.rows.map((r: any) => r.pet).join(","), "cat,dog");
+    const nd = runJson(`sql "SELECT count(*) AS n FROM '/sql/events.ndjson'"`);
+    assert(nd.rows[0].n, 2);
+  });
+
+  await test("sql: cross-format join with --table bindings", () => {
+    const result = runJson(
+      `sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id ORDER BY s.id" -t sales=/sql/sales.csv -t tags=/sql/tags.parquet`
+    );
+    assert(result.rows.length, 3);
+    assert(result.rows[0].name, "alpha");
+    assert(result.rows[0].tag, "aa");
+    assert(result.files.length, 2);
+  });
+
+  await test("sql: xlsx via path literal", () => {
+    const result = runJson(`sql "SELECT * FROM '/sql/report.xlsx' ORDER BY num"`);
+    assert(result.rows.length, 2);
+    assert(result.rows[0].label, "x");
+  });
+
+  await test("sql: sqlite db tables under binding name", () => {
+    const result = runJson(`sql "SELECT email FROM app.users ORDER BY id" -t app=/sql/app.db`);
+    assert(result.rows.length, 2);
+    assert(result.rows[0].email, "a@x.com");
+  });
+
+  await test("sql: format override makes .txt queryable", () => {
+    const result = runJson(`sql "SELECT sum(a) AS s FROM logs" -t logs=/sql/raw.txt:csv`);
+    assert(result.rows[0].s, 4);
+  });
+
+  await test("sql: --max-rows truncates", () => {
+    const result = runJson(`sql "SELECT * FROM '/sql/sales.csv'" --max-rows 2`);
+    assert(result.rowCount, 2);
+    assert(result.truncated, true);
+  });
+
+  await test("sql: human-readable table output", () => {
+    const out = run(`sql "SELECT name FROM '/sql/sales.csv' ORDER BY id LIMIT 1"`);
+    assertIncludes(out, "name");
+    assertIncludes(out, "alpha");
+    assertIncludes(out, "1 row");
+  });
+
+  await test("sql: stdin query", () => {
+    const out = execSync(`echo "SELECT count(*) AS n FROM '/sql/sales.csv'" | ${cmd} --json sql`, {
+      encoding: "utf-8",
+      env: { ...testEnv(), AGENT_FS_API_URL: `http://127.0.0.1:${daemonPort}`, AGENT_FS_API_KEY: apiKey },
+      timeout: 30_000,
+    }).trim();
+    assert(JSON.parse(out).rows[0].n, 3);
+  });
+
+  await test("sql via API", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        op: "sql",
+        query: "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id ORDER BY s.id DESC LIMIT 1",
+        tables: { sales: "/sql/sales.csv", tags: { path: "/sql/tags.parquet", format: "parquet" } },
+      }),
+    });
+    assert(res.ok, true, `Expected 200, got ${res.status}`);
+    const body = await res.json() as any;
+    assert(body.rows.length, 1);
+    assert(body.rows[0].name, "gamma");
+    assert(body.rows[0].tag, "cc");
+    assert(Array.isArray(body.columns), true);
+    assert(body.columns[0].name, "name");
+  });
+
+  await test("sql via API — sandbox blocks host filesystem", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ op: "sql", query: "SELECT * FROM read_csv('/etc/passwd')" }),
+    });
+    assert(res.status, 400, `Expected 400, got ${res.status}`);
+    const body = await res.json() as any;
+    assert(body.error, "VALIDATION_ERROR");
+  });
+
+  await test("sql via API — syntax error is a 400", async () => {
+    const res = await fetch(`${daemonUrl}/orgs/${personalOrgId}/ops`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ op: "sql", query: "SELEKT broken" }),
+    });
+    assert(res.status, 400, `Expected 400, got ${res.status}`);
+  });
+
+  await test("sql via MCP", async () => {
+    const initRes = await fetch(`${daemonUrl}/mcp`, {
+      method: "POST",
+      headers: mcpHeaders(apiKey),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "e2e-sql", version: "1.0.0" },
+        },
+      }),
+    });
+    assert(initRes.ok, true, `MCP init failed: ${initRes.status}`);
+
+    const callRes = await fetch(`${daemonUrl}/mcp`, {
+      method: "POST",
+      headers: mcpHeaders(apiKey),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "sql",
+          arguments: { query: "SELECT count(*) AS n FROM '/sql/sales.csv'" },
+        },
+      }),
+    });
+    assert(callRes.ok, true, `MCP tools/call failed: ${callRes.status}`);
+    const body = await callRes.json() as any;
+    const content = body.result?.content;
+    assert(Array.isArray(content), true, `Expected content array, got ${JSON.stringify(body)}`);
+    const parsed = JSON.parse(content[0]?.text);
+    assert(parsed.rows[0].n, 3);
+  });
+
   // -- Org commands --
 
   await test("org list", () => {

--- a/skills/agent-fs/SKILL.md
+++ b/skills/agent-fs/SKILL.md
@@ -9,7 +9,10 @@ description: >-
   "update role", file persistence for agents, shared agent filesystem, or any
   mention of the agent-fs CLI. Also use when the user needs to manage drives,
   manage org/drive members, generate presigned URLs, check recent activity, or use
-  semantic search across stored files. Also use when the user wants to mount or
+  semantic search across stored files. Also use when the user wants to run SQL
+  over stored data files ("query this csv", "sql over my files", "duckdb",
+  "aggregate the parquet file", "query the sqlite db", "join these spreadsheets").
+  Also use when the user wants to mount or
   unmount agent-fs as a Linux FUSE filesystem ("mount agent-fs", "fuse mount",
   "fuse", "remote mount", "sandbox mount", "expose drives as files",
   "use cat/grep/mv on my agent-fs files", "umount the drive", "mount a remote
@@ -138,6 +141,14 @@ symlinks are unsupported and throw `EPERM`.
 - `search` — general-purpose search combining keywords and meaning (recommended default)
 - `vec-search` — pure semantic search when you want conceptual matches only
 
+### SQL Queries (DuckDB)
+
+| Command | Usage | Description |
+|---------|-------|-------------|
+| `sql` | `agent-fs sql <query> [-t name=path[:format]]... [--max-rows <n>]` | Run DuckDB SQL over stored documents |
+
+Supported formats: csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also `.gz` except parquet/xlsx), sqlite (`.db`/`.sqlite`/`.sqlite3`), and `.duckdb`. Reference file-format documents directly by quoted drive path inside the query, or bind any document to a table name with `-t`. SQLite/DuckDB databases require a `-t` binding and expose their tables as `<name>.<table>`. Append `:format` to a binding to query documents with non-standard extensions (e.g. `-t logs=/raw/data.txt:csv`). Queries are sandboxed — no host filesystem or network access. Results cap at `--max-rows` (default 1000, max 10000); `truncated: true` in JSON output signals more rows exist.
+
 ### Comments
 
 | Command | Usage | Description |
@@ -244,6 +255,23 @@ agent-fs search "financial performance metrics" --limit 5
 
 # Vector-only semantic search (conceptual matches only)
 agent-fs vec-search "financial performance metrics" --limit 5
+```
+
+### Query data files with SQL
+
+```bash
+# Query a CSV directly by path
+agent-fs sql "SELECT category, sum(amount) AS total FROM '/finance/2026.csv' GROUP BY category" --json
+
+# Join documents of different formats
+agent-fs sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id" \
+  -t sales=/data/sales.csv -t tags=/data/tags.parquet
+
+# Query a stored SQLite database (tables exposed as app.<table>)
+agent-fs sql "SELECT count(*) FROM app.users" -t app=/backups/app.db
+
+# Pipe a query via stdin
+echo "SELECT count(*) FROM '/data/events.ndjson'" | agent-fs sql
 ```
 
 ### Review and revert changes


### PR DESCRIPTION
## Summary

Adds a sandboxed `sql` op that runs DuckDB SQL over documents stored in a drive, exposed everywhere the ops registry reaches: CLI (`agent-fs sql`), HTTP API (`POST /orgs/:orgId/ops`), MCP tool, plus a SQL workbench in the live UI powered by DuckDB-WASM.

```bash
agent-fs sql "SELECT category, sum(amount) FROM '/finance/2026.csv' GROUP BY category"
agent-fs sql "SELECT s.name, t.tag FROM sales s JOIN tags t ON s.id = t.id" \
  -t sales=/data/sales.csv -t tags=/data/tags.parquet
agent-fs sql "SELECT count(*) FROM app.users" -t app=/backups/app.db
```

**Formats:** csv, tsv, parquet, xlsx, json, ndjson/jsonl (text formats also `.gz`), sqlite (`.db`/`.sqlite`/`.sqlite3` — tables exposed as `<name>.<table>`), `.duckdb`.

**Making a document SQL-able:** quoted drive-path literals in the query (`FROM '/data/sales.csv'`), named `tables` bindings, or a format override for non-standard extensions (`-t logs=/raw/data.txt:csv`). Docs: [docs/sql.md](./docs/sql.md).

## Security model

The hosted API is multitenant, so user SQL is untrusted. Probing showed DuckDB's `allowed_directories` sandbox is **bypassed by the sqlite extension** (it performs its own file I/O — a file outside the sandbox was readable post-lockdown via `ATTACH`). The op therefore:

1. Materializes every referenced document into in-memory tables during setup — sqlite databases through an isolated bridge instance converted to parquet, so the instance executing user SQL never loads the sqlite extension
2. Then disables the local filesystem, cuts external access, and locks configuration before any user SQL runs
3. Deletes temp files before the query phase

Covered by tests: `/etc/passwd` reads, http(s) fetches, `ATTACH`, `sqlite_scan`, `COPY ... TO`, and `SET` all fail with `VALIDATION_ERROR`. Limits (env-tunable): `AGENT_FS_SQL_TIMEOUT_MS` (30s, interrupt-based), `AGENT_FS_SQL_MAX_FILE_BYTES` (256MB), `AGENT_FS_SQL_MEMORY_LIMIT` (512MB), `maxRows` 1000 default / 10000 max.

## Changes

- **core**: `sql` op (`packages/core/src/ops/sql.ts`), registry + RBAC (`viewer`), data-file MIME types (parquet/tsv/sqlite/ndjson), `@duckdb/node-api` pinned exact (`1.5.3-r.3`) given the 2025 npm supply-chain incident on DuckDB packages
- **cli**: `agent-fs sql [query] -t name=path[:format] --max-rows N`, stdin queries, aligned-table formatter; dep marked `--external` in the npm bundle (per-platform binaries resolve via DuckDB's own optionalDependencies)
- **server/mcp**: no new routes — exposed automatically via ops dispatch, MCP tool registry, and OpenAPI (`docs/openapi.json` regenerated)
- **live**: SQL workbench at `/sql/~/:orgId/:driveId` — document picker, Monaco editor (Cmd+Enter), results table + hand-rolled SVG bar/line charts, CSV/JSON export, "Query" button on queryable files. Dual engine: DuckDB-WASM 1.32.0 in-browser for csv/tsv/parquet/json/ndjson (lazy chunk; bytes fetched via the authenticated API to avoid S3 CORS), automatic server fallback for xlsx/sqlite/duckdb (excel ext is broken in wasm, sqlite_scanner flaky)
- **docs/skill**: `docs/sql.md`, landing docs registration + `llms.txt`, SKILL.md command table/workflow/triggers, README bullet; versions synced to **0.8.2**

## Testing

- 23 new core unit tests (formats, joins, gz, value conversion, truncation, multi-statement, all sandbox escapes) — `bun test packages/core`
- 5 new CLI binding-parser tests
- 15 new e2e tests in `scripts/e2e.ts` exercising CLI + raw HTTP API + MCP against Docker MinIO with real parquet/xlsx/sqlite fixtures — **suite passes 96/96**
- `bun run typecheck` clean; full `bun run test` 415 pass / 0 fail; npm bundle builds; `landing/` and `live/` build under pnpm