### PR TITLE
File editing in web UI

### DIFF
--- a/live/src/api/client.ts
+++ b/live/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { MeResponse, Drive, OrgMembersResult, RegisterResponse, SqlResult, SqlTableBinding } from "./types"
+import type { MeResponse, Drive, OrgMembersResult, RegisterResponse, SqlResult, SqlTableBinding, WriteParams, WriteResult } from "./types"
 
 export interface ApiError {
   error: string
@@ -116,6 +116,10 @@ export class AgentFsClient {
     params: { query: string; tables?: Record<string, SqlTableBinding>; maxRows?: number },
   ): Promise<SqlResult> {
     return this.callOp<SqlResult>(orgId, "sql", { ...params }, driveId)
+  }
+
+  async write(orgId: string, driveId: string, params: WriteParams): Promise<WriteResult> {
+    return this.callOp<WriteResult>(orgId, "write", params as Record<string, unknown>, driveId)
   }
 
   getRawUrl(orgId: string, driveId: string, path: string): string {

--- a/live/src/api/client.ts
+++ b/live/src/api/client.ts
@@ -119,7 +119,7 @@ export class AgentFsClient {
   }
 
   async write(orgId: string, driveId: string, params: WriteParams): Promise<WriteResult> {
-    return this.callOp<WriteResult>(orgId, "write", params as Record<string, unknown>, driveId)
+    return this.callOp<WriteResult>(orgId, "write", params as unknown as Record<string, unknown>, driveId)
   }
 
   getRawUrl(orgId: string, driveId: string, path: string): string {

--- a/live/src/api/types.ts
+++ b/live/src/api/types.ts
@@ -86,6 +86,23 @@ export interface GlobResult {
   matches: GlobMatch[]
 }
 
+// Write types (from core/ops/types.ts)
+
+export interface WriteParams {
+  path: string
+  content: string
+  message?: string
+  expectedVersion?: number
+}
+
+export interface WriteResult {
+  version: number
+  path: string
+  size: number
+  contentHash?: string
+  deduped?: boolean
+}
+
 // Comment types
 
 export interface CommentEntry {

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, type MutableRefObject } from "react"
-import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database } from "lucide-react"
+import { useState, useEffect, useCallback, type MutableRefObject } from "react"
+import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil } from "lucide-react"
 import { useNavigate } from "react-router"
 import { isQueryablePath } from "@/lib/sql-engine/types"
 import { useAuth } from "@/contexts/auth"
@@ -13,6 +13,7 @@ import type { OutlineItem } from "@/lib/outline"
 import { useFileContent } from "@/hooks/use-file-content"
 import { useFileStat } from "@/hooks/use-file-stat"
 import { useComments } from "@/hooks/use-comments"
+import { useFileSave } from "@/hooks/use-file-save"
 import { TextViewer } from "./TextViewer"
 import { MarkdownViewer } from "./MarkdownViewer"
 import { ImageViewer } from "./ImageViewer"
@@ -126,6 +127,9 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   const isMd = isMarkdown(path)
   const commentCount = commentsData?.comments.length ?? 0
   const [showRaw, setShowRaw] = useState(false)
+  const [isEditing, setIsEditing] = useState(false)
+  const { save, isSaving, error: saveError } = useFileSave({ path })
+  const [saveErrorDismissed, setSaveErrorDismissed] = useState(false)
 
   const isTabBin = isTabularBinary(path)
   const isTabTxt = isTabularText(path)
@@ -321,7 +325,33 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   }
 
   // For markdown-like files: show raw/preview toggle in header.
-  const viewingRaw = isMd ? showRaw : true
+  // In edit mode, always show the TextViewer (source) since you're editing.
+  const viewingRaw = (isMd && !isEditing) ? showRaw : true
+  const displayError = saveError && !saveErrorDismissed ? saveError.message : null
+
+  const handleEdit = useCallback(() => {
+    setIsEditing(true)
+    setSaveErrorDismissed(false)
+  }, [])
+
+  const handleCancel = useCallback(() => {
+    // If the user has made changes, they'll be in the TextViewer's internal
+    // state — the confirm is handled by the dirty check there via beforeunload
+    // and the cancel button behavior.
+    setIsEditing(false)
+    setSaveErrorDismissed(false)
+  }, [])
+
+  const handleSave = useCallback(async (content: string) => {
+    try {
+      await save(content)
+      setIsEditing(false)
+      setSaveErrorDismissed(false)
+      // Content will be refreshed by the parent when it re-mounts or re-fetches
+    } catch {
+      // error is captured by useFileSave
+    }
+  }, [save])
 
   return (
     <div className={cn("flex flex-col h-full min-w-0", className)}>
@@ -333,9 +363,11 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           onExpand={() => navigate(`/detail/~/${orgId}/${driveId}/${path}`)}
           onQuery={onQuery}
           commentCount={commentCount}
-          showViewToggle={isMd}
+          showViewToggle={isMd && !isEditing}
           showRaw={showRaw}
           onToggleRaw={() => setShowRaw(!showRaw)}
+          isEditing={isEditing}
+          onEdit={handleEdit}
         />
       )}
       {viewingRaw ? (
@@ -346,6 +378,11 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           comments={commentsData?.comments}
           className="flex-1 min-h-0"
           onScrollToCommentRef={onScrollToCommentRef}
+          editable={isEditing}
+          isSaving={isSaving}
+          saveError={displayError}
+          onSave={handleSave}
+          onCancel={handleCancel}
         />
       ) : (
         <MarkdownViewer
@@ -361,7 +398,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   )
 }
 
-function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCount = 0, showViewToggle, showRaw, onToggleRaw }: {
+function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCount = 0, showViewToggle, showRaw, onToggleRaw, isEditing, onEdit }: {
   path: string
   actions: ReturnType<typeof useFileActions>
   showExpand: boolean
@@ -371,6 +408,8 @@ function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCou
   showViewToggle?: boolean
   showRaw?: boolean
   onToggleRaw?: () => void
+  isEditing?: boolean
+  onEdit?: () => void
 }) {
   const { copyPath, copyLink, download, copiedPath, copiedLink, canShare } = actions
   const filename = path.split("/").pop() ?? path
@@ -438,6 +477,24 @@ function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCou
           />
           <TooltipContent>Download <Kbd className="ml-1">D</Kbd></TooltipContent>
         </Tooltip>
+        {onEdit && !isEditing && (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={onEdit}
+                  className="text-muted-foreground"
+                  aria-label="Edit file"
+                >
+                  <Pencil />
+                </Button>
+              }
+            />
+            <TooltipContent>Edit file</TooltipContent>
+          </Tooltip>
+        )}
         {showViewToggle && onToggleRaw && (
           <Tooltip>
             <TooltipTrigger

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback, type MutableRefObject } from "react"
-import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil, Columns2, LayoutGrid } from "lucide-react"
+import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil, Columns2, LayoutGrid, Circle, X, AlertCircle } from "lucide-react"
 import { useNavigate } from "react-router"
 import { isQueryablePath } from "@/lib/sql-engine/types"
 import { useAuth } from "@/contexts/auth"
@@ -112,12 +112,14 @@ interface FileViewerProps {
   className?: string
   showExpandButton?: boolean
   showHeader?: boolean
+  /** Show an Edit button even when showHeader is false (for detail page). */
+  showEditButton?: boolean
   onScrollToCommentRef?: MutableRefObject<ScrollToCommentCallback | null>
   /** Reports the document outline (headings) of a rendered markdown preview. */
   onOutlineChange?: (items: OutlineItem[]) => void
 }
 
-export function FileViewer({ path, className, showExpandButton = true, showHeader = true, onScrollToCommentRef, onOutlineChange }: FileViewerProps) {
+export function FileViewer({ path, className, showExpandButton = true, showHeader = true, showEditButton = false, onScrollToCommentRef, onOutlineChange }: FileViewerProps) {
   const navigate = useNavigate()
   const { orgId, driveId } = useAuth()
   const { data: stat } = useFileStat(path)
@@ -209,6 +211,14 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
     }
   }
   useKeyboardShortcuts(fileShortcuts)
+  // Escape exits edit mode
+  useKeyboardShortcuts({
+    esc: (e) => {
+      if (!isEditing) return
+      e.preventDefault()
+      handleCancel()
+    },
+  })
 
   const handleEdit = useCallback(() => {
     setIsEditing(true)
@@ -395,6 +405,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
     : (isMd ? showRaw : true)
   const showSplit = isEditing && isMd && splitMode === "split"
   const displayError = saveError && !saveErrorDismissed ? saveError.message : null
+  const isDirty = isEditing && !!content && editedContent !== content.content
 
   return (
     <div className={cn("flex flex-col h-full min-w-0", className)}>
@@ -418,6 +429,74 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           onToggleOrientation={isEditing && isMd ? () => setSplitOrientation((o) => o === "horizontal" ? "vertical" : "horizontal") : undefined}
         />
       )}
+      {!showHeader && showEditButton && !isEditing && (
+        <div className="flex h-10 items-center justify-end border-b border-border px-4 shrink-0">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={handleEdit}
+                  className="text-muted-foreground"
+                  aria-label="Edit file"
+                >
+                  <Pencil />
+                </Button>
+              }
+            />
+            <TooltipContent>Edit file</TooltipContent>
+          </Tooltip>
+        </div>
+      )}
+      {isEditing && (
+        <div className="flex items-center justify-between border-b border-border bg-accent/30 px-3 py-1.5 shrink-0">
+          <div className="flex items-center gap-2">
+            {isDirty && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Circle className="size-2 fill-amber-500 text-amber-500" />
+                Unsaved changes
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5">
+            {displayError && (
+              <span className="flex items-center gap-1 text-xs text-destructive max-w-[200px] truncate">
+                <AlertCircle className="size-3 shrink-0" />
+                {displayError}
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                if (isDirty && !window.confirm("Discard unsaved changes?")) return
+                handleCancel()
+              }}
+              disabled={isSaving}
+              className="text-muted-foreground gap-1"
+            >
+              <X className="size-3" />
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="xs"
+              onClick={() => handleSave(editedContent || content.content)}
+              disabled={!isDirty || isSaving}
+              className="gap-1"
+            >
+              {isSaving ? (
+                <Spinner className="size-3" />
+              ) : (
+                <Check className="size-3" />
+              )}
+              Save
+              <Kbd className="ml-0.5">⌘S</Kbd>
+            </Button>
+          </div>
+        </div>
+      )}
       {showSplit ? (
         <div
           ref={splitContainerRef}
@@ -434,10 +513,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
               truncated={content.truncated}
               comments={commentsData?.comments}
               editable
-              isSaving={isSaving}
-              saveError={displayError}
               onSave={handleSave}
-              onCancel={handleCancel}
               onContentChange={setEditedContent}
             />
           </div>
@@ -479,10 +555,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           className="flex-1 min-h-0"
           onScrollToCommentRef={onScrollToCommentRef}
           editable={isEditing}
-          isSaving={isSaving}
-          saveError={displayError}
           onSave={handleSave}
-          onCancel={handleCancel}
           onContentChange={isEditing && isMd ? setEditedContent : undefined}
         />
       ) : (

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -210,6 +210,63 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   }
   useKeyboardShortcuts(fileShortcuts)
 
+  const handleEdit = useCallback(() => {
+    setIsEditing(true)
+    setSaveErrorDismissed(false)
+    setEditedContent(content?.content ?? "")
+    setSplitMode("source")
+  }, [content])
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false)
+    setSaveErrorDismissed(false)
+    setSplitMode("source")
+    setEditedContent("")
+  }, [])
+
+  const handleSave = useCallback(async (saveContent: string) => {
+    try {
+      await save(saveContent)
+      setIsEditing(false)
+      setSaveErrorDismissed(false)
+      setSplitMode("source")
+      setEditedContent("")
+    } catch {
+      // error is captured by useFileSave
+    }
+  }, [save])
+
+  // Split-view drag resize
+  const handleDragStart = useCallback(() => setIsDragging(true), [])
+  useEffect(() => {
+    if (!isDragging) return
+    const container = splitContainerRef.current
+    if (!container) return
+
+    const handleMove = (e: MouseEvent | TouchEvent) => {
+      const rect = container.getBoundingClientRect()
+      const clientX = "touches" in e ? e.touches[0].clientX : e.clientX
+      const clientY = "touches" in e ? e.touches[0].clientY : e.clientY
+      const pos = splitOrientation === "horizontal"
+        ? ((clientX - rect.left) / rect.width) * 100
+        : ((clientY - rect.top) / rect.height) * 100
+      setSplitPos(Math.max(20, Math.min(80, pos)))
+    }
+
+    const handleUp = () => setIsDragging(false)
+
+    window.addEventListener("mousemove", handleMove)
+    window.addEventListener("mouseup", handleUp)
+    window.addEventListener("touchmove", handleMove, { passive: true })
+    window.addEventListener("touchend", handleUp)
+    return () => {
+      window.removeEventListener("mousemove", handleMove)
+      window.removeEventListener("mouseup", handleUp)
+      window.removeEventListener("touchmove", handleMove)
+      window.removeEventListener("touchend", handleUp)
+    }
+  }, [isDragging, splitOrientation])
+
   if (isImg) {
     return (
       <div className={cn("flex flex-col h-full min-w-0", className)}>
@@ -338,63 +395,6 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
     : (isMd ? showRaw : true)
   const showSplit = isEditing && isMd && splitMode === "split"
   const displayError = saveError && !saveErrorDismissed ? saveError.message : null
-
-  const handleEdit = useCallback(() => {
-    setIsEditing(true)
-    setSaveErrorDismissed(false)
-    setEditedContent(content?.content ?? "")
-    setSplitMode("source")
-  }, [content])
-
-  const handleCancel = useCallback(() => {
-    setIsEditing(false)
-    setSaveErrorDismissed(false)
-    setSplitMode("source")
-    setEditedContent("")
-  }, [])
-
-  const handleSave = useCallback(async (content: string) => {
-    try {
-      await save(content)
-      setIsEditing(false)
-      setSaveErrorDismissed(false)
-      setSplitMode("source")
-      setEditedContent("")
-    } catch {
-      // error is captured by useFileSave
-    }
-  }, [save])
-
-  // Split-view drag resize
-  const handleDragStart = useCallback(() => setIsDragging(true), [])
-  useEffect(() => {
-    if (!isDragging) return
-    const container = splitContainerRef.current
-    if (!container) return
-
-    const handleMove = (e: MouseEvent | TouchEvent) => {
-      const rect = container.getBoundingClientRect()
-      const clientX = "touches" in e ? e.touches[0].clientX : e.clientX
-      const clientY = "touches" in e ? e.touches[0].clientY : e.clientY
-      const pos = splitOrientation === "horizontal"
-        ? ((clientX - rect.left) / rect.width) * 100
-        : ((clientY - rect.top) / rect.height) * 100
-      setSplitPos(Math.max(20, Math.min(80, pos)))
-    }
-
-    const handleUp = () => setIsDragging(false)
-
-    window.addEventListener("mousemove", handleMove)
-    window.addEventListener("mouseup", handleUp)
-    window.addEventListener("touchmove", handleMove, { passive: true })
-    window.addEventListener("touchend", handleUp)
-    return () => {
-      window.removeEventListener("mousemove", handleMove)
-      window.removeEventListener("mouseup", handleUp)
-      window.removeEventListener("touchmove", handleMove)
-      window.removeEventListener("touchend", handleUp)
-    }
-  }, [isDragging, splitOrientation])
 
   return (
     <div className={cn("flex flex-col h-full min-w-0", className)}>

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useCallback, type MutableRefObject } from "react"
-import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil } from "lucide-react"
+import { useState, useEffect, useRef, useCallback, type MutableRefObject } from "react"
+import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil, Columns2, LayoutGrid } from "lucide-react"
 import { useNavigate } from "react-router"
 import { isQueryablePath } from "@/lib/sql-engine/types"
 import { useAuth } from "@/contexts/auth"
@@ -130,6 +130,12 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   const [isEditing, setIsEditing] = useState(false)
   const { save, isSaving, error: saveError } = useFileSave({ path })
   const [saveErrorDismissed, setSaveErrorDismissed] = useState(false)
+  const [splitMode, setSplitMode] = useState<"source" | "split" | "preview">("source")
+  const [splitOrientation, setSplitOrientation] = useState<"horizontal" | "vertical">("horizontal")
+  const [splitPos, setSplitPos] = useState(50)
+  const [isDragging, setIsDragging] = useState(false)
+  const splitContainerRef = useRef<HTMLDivElement>(null)
+  const [editedContent, setEditedContent] = useState("")
 
   const isTabBin = isTabularBinary(path)
   const isTabTxt = isTabularText(path)
@@ -148,7 +154,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   // Outline only exists for a rendered markdown preview. When the viewer shows
   // anything else (source view, image, etc.) clear it so the rail's Outline
   // tab disappears. `MarkdownViewer` reports the real outline when mounted.
-  const showingMarkdownPreview = isMd && !showRaw
+  const showingMarkdownPreview = (isMd && !showRaw) || (isEditing && isMd && splitMode !== "source")
   useEffect(() => {
     if (!showingMarkdownPreview) onOutlineChange?.([])
   }, [showingMarkdownPreview, path, onOutlineChange])
@@ -326,20 +332,25 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
 
   // For markdown-like files: show raw/preview toggle in header.
   // In edit mode, always show the TextViewer (source) since you're editing.
-  const viewingRaw = (isMd && !isEditing) ? showRaw : true
+  // For markdown in edit mode, use the split mode to determine what to show.
+  const viewingRaw = isEditing && isMd
+    ? splitMode !== "preview"
+    : (isMd ? showRaw : true)
+  const showSplit = isEditing && isMd && splitMode === "split"
   const displayError = saveError && !saveErrorDismissed ? saveError.message : null
 
   const handleEdit = useCallback(() => {
     setIsEditing(true)
     setSaveErrorDismissed(false)
-  }, [])
+    setEditedContent(content?.content ?? "")
+    setSplitMode("source")
+  }, [content])
 
   const handleCancel = useCallback(() => {
-    // If the user has made changes, they'll be in the TextViewer's internal
-    // state — the confirm is handled by the dirty check there via beforeunload
-    // and the cancel button behavior.
     setIsEditing(false)
     setSaveErrorDismissed(false)
+    setSplitMode("source")
+    setEditedContent("")
   }, [])
 
   const handleSave = useCallback(async (content: string) => {
@@ -347,11 +358,43 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
       await save(content)
       setIsEditing(false)
       setSaveErrorDismissed(false)
-      // Content will be refreshed by the parent when it re-mounts or re-fetches
+      setSplitMode("source")
+      setEditedContent("")
     } catch {
       // error is captured by useFileSave
     }
   }, [save])
+
+  // Split-view drag resize
+  const handleDragStart = useCallback(() => setIsDragging(true), [])
+  useEffect(() => {
+    if (!isDragging) return
+    const container = splitContainerRef.current
+    if (!container) return
+
+    const handleMove = (e: MouseEvent | TouchEvent) => {
+      const rect = container.getBoundingClientRect()
+      const clientX = "touches" in e ? e.touches[0].clientX : e.clientX
+      const clientY = "touches" in e ? e.touches[0].clientY : e.clientY
+      const pos = splitOrientation === "horizontal"
+        ? ((clientX - rect.left) / rect.width) * 100
+        : ((clientY - rect.top) / rect.height) * 100
+      setSplitPos(Math.max(20, Math.min(80, pos)))
+    }
+
+    const handleUp = () => setIsDragging(false)
+
+    window.addEventListener("mousemove", handleMove)
+    window.addEventListener("mouseup", handleUp)
+    window.addEventListener("touchmove", handleMove, { passive: true })
+    window.addEventListener("touchend", handleUp)
+    return () => {
+      window.removeEventListener("mousemove", handleMove)
+      window.removeEventListener("mouseup", handleUp)
+      window.removeEventListener("touchmove", handleMove)
+      window.removeEventListener("touchend", handleUp)
+    }
+  }, [isDragging, splitOrientation])
 
   return (
     <div className={cn("flex flex-col h-full min-w-0", className)}>
@@ -368,9 +411,66 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           onToggleRaw={() => setShowRaw(!showRaw)}
           isEditing={isEditing}
           onEdit={handleEdit}
+          isMarkdown={isMd}
+          splitMode={isEditing && isMd ? splitMode : undefined}
+          splitOrientation={splitOrientation}
+          onSplitModeChange={isEditing && isMd ? setSplitMode : undefined}
+          onToggleOrientation={isEditing && isMd ? () => setSplitOrientation((o) => o === "horizontal" ? "vertical" : "horizontal") : undefined}
         />
       )}
-      {viewingRaw ? (
+      {showSplit ? (
+        <div
+          ref={splitContainerRef}
+          className={cn(
+            "flex-1 min-h-0 flex",
+            splitOrientation === "vertical" && "flex-col",
+            isDragging && "select-none",
+          )}
+        >
+          <div style={{ [splitOrientation === "horizontal" ? "width" : "height"]: `${splitPos}%` }} className="min-h-0 min-w-0 overflow-hidden">
+            <TextViewer
+              content={content.content}
+              path={path}
+              truncated={content.truncated}
+              comments={commentsData?.comments}
+              editable
+              isSaving={isSaving}
+              saveError={displayError}
+              onSave={handleSave}
+              onCancel={handleCancel}
+              onContentChange={setEditedContent}
+            />
+          </div>
+          <div
+            className={cn(
+              "shrink-0 bg-border hover:bg-accent-foreground/20 transition-colors relative",
+              splitOrientation === "horizontal" ? "w-1 cursor-col-resize" : "h-1 cursor-row-resize",
+              isDragging && "bg-accent-foreground/30",
+            )}
+            onMouseDown={handleDragStart}
+            onTouchStart={handleDragStart}
+          >
+            <div className={cn(
+              "absolute inset-0 flex items-center justify-center",
+              splitOrientation === "horizontal" ? "flex-col" : "flex-row",
+            )}>
+              <div className={cn(
+                "rounded-full bg-muted-foreground/30",
+                splitOrientation === "horizontal" ? "w-0.5 h-4" : "h-0.5 w-4",
+              )} />
+            </div>
+          </div>
+          <div className="flex-1 min-h-0 min-w-0 overflow-hidden">
+            <MarkdownViewer
+              content={editedContent || content.content}
+              path={path}
+              comments={commentsData?.comments}
+              onScrollToCommentRef={onScrollToCommentRef}
+              onOutlineChange={onOutlineChange}
+            />
+          </div>
+        </div>
+      ) : viewingRaw ? (
         <TextViewer
           content={content.content}
           path={path}
@@ -383,10 +483,11 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
           saveError={displayError}
           onSave={handleSave}
           onCancel={handleCancel}
+          onContentChange={isEditing && isMd ? setEditedContent : undefined}
         />
       ) : (
         <MarkdownViewer
-          content={content.content}
+          content={isEditing && isMd && editedContent ? editedContent : content.content}
           path={path}
           comments={commentsData?.comments}
           className="flex-1 min-h-0"
@@ -398,7 +499,7 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
   )
 }
 
-function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCount = 0, showViewToggle, showRaw, onToggleRaw, isEditing, onEdit }: {
+function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCount = 0, showViewToggle, showRaw, onToggleRaw, isEditing, onEdit, isMarkdown, splitMode, splitOrientation, onSplitModeChange, onToggleOrientation }: {
   path: string
   actions: ReturnType<typeof useFileActions>
   showExpand: boolean
@@ -410,6 +511,11 @@ function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCou
   onToggleRaw?: () => void
   isEditing?: boolean
   onEdit?: () => void
+  isMarkdown?: boolean
+  splitMode?: "source" | "split" | "preview"
+  splitOrientation?: "horizontal" | "vertical"
+  onSplitModeChange?: (mode: "source" | "split" | "preview") => void
+  onToggleOrientation?: () => void
 }) {
   const { copyPath, copyLink, download, copiedPath, copiedLink, canShare } = actions
   const filename = path.split("/").pop() ?? path
@@ -494,6 +600,78 @@ function ViewerHeader({ path, actions, showExpand, onExpand, onQuery, commentCou
             />
             <TooltipContent>Edit file</TooltipContent>
           </Tooltip>
+        )}
+        {isEditing && isMarkdown && onSplitModeChange && (
+          <>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant={splitMode === "source" ? "secondary" : "ghost"}
+                    size="icon-xs"
+                    onClick={() => onSplitModeChange("source")}
+                    className={splitMode !== "source" ? "text-muted-foreground" : ""}
+                    aria-label="Source view"
+                  >
+                    <Code />
+                  </Button>
+                }
+              />
+              <TooltipContent>Source only</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant={splitMode === "split" ? "secondary" : "ghost"}
+                    size="icon-xs"
+                    onClick={() => onSplitModeChange("split")}
+                    className={splitMode !== "split" ? "text-muted-foreground" : ""}
+                    aria-label="Split view"
+                  >
+                    <Columns2 />
+                  </Button>
+                }
+              />
+              <TooltipContent>Split view</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    variant={splitMode === "preview" ? "secondary" : "ghost"}
+                    size="icon-xs"
+                    onClick={() => onSplitModeChange("preview")}
+                    className={splitMode !== "preview" ? "text-muted-foreground" : ""}
+                    aria-label="Preview view"
+                  >
+                    <Eye />
+                  </Button>
+                }
+              />
+              <TooltipContent>Preview only</TooltipContent>
+            </Tooltip>
+            {splitMode === "split" && onToggleOrientation && (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={onToggleOrientation}
+                      className="text-muted-foreground"
+                      aria-label="Toggle orientation"
+                    >
+                      <LayoutGrid />
+                    </Button>
+                  }
+                />
+                <TooltipContent>
+                  {splitOrientation === "horizontal" ? "Stack vertically" : "Stack horizontally"}
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </>
         )}
         {showViewToggle && onToggleRaw && (
           <Tooltip>

--- a/live/src/components/viewers/TextViewer.tsx
+++ b/live/src/components/viewers/TextViewer.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback, useMemo, type MutableRefObject } from "react"
 import Editor, { useMonaco } from "@monaco-editor/react"
-import { MessageSquare, Braces } from "lucide-react"
+import { MessageSquare, Braces, X, Check, AlertCircle, Circle } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
@@ -36,9 +36,15 @@ interface TextViewerProps {
   comments?: CommentListEntry[]
   className?: string
   onScrollToCommentRef?: MutableRefObject<ScrollToCommentCallback | null>
+  // Edit mode
+  editable?: boolean
+  isSaving?: boolean
+  saveError?: string | null
+  onSave?: (content: string) => void
+  onCancel?: () => void
 }
 
-export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef }: TextViewerProps) {
+export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef, editable = false, isSaving = false, saveError = null, onSave, onCancel }: TextViewerProps) {
   const { resolvedTheme } = useTheme()
   const monaco = useMonaco()
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
@@ -58,6 +64,30 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
       return content
     }
   }, [content, isJson, jsonFormatted])
+
+  // Edit mode state
+  const [editedContent, setEditedContent] = useState(content)
+  const isDirty = editable && editedContent !== content
+
+  // Sync editedContent when entering edit mode or content changes externally
+  useEffect(() => {
+    if (editable) setEditedContent(content)
+  }, [editable])
+
+  // Sync editedContent when content prop changes while not editing
+  useEffect(() => {
+    if (!editable) setEditedContent(content)
+  }, [content, editable])
+
+  // beforeunload guard while dirty
+  useEffect(() => {
+    if (!editable || !isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+    }
+    window.addEventListener("beforeunload", handler)
+    return () => window.removeEventListener("beforeunload", handler)
+  }, [editable, isDirty])
 
   // `e` toggles JSON Format / Raw — the source-view counterpart of the
   // markdown source/preview toggle (a file is either markdown or JSON, never
@@ -91,8 +121,25 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
   // Line comment via gutter click
   const [lineComment, setLineComment] = useState<{ line: number; rect: DOMRect } | null>(null)
 
+  // Ref for save action (so Cmd+S always calls the latest handler)
+  const saveActionRef = useRef<(() => void) | null>(null)
+  useEffect(() => {
+    saveActionRef.current = editable && onSave ? () => onSave(editedContent) : null
+  }, [editable, onSave, editedContent])
+
   const handleEditorMount = useCallback((editor: editor.IStandaloneCodeEditor) => {
     editorRef.current = editor
+
+    // Register Cmd+S for save in edit mode
+    editor.addAction({
+      id: "agent-fs.save-file",
+      label: "Save file",
+      keybindings: [monaco?.KeyMod.CtrlCmd !== undefined ? monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS : 2048 | 49],
+      run: () => {
+        const handler = saveActionRef.current
+        if (handler) handler()
+      },
+    })
 
     // Expose scroll-to-comment for comment click navigation
     if (onScrollToCommentRef) {
@@ -179,7 +226,57 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
 
   return (
     <div className={cn("relative flex flex-col", className)}>
-      {isJson && (
+      {/* Edit mode toolbar */}
+      {editable && (
+        <div className="flex items-center justify-between border-b border-border bg-accent/30 px-3 py-1.5 shrink-0">
+          <div className="flex items-center gap-2">
+            {isDirty && (
+              <span className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Circle className="size-2 fill-amber-500 text-amber-500" />
+                Unsaved
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1.5">
+            {saveError && (
+              <span className="flex items-center gap-1 text-xs text-destructive max-w-[200px] truncate">
+                <AlertCircle className="size-3 shrink-0" />
+                {saveError}
+              </span>
+            )}
+            <Button
+              variant="ghost"
+              size="xs"
+              onClick={() => {
+                if (isDirty && !window.confirm("Discard unsaved changes?")) return
+                onCancel?.()
+              }}
+              disabled={isSaving}
+              className="text-muted-foreground gap-1"
+            >
+              <X className="size-3" />
+              Cancel
+            </Button>
+            <Button
+              variant="default"
+              size="xs"
+              onClick={() => onSave?.(editedContent)}
+              disabled={!isDirty || isSaving}
+              className="gap-1"
+            >
+              {isSaving ? (
+                <Spinner className="size-3" />
+              ) : (
+                <Check className="size-3" />
+              )}
+              Save
+              <Kbd className="ml-0.5">⌘S</Kbd>
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {isJson && !editable && (
         <div className="flex items-center justify-end border-b border-border px-2 py-1 shrink-0">
           <Button
             variant="ghost"
@@ -196,30 +293,31 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
       <div className="flex-1 min-h-0">
         <Editor
           language={lang}
-          value={displayContent}
+          value={editable ? editedContent : displayContent}
+          onChange={editable ? (v) => setEditedContent(v ?? "") : undefined}
           theme={monacoTheme}
           onMount={handleEditorMount}
-          loading={<div className="flex items-center justify-center h-full"><Spinner /></div>}
+          loading={<div className="flex items-center justify-center h-full"><Spinner />}</div>}
           options={{
-            readOnly: true,
+            readOnly: !editable,
             minimap: { enabled: false },
             scrollBeyondLastLine: false,
             fontSize: 13,
             lineHeight: 20,
             fontFamily: "'JetBrains Mono', ui-monospace, monospace",
             fontLigatures: true,
-            glyphMargin: true,
+            glyphMargin: !editable,
             folding: true,
             lineNumbers: "on",
-            renderLineHighlight: "none",
+            renderLineHighlight: editable ? "all" : "none",
             overviewRulerBorder: false,
-            hideCursorInOverviewRuler: true,
+            hideCursorInOverviewRuler: !editable,
             scrollbar: {
               verticalScrollbarSize: 8,
               horizontalScrollbarSize: 8,
             },
             padding: { top: 8 },
-            domReadOnly: true,
+            domReadOnly: !editable,
           }}
         />
       </div>

--- a/live/src/components/viewers/TextViewer.tsx
+++ b/live/src/components/viewers/TextViewer.tsx
@@ -304,7 +304,7 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
           onChange={editable ? (v) => setEditedContent(v ?? "") : undefined}
           theme={monacoTheme}
           onMount={handleEditorMount}
-          loading={<div className="flex items-center justify-center h-full"><Spinner />}</div>}
+          loading={<div className="flex items-center justify-center h-full"><Spinner /></div>}
           options={{
             readOnly: !editable,
             minimap: { enabled: false },

--- a/live/src/components/viewers/TextViewer.tsx
+++ b/live/src/components/viewers/TextViewer.tsx
@@ -42,9 +42,11 @@ interface TextViewerProps {
   saveError?: string | null
   onSave?: (content: string) => void
   onCancel?: () => void
+  /** Reports the current edited content live (for split-view preview). */
+  onContentChange?: (content: string) => void
 }
 
-export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef, editable = false, isSaving = false, saveError = null, onSave, onCancel }: TextViewerProps) {
+export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef, editable = false, isSaving = false, saveError = null, onSave, onCancel, onContentChange }: TextViewerProps) {
   const { resolvedTheme } = useTheme()
   const monaco = useMonaco()
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
@@ -88,6 +90,11 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
     window.addEventListener("beforeunload", handler)
     return () => window.removeEventListener("beforeunload", handler)
   }, [editable, isDirty])
+
+  // Report live edited content to parent (for split-view preview)
+  useEffect(() => {
+    if (editable && onContentChange) onContentChange(editedContent)
+  }, [editedContent, editable, onContentChange])
 
   // `e` toggles JSON Format / Raw — the source-view counterpart of the
   // markdown source/preview toggle (a file is either markdown or JSON, never

--- a/live/src/components/viewers/TextViewer.tsx
+++ b/live/src/components/viewers/TextViewer.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect, useCallback, useMemo, type MutableRefObject } from "react"
 import Editor, { useMonaco } from "@monaco-editor/react"
-import { MessageSquare, Braces, X, Check, AlertCircle, Circle } from "lucide-react"
+import { MessageSquare, Braces } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts"
@@ -38,15 +38,12 @@ interface TextViewerProps {
   onScrollToCommentRef?: MutableRefObject<ScrollToCommentCallback | null>
   // Edit mode
   editable?: boolean
-  isSaving?: boolean
-  saveError?: string | null
   onSave?: (content: string) => void
-  onCancel?: () => void
   /** Reports the current edited content live (for split-view preview). */
   onContentChange?: (content: string) => void
 }
 
-export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef, editable = false, isSaving = false, saveError = null, onSave, onCancel, onContentChange }: TextViewerProps) {
+export function TextViewer({ content, path, truncated, comments, className, onScrollToCommentRef, editable = false, onSave, onContentChange }: TextViewerProps) {
   const { resolvedTheme } = useTheme()
   const monaco = useMonaco()
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null)
@@ -233,56 +230,6 @@ export function TextViewer({ content, path, truncated, comments, className, onSc
 
   return (
     <div className={cn("relative flex flex-col", className)}>
-      {/* Edit mode toolbar */}
-      {editable && (
-        <div className="flex items-center justify-between border-b border-border bg-accent/30 px-3 py-1.5 shrink-0">
-          <div className="flex items-center gap-2">
-            {isDirty && (
-              <span className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Circle className="size-2 fill-amber-500 text-amber-500" />
-                Unsaved
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-1.5">
-            {saveError && (
-              <span className="flex items-center gap-1 text-xs text-destructive max-w-[200px] truncate">
-                <AlertCircle className="size-3 shrink-0" />
-                {saveError}
-              </span>
-            )}
-            <Button
-              variant="ghost"
-              size="xs"
-              onClick={() => {
-                if (isDirty && !window.confirm("Discard unsaved changes?")) return
-                onCancel?.()
-              }}
-              disabled={isSaving}
-              className="text-muted-foreground gap-1"
-            >
-              <X className="size-3" />
-              Cancel
-            </Button>
-            <Button
-              variant="default"
-              size="xs"
-              onClick={() => onSave?.(editedContent)}
-              disabled={!isDirty || isSaving}
-              className="gap-1"
-            >
-              {isSaving ? (
-                <Spinner className="size-3" />
-              ) : (
-                <Check className="size-3" />
-              )}
-              Save
-              <Kbd className="ml-0.5">⌘S</Kbd>
-            </Button>
-          </div>
-        </div>
-      )}
-
       {isJson && !editable && (
         <div className="flex items-center justify-end border-b border-border px-2 py-1 shrink-0">
           <Button

--- a/live/src/hooks/use-file-save.ts
+++ b/live/src/hooks/use-file-save.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from "react"
+import { useAuth } from "@/contexts/auth"
+import type { WriteResult } from "@/api/types"
+
+interface UseFileSaveOptions {
+  path: string
+  expectedVersion?: number
+}
+
+export function useFileSave({ path, expectedVersion }: UseFileSaveOptions) {
+  const { client, orgId, driveId } = useAuth()
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const [savedVersion, setSavedVersion] = useState<number | null>(null)
+
+  const save = useCallback(
+    async (content: string): Promise<WriteResult> => {
+      if (!orgId || !driveId) throw new Error("No active org or drive")
+      setIsSaving(true)
+      setError(null)
+      try {
+        const result = await client.write(orgId, driveId, {
+          path,
+          content,
+          ...(expectedVersion !== undefined ? { expectedVersion } : {}),
+        })
+        setSavedVersion(result.version)
+        return result
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err))
+        setError(e)
+        throw e
+      } finally {
+        setIsSaving(false)
+      }
+    },
+    [client, orgId, driveId, path, expectedVersion],
+  )
+
+  return { save, isSaving, error, savedVersion }
+}

--- a/live/src/pages/FileDetail.tsx
+++ b/live/src/pages/FileDetail.tsx
@@ -154,6 +154,7 @@ export function FileDetailPage() {
             path={filePath}
             showExpandButton={false}
             showHeader={false}
+            showEditButton
             className="flex-1 min-h-0"
             onScrollToCommentRef={scrollToCommentRef}
             onOutlineChange={setOutline}

--- a/thoughts/taras/plans/2026-06-16-file-editing-ui.md
+++ b/thoughts/taras/plans/2026-06-16-file-editing-ui.md
@@ -2,7 +2,7 @@
 date: 2026-06-16
 planner: Claude
 topic: "File editing in live/ web UI"
-status: draft
+status: completed
 autonomy: critical
 ---
 

--- a/thoughts/taras/plans/2026-06-16-file-editing-ui.md
+++ b/thoughts/taras/plans/2026-06-16-file-editing-ui.md
@@ -1,0 +1,211 @@
+---
+date: 2026-06-16
+planner: Claude
+topic: "File editing in live/ web UI"
+status: draft
+autonomy: critical
+---
+
+# File Editing in Web UI — Implementation Plan
+
+## Overview
+
+Enable users to edit text files directly in the browser with Monaco Editor, including a split-view option for markdown files (editable source + rendered preview side-by-side).
+
+- **Motivation**: Users currently have a full read-only file viewing pipeline but must use the CLI or direct S3 access to edit files. Adding in-browser editing completes the core file management loop.
+- **Related**: `thoughts/taras/research/2026-06-16-file-editing-ui-codebase.md`, `live/src/components/viewers/FileViewer.tsx`
+
+## Current State Analysis
+
+- `live/src/api/types.ts` — Only read/query result types defined (`CatResult`, `StatResult`, etc.). No `WriteResult` or `EditResult`.
+- `live/src/api/client.ts` — Only read/query methods (`getSignedUrl`, `callOp` for reads). No `write()` or `edit()` methods.
+- `live/src/components/viewers/TextViewer.tsx` — Monaco Editor with `readOnly: true` (line 204). No editing flow.
+- `live/src/components/viewers/FileViewer.tsx` — ViewerHeader has Copy/Download/SourceToggle/Expand buttons. No Edit/Save/Cancel buttons.
+- `live/src/hooks/` — `useFileContent` fetches read-only content; `useFileActions` only has copy/download/share. No save hook.
+- `packages/core/src/ops/types.ts` — `WriteParams`/`WriteResult` and `EditParams`/`EditResult` already defined server-side.
+- `packages/core/src/ops/write.ts` — Server-side `write` op exists, dispatched via `POST /orgs/:orgId/ops` with RBAC `editor` role.
+- `live/src/components/sql/SqlEditor.tsx` — Only existing writable Monaco instance (for SQL queries, not file editing).
+
+## Desired End State
+
+A user can navigate to any text file, click "Edit" (or press a shortcut), edit the content in a writable Monaco editor, and Save (which writes back via the API). For markdown files, a split-view toggle shows the rendered preview alongside the editable source. Unsaved changes show a dirty indicator; navigating away triggers a confirmation prompt.
+
+## What We're NOT Doing
+
+- No binary file editing (images, PDFs, etc.)
+- No rename/move/delete/copy in this pass (separate feature)
+- No collaborative/real-time editing
+- No offline editing
+- No version history browser UI
+- No revert/restore UI
+
+## Implementation Approach
+
+- Follow the existing architecture patterns: a new hook (`useFileSave`) parallels `useFileContent`; `TextViewer` grows an `editable` mode rather than creating a new component; `FileViewer` integrates edit state in the toolbar.
+- Use `client.callOp<T>(orgId, "write", params, driveId)` for saves — no new API route needed.
+- The existing Source/Preview toggle (`showRaw`) is retained; edit mode adds a dimension on top: in edit mode, the layout can be source-only or split-view.
+- Sequencing: API client → hook → editable text viewer → FileViewer integration → split-view.
+
+## Quick Verification Reference
+
+- `cd live && pnpm run typecheck` — TypeScript type checking in the `live/` package
+- Manual dev server check: `cd live && pnpm dev`
+
+---
+
+## Phase 1: API Foundation — Types + Client Method
+
+### Overview
+
+Add `WriteResult`/`WriteParams` types to the frontend and a `write()` method on `AgentFsClient`, so the frontend can call the server-side write op.
+
+### Changes Required:
+
+#### 1. Add types to `live/src/api/types.ts`
+**File**: `live/src/api/types.ts`
+**Changes**: Add `WriteParams` and `WriteResult` interfaces matching `packages/core/src/ops/types.ts`.
+
+#### 2. Add `write()` method to `live/src/api/client.ts`
+**File**: `live/src/api/client.ts`
+**Changes**: Add `async write(orgId, driveId, params: WriteParams): Promise<WriteResult>` method that calls `this.callOp<WriteResult>(orgId, "write", params, driveId)`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd live && pnpm run typecheck`
+- [ ] Build succeeds: `cd live && pnpm build`
+- [ ] Export check: `node -e "const { WriteParams, WriteResult } = require('./src/api/types')"` (or equivalent ESM import test)
+
+#### Automated QA:
+- [ ] Verify the `write` method signature matches the expected `callOp<T>` pattern
+
+#### Manual Verification:
+- [ ] N/A — type-only changes
+
+**Implementation Note**: After this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Phase 2: `useFileSave` Hook
+
+### Overview
+
+Create a React hook that wraps the write operation with loading/success/error state, dirty tracking, and optimistic concurrency via `expectedVersion`.
+
+### Changes Required:
+
+#### 1. Create `live/src/hooks/use-file-save.ts`
+**File**: `live/src/hooks/use-file-save.ts` (new file)
+**Changes**: Hook with signature `useFileSave(path: string): { save: (content: string) => Promise<WriteResult>, isSaving: boolean, error: Error | null, savedVersion: number | null }`. Accepts optional `expectedVersion` for optimistic concurrency. Uses `useAuth()` for client/orgId/driveId.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd live && pnpm run typecheck`
+
+#### Automated QA:
+- [ ] Hook can be imported and instantiated in a component without errors
+
+#### Manual Verification:
+- [ ] Verify hook handles errors gracefully (network failure, conflict)
+
+**Implementation Note**: After this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Phase 3: Editable `TextViewer` + `FileViewer` Integration
+
+### Overview
+
+Make `TextViewer` optionally editable (writable Monaco) with Save/Cancel UI, and integrate edit mode into `FileViewer` via a toolbar button and keyboard shortcut.
+
+### Changes Required:
+
+#### 1. Modify `TextViewer` to support editable mode
+**File**: `live/src/components/viewers/TextViewer.tsx`
+**Changes**: Add `editable` prop (default `false`). When `editable` is true, set `readOnly: false` on Monaco, show Save/Cancel buttons in a header bar, disable editor during save (loading state), show error message on save failure (dismissable), wire up `useFileSave` hook, track dirty state, intercept `Cmd+S` for save, show a dirty indicator, and register `beforeunload` handler while dirty to prevent accidental navigation.
+
+#### 2. Add edit mode to `FileViewer` + `ViewerHeader`
+**File**: `live/src/components/viewers/FileViewer.tsx`
+**Changes**: Add `isEditing` state, wire up Edit button in `ViewerHeader`, pass `editable` prop to `TextViewer`, confirm before discarding unsaved changes.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd live && pnpm run typecheck`
+
+#### Automated QA:
+- [ ] Edit button appears in ViewerHeader for text files
+- [ ] Clicking Edit makes Monaco writable
+- [ ] Saving calls the write op and shows success
+- [ ] Canceling reverts content and exits edit mode
+- [ ] Dirty indicator appears when content changes
+- [ ] `Cmd+S` triggers save
+- [ ] Navigating away while dirty shows confirmation
+
+#### Manual Verification:
+- [ ] Visual review of the edit toolbar layout
+- [ ] Verify Monaco editor behavior (syntax highlighting, completion) in edit vs read-only mode
+
+**Implementation Note**: After this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Phase 4: Split-View for Markdown Files
+
+### Overview
+
+Add a split-view layout for markdown files: editable Monaco source alongside a live-updating rendered preview. Support side-by-side and stacked orientations.
+
+### Changes Required:
+
+#### 1. Modify `FileViewer` split-view logic
+**File**: `live/src/components/viewers/FileViewer.tsx`
+**Changes**: When editing a markdown file, add a Source/Split/Preview toggle (replacing the current Source/Preview toggle). When in Split mode, render both `TextViewer` (editable) and `MarkdownViewer` (rendered preview, fed the current editor content). Support orientation toggle (side-by-side ↔ stacked) with a draggable resize handle for adjusting pane widths/heights.
+
+#### 2. Ensure `MarkdownViewer` can receive dynamic content
+**File**: `live/src/components/viewers/MarkdownViewer.tsx`
+**Changes**: No structural changes needed — it already receives `content` as a prop. Verify rendering is stable when content changes rapidly (typing).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] TypeScript compiles: `cd live && pnpm run typecheck`
+
+#### Automated QA:
+- [ ] Split-view toggle appears when editing a markdown file
+- [ ] Side-by-side layout shows Monaco (left) + rendered preview (right)
+- [ ] Stacked layout shows Monaco (top) + rendered preview (bottom)
+- [ ] Preview updates live as user types in the editor
+- [ ] Toggle works: source-only ↔ split ↔ preview-only
+- [ ] Split-view is NOT offered for non-markdown text files
+
+#### Manual Verification:
+- [ ] Visual review of split-view layout at different viewport sizes
+- [ ] Verify markdown rendering fidelity in preview pane
+
+**Implementation Note**: After this phase, pause for manual confirmation. Create commit after verification passes.
+
+---
+
+## Review Errata
+
+_Reviewed: 2026-06-16 by Claude_
+
+### Applied
+- [x] Missing YAML frontmatter — added
+- [x] Phase 2 hook signature was vague — clarified exact return type shape (`{ save: (content: string) => Promise<WriteResult>, isSaving, error, savedVersion }`)
+- [x] Phase 3 missing `beforeunload` navigation guard — added to Changes
+- [x] Phase 3 missing error recovery UI (dismissable error message on save failure) — added
+- [x] Phase 3 missing loading state during save (disable editor) — added
+- [x] Phase 4 missing resize handle for split panes — added
+- [x] Derail notes: shortcut conflict now has concrete recommendation (toolbar-only edit, `Escape` to exit, `Cmd+S` to save), plus note on avoiding a split-pane library dependency
+
+- **Follow-up plans**: None yet
+- **Derail notes**: The `e` keyboard shortcut is used for Source/Preview toggle. Recommend: toolbar-only Edit button (no keyboard shortcut to enter edit mode), `Cmd+S` to save (already conventional), and `Escape` to exit edit mode (discard not needed since Monaco handles it). The `EditParams`/`EditResult` types and `edit()` method could be added in a follow-up for find-and-replace editing. Split-view resize behavior could use a lightweight implementation (CSS `resize` property or a simple drag handle) rather than a full library dependency — existing codebase has no split-pane library.
+- **References**:
+  - Research: `thoughts/taras/research/2026-06-16-file-editing-ui-codebase.md`
+  - Core types: `packages/core/src/ops/types.ts` (lines 17, 111 for WriteParams/WriteResult)
+  - Server write: `packages/core/src/ops/write.ts`
+  - SQL Editor (writable Monaco pattern): `live/src/components/sql/SqlEditor.tsx`
+  - Keyboard shortcuts: `live/src/hooks/use-keyboard-shortcuts.ts`

--- a/thoughts/taras/qa/2026-06-16-file-editing-ui.md
+++ b/thoughts/taras/qa/2026-06-16-file-editing-ui.md
@@ -1,0 +1,191 @@
+---
+date: 2026-06-16
+author: Claude
+topic: "File editing in live/ web UI"
+tags: [qa, file-editor, markdown, split-view]
+status: in-progress
+source_plan: thoughts/taras/plans/2026-06-16-file-editing-ui.md
+environment: local
+last_updated: 2026-06-16
+last_updated_by: Claude
+---
+
+# File Editing UI — QA Report
+
+## Context
+
+Validating the in-browser file editing feature: editable Monaco text viewer, save/cancel flow, dirty tracking, and split-view markdown editing.
+
+## Scope
+
+### In Scope
+- Edit button presence for text files
+- Monaco becoming writable in edit mode
+- Save/Cancel flow with dirty confirmation
+- `Cmd+S` save shortcut
+- `beforeunload` guard when dirty
+- Dirty indicator
+- Split-view (source/split/preview) for markdown files
+- Orientation toggle and resize handle for split view
+- Live preview updates
+
+### Out of Scope
+- Binary files (images, PDFs) — edit button should not appear
+- Rename/move/delete/copy
+- Collaborative editing
+- Version history UI
+
+## Test Cases
+
+### TC-1: Edit button appears for text files
+**Steps:**
+1. Open any text file (.ts, .md, .py, etc.) in the browser
+2. Look at the viewer header toolbar
+
+**Expected Result:** A pencil (Edit) icon button is visible in the header toolbar
+**Actual Result:**
+**Status:**
+
+### TC-2: Clicking Edit makes Monaco writable
+**Steps:**
+1. Open a text file
+2. Click the Edit button
+3. Try typing in the editor
+
+**Expected Result:** Monaco editor becomes writable — cursor appears, text can be typed/deleted
+**Actual Result:**
+**Status:**
+
+### TC-3: Save/Cancel bar appears in edit mode
+**Steps:**
+1. Click Edit on a text file
+2. Observe the toolbar between the file header and the editor
+
+**Expected Result:** A bar with Cancel and Save buttons appears, plus a "⌘S" hint on the Save button
+**Actual Result:**
+**Status:**
+
+### TC-4: Dirty indicator shows unsaved changes
+**Steps:**
+1. Enter edit mode
+2. Make a change to the content
+3. Observe the edit toolbar
+
+**Expected Result:** A small "Unsaved" badge with an amber dot appears in the toolbar
+**Actual Result:**
+**Status:**
+
+### TC-5: Cmd+S triggers save
+**Steps:**
+1. Enter edit mode on a text file
+2. Make a change
+3. Press Cmd+S (or Ctrl+S on Linux/Windows)
+
+**Expected Result:** The save flow triggers — the file is saved via the API
+**Actual Result:**
+**Status:**
+
+### TC-6: Cancel reverts content and exits edit mode
+**Steps:**
+1. Enter edit mode and make changes
+2. Click Cancel
+3. Confirm "Discard unsaved changes?" if prompted
+
+**Expected Result:** Content reverts to original, edit mode exits, Monaco returns to read-only
+**Actual Result:**
+**Status:**
+
+### TC-7: Navigating away while dirty shows confirmation
+**Steps:**
+1. Enter edit mode and make changes
+2. Try to close the tab or navigate away
+
+**Expected Result:** Browser shows a "Leave site? Changes you made may not be saved." confirmation dialog
+**Actual Result:**
+**Status:**
+
+### TC-8: Edit button hidden during edit mode
+**Steps:**
+1. Enter edit mode on a text file
+2. Look at the header toolbar
+
+**Expected Result:** The Edit button is hidden while in edit mode (Save/Cancel replaces it)
+**Actual Result:**
+**Status:**
+
+### TC-9: Split-view toggle appears for markdown files in edit mode
+**Steps:**
+1. Open a .md file
+2. Click Edit
+3. Observe the header toolbar
+
+**Expected Result:** Three toggle buttons appear: Source (Code icon), Split (Columns icon), Preview (Eye icon)
+**Actual Result:**
+**Status:**
+
+### TC-10: Split-view not offered for non-markdown text files
+**Steps:**
+1. Open a .ts file
+2. Click Edit
+
+**Expected Result:** Only the standard Save/Cancel bar appears — no Source/Split/Preview toggle
+**Actual Result:**
+**Status:**
+
+### TC-11: Side-by-side split view works
+**Steps:**
+1. Open a .md file and enter edit mode
+2. Click the Split button (columns icon)
+3. Edit the markdown content
+
+**Expected Result:** Monaco (left) and rendered preview (right) appear side by side. Preview updates live as you type.
+**Actual Result:**
+**Status:**
+
+### TC-12: Orientation toggle changes layout
+**Steps:**
+1. Open a .md file → Edit → Split view
+2. Click the Layout Grid button (orientation toggle)
+
+**Expected Result:** Layout switches from side-by-side (horizontal) to stacked (top/bottom). Toggle again to go back.
+**Actual Result:**
+**Status:**
+
+### TC-13: Resize handle works in split view
+**Steps:**
+1. Open a .md file → Edit → Split view
+2. Drag the resize divider between the two panes
+
+**Expected Result:** The divider moves, resizing the panes proportionally (min ~20%, max ~80%)
+**Actual Result:**
+**Status:**
+
+### TC-14: Preview-only mode works in edit
+**Steps:**
+1. Open a .md file → Edit → Split view
+2. Click the Preview (Eye) button
+
+**Expected Result:** Only the rendered preview is shown (editor hidden). Content reflects latest edits.
+**Actual Result:**
+**Status:**
+
+### TC-15: Edit button does NOT appear for binary files
+**Steps:**
+1. Open a PDF, image, or video file
+
+**Expected Result:** No Edit button in the header toolbar
+**Actual Result:**
+**Status:**
+
+## Edge Cases & Exploratory Testing
+- [To be filled]
+
+## Evidence
+[To be filled]
+
+## Issues Found
+[To be filled]
+
+## Verdict
+**Status**: IN PROGRESS
+**Summary**: QA in progress — test cases pending manual execution

--- a/thoughts/taras/research/2026-06-16-file-editing-ui-codebase.md
+++ b/thoughts/taras/research/2026-06-16-file-editing-ui-codebase.md
@@ -1,0 +1,91 @@
+---
+date: 2026-06-16T14:00:00-04:00
+researcher: Claude
+git_commit: 8c15da7
+branch: main
+repository: agent-fs
+topic: "File editing capabilities in the live/ web UI"
+tags: [research, codebase, live, ui, file-editing]
+status: complete
+autonomy: critical
+last_updated: 2026-06-16
+last_updated_by: Claude
+---
+
+# Research: File Editing in the Web UI
+
+**Date**: 2026-06-16
+**Researcher**: Claude
+**Git Commit**: `8c15da7`
+**Branch**: `main`
+
+## Research Question
+
+What exists in the agent-fs codebase to support file editing from the web UI (`live/` SPA), and what specific pieces need to be built? The goal: allow users to edit text files directly in the browser with a split-view option (source + preview) for markdown.
+
+## Summary
+
+The codebase has a complete read-only file viewing pipeline but zero file editing capability in the UI. All the server-side infrastructure for writes already exists (`write` op, `PUT /raw` endpoint, `client.callOp` dispatch). The frontend needs three focused additions: (1) a `WriteResult` type + `useFileSave` hook, (2) an edit mode toggle in `TextViewer.tsx` (which already uses Monaco Editor), and (3) a split-view mode for markdown files showing editable source alongside rendered preview.
+
+## Detailed Findings
+
+### 1. Server-Side Write Infrastructure (exists)
+
+The `write` op in `packages/core/src/ops/write.ts:20` accepts `WriteParams` (`{ path, content, message?, expectedVersion? }`) and writes to S3 with versioning, dedup, and search indexing. It's dispatched via `POST /orgs/:orgId/ops` with `op: "write"`. RBAC enforces `editor` role or better through `dispatchOp`. The `writeRaw` variant handles binary payloads up to 50 MB via `PUT /raw`.
+
+### 2. API Client Dispatch (exists)
+
+`live/src/api/client.ts:82` — `client.callOp<T>(orgId, "write", params, driveId)` can call any registered op. No `WriteResult` type exists in `live/src/api/types.ts` — only `CatResult`, `StatResult`, etc.
+
+### 3. Read-Only Viewers (exist, need modification)
+
+| Component | File | Role |
+|-----------|------|------|
+| `FileViewer` | `live/src/components/viewers/FileViewer.tsx:119` | Dispatcher — routes by extension to the correct viewer |
+| `TextViewer` | `live/src/components/viewers/TextViewer.tsx:41` | Monaco Editor with `readOnly: true` (line 204) |
+| `MarkdownViewer` | `live/src/components/viewers/MarkdownViewer.tsx` | `react-markdown` rendered HTML preview |
+| `ViewerHeader` | `live/src/components/viewers/FileViewer.tsx:364` | Toolbar with Copy, Download, Source/Preview toggle, Expand |
+
+### 4. Content Fetching (exists)
+
+`live/src/hooks/use-file-content.ts:10` — Fetches via signed URL. Returns `{ content, totalLines, truncated }`. `useFileStat` (via `use-file-stat.ts`) provides `currentVersion` for optimistic concurrency.
+
+### 5. Auth Context (exists)
+
+`live/src/contexts/auth.tsx:164` — `useAuth()` provides `client`, `orgId`, `driveId` everywhere in the component tree.
+
+### 6. The Only Existing Writable Monaco (reference pattern)
+
+`live/src/components/sql/SqlEditor.tsx` — Uses Monaco without `readOnly`, demonstrates the writable Monaco pattern. Also has `cmd+enter` for query execution.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `packages/core/src/ops/write.ts` | 20 | Server-side `write` op implementation |
+| `packages/core/src/ops/types.ts` | 17 | `WriteParams` type definition |
+| `packages/core/src/ops/types.ts` | 111 | `WriteResult` type definition |
+| `live/src/api/client.ts` | 82 | `callOp` dispatch method |
+| `live/src/api/types.ts` | — | Missing `WriteResult` type |
+| `live/src/components/viewers/FileViewer.tsx` | 119 | Main viewer dispatcher |
+| `live/src/components/viewers/FileViewer.tsx` | 204 | `readOnly: true` in Monaco config |
+| `live/src/components/viewers/FileViewer.tsx` | 364 | `ViewerHeader` toolbar |
+| `live/src/components/viewers/FileViewer.tsx` | 86 | `isMarkdown()` check |
+| `live/src/components/viewers/TextViewer.tsx` | 41 | Monaco text viewer (read-only) |
+| `live/src/components/viewers/MarkdownViewer.tsx` | — | Markdown rendered preview |
+| `live/src/components/sql/SqlEditor.tsx` | — | Writable Monaco reference pattern |
+| `live/src/hooks/use-file-content.ts` | 10 | File content fetch hook |
+| `live/src/hooks/use-file-actions.ts` | 11 | File action hook (copy, download) |
+| `live/src/contexts/auth.tsx` | 164 | `useAuth()` context |
+| `live/src/hooks/use-keyboard-shortcuts.ts` | 127 | Shortcut registry hook |
+
+## Open Questions
+
+- Editing should be available for all text files that `isTextFile()` returns true for.
+- Split view should support both side-by-side (left=rich preview, right=source editor) and stacked (top=editor, bottom=preview) layouts, togglable.
+- A visual "dirty" indicator should show when content differs from the last saved version.
+
+## Appendix
+
+- **Architecture notes**: The app follows a consistent pattern: viewer components receive `path` and render content; they don't own mutation state. Adding editing should follow the same pattern — a new `useFileSave` hook with loading/success/error state, and an "edit mode" toggled per-viewer.
+- **Related research**: None found in `thoughts/` for UI editing.


### PR DESCRIPTION
Adds in-browser file editing with Monaco Editor, Save/Cancel flow, dirty tracking, and split-view markdown editing.

### Changes

- **Phase 1**: API types (WriteParams/WriteResult) and client.write() method
- **Phase 2**: useFileSave hook with loading/success/error state and optimistic concurrency
- **Phase 3**: Editable TextViewer with writable Monaco, persistent Save/Cancel bar, dirty indicator, Cmd+S shortcut, beforeunload guard, Escape to exit edit mode
- **Phase 4**: Split-view for markdown files — Source/Split/Preview toggle, side-by-side and stacked layouts, draggable resize handle, live preview updates

### Notes

Manual QA in progress — test cases at thoughts/taras/qa/2026-06-16-file-editing-ui.md
