### PR TITLE
feat(storage): multi-adapter storage via StorageAdapter interface (S3 + local-FS)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "desplega-ai"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@desplega.ai/agent-fs",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "bin": {
         "agent-fs": "dist/cli.js",
       },
@@ -46,7 +46,7 @@
     },
     "packages/core": {
       "name": "@desplega.ai/agent-fs-core",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.750.0",
         "@aws-sdk/s3-request-presigner": "^3.750.0",
@@ -55,6 +55,7 @@
         "chonkie": "^0.3.0",
         "diff": "^8.0.3",
         "drizzle-orm": "^0.44.0",
+        "files-sdk": "^2.0.0",
         "node-llama-cpp": "^3.17.1",
         "openai": "^6.29.0",
         "sqlite-vec": "^0.1.9",
@@ -68,15 +69,15 @@
     },
     "packages/fuse-helper-linux-arm64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-      "version": "0.8.1",
+      "version": "0.9.0",
     },
     "packages/fuse-helper-linux-x64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-      "version": "0.8.1",
+      "version": "0.9.0",
     },
     "packages/just-bash": {
       "name": "@desplega.ai/agent-fs-just-bash",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "peerDependencies": {
         "just-bash": ">=3.0.1",
       },
@@ -86,7 +87,7 @@
     },
     "packages/mcp": {
       "name": "@desplega.ai/agent-fs-mcp",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -95,7 +96,7 @@
     },
     "packages/server": {
       "name": "@desplega.ai/agent-fs-server",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@desplega.ai/agent-fs-mcp": "workspace:*",
@@ -732,6 +733,8 @@
 
     "filenamify": ["filenamify@6.0.0", "", { "dependencies": { "filename-reserved-regex": "^3.0.0" } }, "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ=="],
 
+    "files-sdk": ["files-sdk@2.0.0", "", { "dependencies": { "commander": "^15.0.0", "picomatch": "^4.0.4" }, "optionalDependencies": { "@modelcontextprotocol/sdk": "^1.29.0" }, "peerDependencies": { "@anthropic-ai/claude-agent-sdk": "^0.3.0", "@aws-sdk/client-s3": "^3.700.0", "@aws-sdk/lib-storage": "^3.700.0", "@aws-sdk/s3-presigned-post": "^3.700.0", "@aws-sdk/s3-request-presigner": "^3.700.0", "@azure/core-auth": "^1.9.0", "@azure/identity": "^4.5.0", "@azure/storage-blob": "^12.26.0", "@bunny.net/storage-sdk": "^0.3.1", "@google-cloud/storage": "^7.19.0", "@googleapis/drive": "^20.0.0", "@microsoft/microsoft-graph-client": "^3.0.7", "@netlify/blobs": "^10.7.4", "@openai/agents": "^0.11.0", "@opentelemetry/api": "^1.9.0", "@supabase/storage-js": "^2.105.4", "@sveltejs/kit": "^2.0.0", "@vercel/blob": "^2.4.0", "ai": "^6.0.0", "astro": "^4.0.0 || ^5.0.0 || ^6.0.0", "basic-ftp": "^6.0.1", "box-typescript-sdk-gen": "^1.19.1", "cloudinary": "^2.10.0", "convex": "^1.16.0", "disk": "^0.8.18", "dropbox": "^10.34.0", "fastify": "^4.0.0 || ^5.0.0", "firebase-admin": "^13.10.0", "google-auth-library": "^10.0.0", "h3": "^1.0.0", "hono": "^4.0.0", "koa": "^2.0.0 || ^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "node-appwrite": "^26.0.0", "openai": "^6.0.0", "pocketbase": "^0.27.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "ssh2-sftp-client": "^12.1.1", "svelte": "^4.0.0 || ^5.0.0", "uploadthing": "^7", "vue": "^3.4.0", "zod": "^3.23.0 || ^4.0.0" }, "optionalPeers": ["@anthropic-ai/claude-agent-sdk", "@aws-sdk/client-s3", "@aws-sdk/lib-storage", "@aws-sdk/s3-presigned-post", "@aws-sdk/s3-request-presigner", "@azure/core-auth", "@azure/identity", "@azure/storage-blob", "@bunny.net/storage-sdk", "@google-cloud/storage", "@googleapis/drive", "@microsoft/microsoft-graph-client", "@netlify/blobs", "@openai/agents", "@opentelemetry/api", "@supabase/storage-js", "@sveltejs/kit", "@vercel/blob", "ai", "astro", "basic-ftp", "box-typescript-sdk-gen", "cloudinary", "convex", "disk", "dropbox", "fastify", "firebase-admin", "google-auth-library", "h3", "hono", "koa", "next", "node-appwrite", "openai", "pocketbase", "react", "react-dom", "ssh2-sftp-client", "svelte", "uploadthing", "vue", "zod"], "bin": { "files": "dist/cli/index.js" } }, "sha512-97/pw8eIZ3EKiP+28CNbSssqjnlJQKLhqpJG1vt3vVPX6wuZxvcsMzCvQYBE3W6HjWOcbtFxSbj8jyR/dtJGpw=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
@@ -939,6 +942,8 @@
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -1151,6 +1156,10 @@
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "fetch-blob/web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "files-sdk/@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "files-sdk/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.9.0",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.9.0"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.10.0",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.10.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",

--- a/packages/cli/src/__tests__/capability-error.test.ts
+++ b/packages/cli/src/__tests__/capability-error.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { createTestDb, MockS3Client } from "../../../core/src/test-utils.js";
+import { createApp } from "../../../server/src/app.js";
+
+// CLI surfacing test: drive the real ApiClient against an in-process daemon
+// backed by a no-versioning adapter so a `revert` returns HTTP 422
+// UNSUPPORTED_OPERATION. Assert the thrown Error.message is the clean
+// message + "Suggestion:" line that `commands/ops.ts` prints as `Error: <msg>`
+// — no stack trace, no raw S3/FS error.
+
+let server: ReturnType<typeof Bun.serve>;
+let port = 0;
+let apiKey: string;
+let orgId: string;
+
+beforeAll(async () => {
+  const db = createTestDb();
+  const s3 = new MockS3Client({ capabilities: { versioning: false } });
+  const app = createApp(db, s3 as any);
+
+  server = Bun.serve({ port: 0, fetch: app.fetch });
+  port = server.port!;
+
+  const res = await fetch(`http://localhost:${port}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "cli-cap@example.com" }),
+  });
+  const body = await res.json();
+  apiKey = body.apiKey;
+  orgId = body.orgId;
+
+  process.env.AGENT_FS_API_URL = `http://localhost:${port}`;
+  process.env.AGENT_FS_API_KEY = apiKey;
+});
+
+afterAll(() => {
+  server?.stop();
+  delete process.env.AGENT_FS_API_URL;
+  delete process.env.AGENT_FS_API_KEY;
+});
+
+describe("CLI surfacing of UnsupportedOperation", () => {
+  async function makeClient() {
+    const { ApiClient } = await import("../api-client.js");
+    return new ApiClient();
+  }
+
+  test("revert 422 surfaces as a clean Error message with a Suggestion line", async () => {
+    const client = await makeClient();
+
+    // Seed a file so the version row exists.
+    await client.callOp(orgId, "write", { path: "/cli-cap.txt", content: "v1" });
+
+    let caught: Error | null = null;
+    try {
+      await client.callOp(orgId, "revert", { path: "/cli-cap.txt", version: 1 });
+    } catch (err: any) {
+      caught = err;
+    }
+
+    expect(caught).not.toBeNull();
+    const msg = caught!.message;
+    // Clean, friendly wording + actionable suggestion...
+    expect(msg).toContain("not supported");
+    expect(msg).toContain("Suggestion:");
+    // ...and NOT a stack trace leaking into the rendered line.
+    expect(msg).not.toMatch(/\n\s+at\s/);
+  });
+});

--- a/packages/cli/src/commands/config-cmd.ts
+++ b/packages/cli/src/commands/config-cmd.ts
@@ -1,11 +1,13 @@
 import { Command } from "commander";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
 import {
   getConfig,
   setConfigValue,
   getDbPath,
   getConfigPath,
-  AgentS3Client,
+  createStorageAdapter,
+  isLocalStorageConfig,
   createEmbeddingProviderFromEnv,
 } from "@/core";
 
@@ -67,30 +69,57 @@ export function configCommands() {
         message: configExists ? getConfigPath() : "Not found — run `agent-fs onboard`",
       });
 
-      // 2. Required S3 fields
-      const s3Fields = ["endpoint", "bucket", "accessKeyId", "secretAccessKey"] as const;
-      const missingS3 = s3Fields.filter((f) => !config.s3[f]);
-      results.push({
-        name: "S3 config",
-        ok: missingS3.length === 0,
-        message:
-          missingS3.length === 0
-            ? `${config.s3.provider} → ${config.s3.endpoint}/${config.s3.bucket}`
-            : `Missing: ${missingS3.join(", ")}`,
-      });
+      // 2 + 3. Storage config + connectivity (provider-aware)
+      if (isLocalStorageConfig(config.s3)) {
+        // Local-FS backend: "validate" = root is set and creatable + writable.
+        const root = config.s3.root;
+        results.push({
+          name: "Storage config",
+          ok: !!root,
+          message: root ? `local → ${root}` : "Missing: root",
+        });
+        if (root) {
+          let ok = true;
+          let message = `Writable (${root})`;
+          try {
+            mkdirSync(root, { recursive: true });
+            const probe = join(root, `.agent-fs-probe-${process.pid}`);
+            writeFileSync(probe, "ok");
+            rmSync(probe);
+          } catch (err: any) {
+            ok = false;
+            message = err.message || `Not writable: ${root}`;
+          }
+          results.push({ name: "Storage connectivity", ok, message });
+        }
+      } else {
+        // S3 / MinIO backend: required fields + a live list probe. Capture a
+        // narrowed local (the guard's narrowing is lost inside the .filter
+        // callback since config.s3 is a property access).
+        const s3cfg = config.s3;
+        const s3Fields = ["endpoint", "bucket", "accessKeyId", "secretAccessKey"] as const;
+        const missingS3 = s3Fields.filter((f) => !s3cfg[f]);
+        results.push({
+          name: "S3 config",
+          ok: missingS3.length === 0,
+          message:
+            missingS3.length === 0
+              ? `${s3cfg.provider} → ${s3cfg.endpoint}/${s3cfg.bucket}`
+              : `Missing: ${missingS3.join(", ")}`,
+        });
 
-      // 3. S3 connectivity
-      if (missingS3.length === 0) {
-        try {
-          const s3 = new AgentS3Client(config.s3);
-          await s3.listObjects("");
-          results.push({ name: "S3 connectivity", ok: true, message: "Connected" });
-        } catch (err: any) {
-          results.push({
-            name: "S3 connectivity",
-            ok: false,
-            message: err.message || "Connection failed",
-          });
+        if (missingS3.length === 0) {
+          try {
+            const s3 = createStorageAdapter(s3cfg);
+            await s3.listObjects("");
+            results.push({ name: "S3 connectivity", ok: true, message: "Connected" });
+          } catch (err: any) {
+            results.push({
+              name: "S3 connectivity",
+              ok: false,
+              message: err.message || "Connection failed",
+            });
+          }
         }
       }
 

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 import { execSync } from "node:child_process";
 import {
   getConfig,
+  setConfig,
   setConfigValue,
   createDatabase,
   getUserByApiKey,
@@ -10,13 +11,26 @@ import {
   createUser,
   getConfigPath,
   getDbPath,
+  getHome,
+  isLocalStorageConfig,
 } from "@/core";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
 
 export function onboardCommand() {
   const cmd = new Command("onboard")
     .description("Set up agent-fs (storage, embeddings, database, first user)")
     .option("--local", "Use local MinIO Docker container for S3")
+    .option(
+      "--filesystem",
+      "Use a local filesystem directory for storage (no Docker/MinIO)"
+    )
+    .option("--storage <provider>", "Storage backend: minio (default) | local")
+    .option(
+      "--storage-root <dir>",
+      "Directory for --filesystem storage (default: ~/.agent-fs/storage)"
+    )
     .option("--remote <url>", "Connect to a remote agent-fs server")
     .option("-y, --yes", "Accept all defaults without prompts")
     .option("--s3-endpoint <url>", "S3 endpoint URL")
@@ -52,12 +66,18 @@ export function onboardCommand() {
 
       console.log("Setting up agent-fs...\n");
 
+      // A local filesystem backend ("--filesystem" / "--storage local") is a
+      // distinct path from "--local" (which means a local MinIO *container*).
+      const isFilesystem = !!opts.filesystem || opts.storage === "local";
+
       // Default to local mode unless explicit S3 flags or --remote provided
       const hasCustomS3 = opts.s3Endpoint || opts.s3Bucket || opts.s3AccessKey || opts.s3SecretKey;
-      const isLocal = !hasCustomS3;
+      const isLocal = !isFilesystem && !hasCustomS3;
 
       // Step 1: Storage backend
-      if (opts.s3Endpoint) {
+      if (isFilesystem) {
+        setupLocalFilesystem(opts.storageRoot);
+      } else if (opts.s3Endpoint) {
         // Custom S3 from flags
         setConfigValue("s3.endpoint", opts.s3Endpoint);
         if (opts.s3Bucket) setConfigValue("s3.bucket", opts.s3Bucket);
@@ -86,7 +106,7 @@ export function onboardCommand() {
       const db = createDatabase();
       console.log("Database ready.");
 
-      if (isLocal || opts.yes) {
+      if (isLocal || isFilesystem || opts.yes) {
         const { apiKey } = ensureLocalUser(db);
         const user = getUserByApiKey(db, apiKey)!;
         const orgs = listUserOrgs(db, user.id);
@@ -252,8 +272,39 @@ async function setupLocalMinIO(autoYes: boolean) {
   console.log("MinIO configured.");
 }
 
+/**
+ * Local-filesystem storage: no Docker, no S3. Replaces the whole `s3` config
+ * section with the `{ provider: "local", root }` variant (via setConfig, not a
+ * dot-path set, so stale S3 fields don't linger) and ensures the dir exists.
+ */
+function setupLocalFilesystem(rootOpt?: string) {
+  let root: string;
+  if (rootOpt && rootOpt.length > 0) {
+    if (rootOpt.startsWith("~/")) {
+      root = join(homedir(), rootOpt.slice(2));
+    } else {
+      root = isAbsolute(rootOpt) ? rootOpt : resolve(rootOpt);
+    }
+  } else {
+    root = join(getHome(), "storage");
+  }
+
+  mkdirSync(root, { recursive: true });
+  setConfig("s3", { provider: "local", root });
+
+  console.log("Filesystem storage configured (no Docker required).");
+  console.log(`  Provider: local`);
+  console.log(`  Root: ${root}`);
+}
+
 async function setupCustomS3() {
   const config = getConfig();
+  // The storage union is S3 here (this path is only reached for non-local
+  // backends); narrow so the S3-only fields are accessible.
+  if (isLocalStorageConfig(config.s3)) {
+    console.log(`Using local filesystem storage at ${config.s3.root}`);
+    return;
+  }
   console.log("Using S3 configuration from ~/.agent-fs/config.json");
   console.log(`  Provider: ${config.s3.provider}`);
   console.log(`  Endpoint: ${config.s3.endpoint}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
     "chonkie": "^0.3.0",
     "diff": "^8.0.3",
     "drizzle-orm": "^0.44.0",
+    "files-sdk": "^2.0.0",
     "node-llama-cpp": "^3.17.1",
     "openai": "^6.29.0",
     "sqlite-vec": "^0.1.9",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -7,6 +7,7 @@ import {
   setConfigValue,
   getHome,
 } from "./config.js";
+import type { S3StorageConfig } from "./config.js";
 import { createTestConfigDir } from "./test-utils.js";
 
 /**
@@ -26,6 +27,8 @@ const OVERRIDE_ENV_VARS = [
   "AWS_REGION",
   "S3_REGION",
   "S3_PROVIDER",
+  "AGENT_FS_STORAGE_PROVIDER",
+  "AGENT_FS_LOCAL_ROOT",
   "SERVER_PORT",
   "SERVER_HOST",
   "EMBEDDING_PROVIDER",
@@ -83,8 +86,8 @@ describe("Config system", () => {
   test("getConfig creates directory and config.json with defaults", () => {
     const config = getConfig();
 
-    expect(config.s3.bucket).toBe("agentfs");
-    expect(config.s3.endpoint).toBe("http://localhost:9000");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("agentfs");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
     expect(config.server.port).toBe(7433);
     expect(config.server.host).toBe("127.0.0.1");
     expect(config.embedding.provider).toBe("local");
@@ -149,7 +152,7 @@ describe("Deep merge config", () => {
     expect(config.server.cors).toEqual({ origins: ["*"] });
     expect(config.server.rateLimit).toEqual({ requestsPerMinute: 1200 });
     // Other sections untouched
-    expect(config.s3.bucket).toBe("agentfs");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("agentfs");
     expect(config.s3.provider).toBe("minio");
     expect(config.embedding.provider).toBe("local");
   });
@@ -163,10 +166,10 @@ describe("Deep merge config", () => {
 
     const config = getConfig();
 
-    expect(config.s3.bucket).toBe("my-bucket");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("my-bucket");
     expect(config.s3.provider).toBe("minio");
-    expect(config.s3.region).toBe("us-east-1");
-    expect(config.s3.endpoint).toBe("http://localhost:9000");
+    expect((config.s3 as S3StorageConfig).region).toBe("us-east-1");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
   });
 });
 
@@ -195,11 +198,11 @@ describe("Env var overrides", () => {
 
     const config = getConfig();
 
-    expect(config.s3.endpoint).toBe("https://s3.example.com");
-    expect(config.s3.accessKeyId).toBe("my-access-key");
-    expect(config.s3.secretAccessKey).toBe("my-secret-key");
-    expect(config.s3.bucket).toBe("env-bucket");
-    expect(config.s3.region).toBe("eu-west-1");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("https://s3.example.com");
+    expect((config.s3 as S3StorageConfig).accessKeyId).toBe("my-access-key");
+    expect((config.s3 as S3StorageConfig).secretAccessKey).toBe("my-secret-key");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("env-bucket");
+    expect((config.s3 as S3StorageConfig).region).toBe("eu-west-1");
     expect(config.s3.provider).toBe("tigris");
   });
 
@@ -222,11 +225,11 @@ describe("Env var overrides", () => {
 
     const config = getConfig();
 
-    expect(config.s3.endpoint).toBe("https://tigris.example.com");
-    expect(config.s3.accessKeyId).toBe("tigris-access-key");
-    expect(config.s3.secretAccessKey).toBe("tigris-secret-key");
-    expect(config.s3.bucket).toBe("tigris-bucket");
-    expect(config.s3.region).toBe("auto");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("https://tigris.example.com");
+    expect((config.s3 as S3StorageConfig).accessKeyId).toBe("tigris-access-key");
+    expect((config.s3 as S3StorageConfig).secretAccessKey).toBe("tigris-secret-key");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("tigris-bucket");
+    expect((config.s3 as S3StorageConfig).region).toBe("auto");
   });
 
   test("SERVER_PORT is parsed as integer", () => {
@@ -261,11 +264,11 @@ describe("Env var overrides", () => {
 
     const config = getConfig();
 
-    expect(config.s3.bucket).toBe("env-only-bucket");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("env-only-bucket");
     expect(config.server.port).toBe(5555);
     expect(config.embedding.provider).toBe("gemini");
     // Other defaults still intact
-    expect(config.s3.endpoint).toBe("http://localhost:9000");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
     expect(config.server.host).toBe("127.0.0.1");
   });
 
@@ -290,8 +293,8 @@ describe("Env var overrides", () => {
 
     const config = getConfig();
 
-    expect(config.s3.bucket).toBe("env-wins-bucket");
-    expect(config.s3.endpoint).toBe("http://json-endpoint:9000"); // not overridden by env
+    expect((config.s3 as S3StorageConfig).bucket).toBe("env-wins-bucket");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://json-endpoint:9000"); // not overridden by env
     expect(config.server.port).toBe(8888);
   });
 
@@ -300,15 +303,15 @@ describe("Env var overrides", () => {
 
     const config = getConfig();
 
-    expect(config.s3.publicEndpoint).toBe("https://public.s3.example.com");
+    expect((config.s3 as S3StorageConfig).publicEndpoint).toBe("https://public.s3.example.com");
     // s3.endpoint should remain at default (not overridden)
-    expect(config.s3.endpoint).toBe("http://localhost:9000");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
   });
 
   test("s3.publicEndpoint is undefined when S3_PUBLIC_ENDPOINT is unset", () => {
     const config = getConfig();
 
-    expect(config.s3.publicEndpoint).toBeUndefined();
+    expect((config.s3 as S3StorageConfig).publicEndpoint).toBeUndefined();
   });
 
   test("auth.apiKey is NOT overridable via env vars", () => {
@@ -325,5 +328,94 @@ describe("Env var overrides", () => {
     const config = getConfig();
 
     expect(config.auth.apiKey).toBe("original-key");
+  });
+});
+
+describe("Local-FS storage variant", () => {
+  let testHome: string;
+  let cleanup: () => void;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = clearOverrideEnvVars();
+    ({ dir: testHome, cleanup } = createTestConfigDir());
+  });
+
+  afterEach(() => {
+    cleanup();
+    restoreEnvVars(savedEnv);
+  });
+
+  test("local config.json round-trips through getConfig with no stale S3 fields", () => {
+    const configPath = join(testHome, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ s3: { provider: "local", root: "/data/fsroot" } }, null, 2)
+    );
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("local");
+    expect((config.s3 as { root: string }).root).toBe("/data/fsroot");
+    // Provider switch must REPLACE s3 wholesale — no bleed-through of the
+    // S3-shaped DEFAULT_CONFIG.s3 fields.
+    expect("bucket" in config.s3).toBe(false);
+    expect("endpoint" in config.s3).toBe(false);
+    expect("accessKeyId" in config.s3).toBe(false);
+  });
+
+  test("S3 config.json still merges defaults (regression — no provider switch)", () => {
+    const configPath = join(testHome, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ s3: { bucket: "my-bucket" } }, null, 2)
+    );
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("minio");
+    expect((config.s3 as { bucket: string }).bucket).toBe("my-bucket");
+    expect((config.s3 as { endpoint: string }).endpoint).toBe("http://localhost:9000");
+    expect((config.s3 as { region: string }).region).toBe("us-east-1");
+  });
+
+  test("AGENT_FS_STORAGE_PROVIDER=local selects local and honors AGENT_FS_LOCAL_ROOT, skipping S3_*", () => {
+    process.env.AGENT_FS_STORAGE_PROVIDER = "local";
+    process.env.AGENT_FS_LOCAL_ROOT = "/srv/agentfs";
+    // S3 env vars must be ignored for the local backend.
+    process.env.S3_BUCKET = "should-be-ignored";
+    process.env.S3_ENDPOINT = "http://ignored:9000";
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("local");
+    expect((config.s3 as { root: string }).root).toBe("/srv/agentfs");
+    expect("bucket" in config.s3).toBe(false);
+    expect("endpoint" in config.s3).toBe(false);
+  });
+
+  test("AGENT_FS_STORAGE_PROVIDER=local without AGENT_FS_LOCAL_ROOT defaults root to <home>/storage", () => {
+    process.env.AGENT_FS_STORAGE_PROVIDER = "local";
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("local");
+    expect((config.s3 as { root: string }).root).toBe(join(testHome, "storage"));
+  });
+
+  test("local config.json ignores S3_* env overrides", () => {
+    const configPath = join(testHome, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ s3: { provider: "local", root: "/data/fsroot" } }, null, 2)
+    );
+    process.env.S3_ENDPOINT = "http://ignored:9000";
+    process.env.S3_BUCKET = "ignored-bucket";
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("local");
+    expect((config.s3 as { root: string }).root).toBe("/data/fsroot");
+    expect("endpoint" in config.s3).toBe(false);
   });
 });

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -171,6 +171,24 @@ describe("Deep merge config", () => {
     expect((config.s3 as S3StorageConfig).region).toBe("us-east-1");
     expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
   });
+
+  test("non-minio S3 provider keeps default S3 fields (only local switches the shape)", () => {
+    // A partial S3-compatible config with a non-default provider must still
+    // inherit the sibling S3 defaults — all S3 providers share one shape, so it
+    // must NOT be replaced wholesale the way a `local` switch is.
+    const configPath = join(testHome, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ s3: { provider: "s3", bucket: "prod-bucket" } }, null, 2)
+    );
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("s3");
+    expect((config.s3 as S3StorageConfig).bucket).toBe("prod-bucket");
+    expect((config.s3 as S3StorageConfig).region).toBe("us-east-1");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("http://localhost:9000");
+  });
 });
 
 describe("Env var overrides", () => {
@@ -417,5 +435,32 @@ describe("Local-FS storage variant", () => {
     expect(config.s3.provider).toBe("local");
     expect((config.s3 as { root: string }).root).toBe("/data/fsroot");
     expect("endpoint" in config.s3).toBe(false);
+  });
+
+  test("AGENT_FS_STORAGE_PROVIDER overrides a persisted local config and applies S3 env vars", () => {
+    // A machine onboarded with `--filesystem` (persisted provider: "local") must
+    // still be switchable to S3 via env (deployment scenario). The env provider
+    // wins, and seeded S3 defaults fill the fields env doesn't set.
+    const configPath = join(testHome, "config.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({ s3: { provider: "local", root: "/data/fsroot" } }, null, 2)
+    );
+    process.env.AGENT_FS_STORAGE_PROVIDER = "s3";
+    process.env.S3_ENDPOINT = "https://s3.example.com";
+    process.env.S3_BUCKET = "switched-bucket";
+    process.env.S3_ACCESS_KEY_ID = "ak";
+    process.env.S3_SECRET_ACCESS_KEY = "sk";
+
+    const config = getConfig();
+
+    expect(config.s3.provider).toBe("s3");
+    expect("root" in config.s3).toBe(false);
+    expect((config.s3 as S3StorageConfig).bucket).toBe("switched-bucket");
+    expect((config.s3 as S3StorageConfig).endpoint).toBe("https://s3.example.com");
+    expect((config.s3 as S3StorageConfig).accessKeyId).toBe("ak");
+    expect((config.s3 as S3StorageConfig).secretAccessKey).toBe("sk");
+    // Seeded S3 defaults remain for fields env didn't override.
+    expect((config.s3 as S3StorageConfig).region).toBe("us-east-1");
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -10,17 +10,59 @@ function resolveHome(): string {
   return home;
 }
 
+/**
+ * S3 / MinIO storage backend config (the historical default). `provider` is an
+ * open string — known labels are "minio" | "s3" | "r2" | "tigris", but any
+ * S3-compatible provider name (or an env-supplied value) is accepted.
+ */
+export interface S3StorageConfig {
+  provider: string;
+  bucket: string;
+  region: string;
+  endpoint: string;
+  publicEndpoint?: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  versioningEnabled?: boolean;
+}
+
+/** Local-filesystem storage backend config (no S3/Docker). */
+export interface LocalStorageConfig {
+  provider: "local";
+  /** Directory the local-FS backend manages (keys map to nested paths under it). */
+  root: string;
+}
+
+/**
+ * Storage backend configuration — a tagged union discriminated by `provider`.
+ * Existing S3 configs default to / migrate to the {@link S3StorageConfig}
+ * variant, keeping the S3 path byte-for-byte behavior-compatible.
+ */
+export type AgentFSStorageConfig = S3StorageConfig | LocalStorageConfig;
+
+/**
+ * Narrow the storage union to its local-FS variant.
+ *
+ * A user-defined type guard is required (rather than a bare
+ * `cfg.provider === "local"` check) because {@link S3StorageConfig.provider} is
+ * an open `string` that structurally subsumes the `"local"` literal, so plain
+ * control-flow narrowing can't discriminate the union on its own.
+ */
+export function isLocalStorageConfig(
+  cfg: AgentFSStorageConfig
+): cfg is LocalStorageConfig {
+  return cfg.provider === "local";
+}
+
 export interface AgentFSConfig {
-  s3: {
-    provider: string;
-    bucket: string;
-    region: string;
-    endpoint: string;
-    publicEndpoint?: string;
-    accessKeyId: string;
-    secretAccessKey: string;
-    versioningEnabled?: boolean;
-  };
+  /**
+   * Storage backend. Field name kept as `s3` (legacy) to minimize churn across
+   * the many `config.s3` consumers even though it now also carries the non-S3
+   * `local` variant; discriminated by `config.s3.provider`. (Renaming to
+   * `config.storage` is a larger refactor, recorded as a derail in the
+   * multi-adapter plan — intentionally not done here.)
+   */
+  s3: AgentFSStorageConfig;
   embedding: {
     provider: "local" | "openai" | "gemini";
     model: string;
@@ -112,14 +154,28 @@ function deepMergeConfig(
 ): AgentFSConfig {
   const result = { ...defaults };
   for (const key of Object.keys(overrides) as (keyof AgentFSConfig)[]) {
-    if (
-      overrides[key] &&
-      typeof overrides[key] === "object" &&
-      !Array.isArray(overrides[key])
-    ) {
-      result[key] = { ...(defaults[key] as any), ...(overrides[key] as any) } as any;
-    } else if (overrides[key] !== undefined) {
-      result[key] = overrides[key] as any;
+    const ov = overrides[key];
+    // Storage is a tagged union: when the override switches `provider` to a
+    // different-shaped variant (e.g. "local"), a shallow 2-level merge would
+    // leave stale S3 fields (bucket/endpoint/…) bleeding under it. Replace
+    // wholesale on a provider switch; otherwise shallow-merge (same/unset
+    // provider) so partial S3 overrides keep their sibling defaults.
+    if (key === "s3" && ov && typeof ov === "object" && !Array.isArray(ov)) {
+      const ovS3 = ov as Partial<AgentFSStorageConfig>;
+      if (ovS3.provider && ovS3.provider !== defaults.s3.provider) {
+        result.s3 = { ...(ovS3 as AgentFSStorageConfig) };
+      } else {
+        result.s3 = {
+          ...(defaults.s3 as object),
+          ...(ovS3 as object),
+        } as AgentFSStorageConfig;
+      }
+      continue;
+    }
+    if (ov && typeof ov === "object" && !Array.isArray(ov)) {
+      result[key] = { ...(defaults[key] as any), ...(ov as any) } as any;
+    } else if (ov !== undefined) {
+      result[key] = ov as any;
     }
   }
   return result;
@@ -132,19 +188,37 @@ function deepMergeConfig(
 function applyEnvOverrides(config: AgentFSConfig): AgentFSConfig {
   const env = process.env;
 
-  // S3 overrides (AWS_* takes precedence over S3_*)
-  if (env.AWS_ENDPOINT_URL_S3 || env.S3_ENDPOINT)
-    config.s3.endpoint = (env.AWS_ENDPOINT_URL_S3 || env.S3_ENDPOINT)!;
-  if (env.AWS_ACCESS_KEY_ID || env.S3_ACCESS_KEY_ID)
-    config.s3.accessKeyId = (env.AWS_ACCESS_KEY_ID || env.S3_ACCESS_KEY_ID)!;
-  if (env.AWS_SECRET_ACCESS_KEY || env.S3_SECRET_ACCESS_KEY)
-    config.s3.secretAccessKey = (env.AWS_SECRET_ACCESS_KEY || env.S3_SECRET_ACCESS_KEY)!;
-  if (env.BUCKET_NAME || env.S3_BUCKET)
-    config.s3.bucket = (env.BUCKET_NAME || env.S3_BUCKET)!;
-  if (env.AWS_REGION || env.S3_REGION)
-    config.s3.region = (env.AWS_REGION || env.S3_REGION)!;
-  if (env.S3_PROVIDER) config.s3.provider = env.S3_PROVIDER;
-  if (env.S3_PUBLIC_ENDPOINT) config.s3.publicEndpoint = env.S3_PUBLIC_ENDPOINT;
+  // Storage backend selection. AGENT_FS_STORAGE_PROVIDER switches the backend;
+  // for the local-FS variant AGENT_FS_LOCAL_ROOT points at the managed dir.
+  // When local is selected we REPLACE config.s3 with the local-shaped variant
+  // (so no stale S3 fields linger) and SKIP the S3_*/AWS_* block below — those
+  // env vars are meaningless for a filesystem backend.
+  if (env.AGENT_FS_STORAGE_PROVIDER === "local" || config.s3.provider === "local") {
+    const existingRoot = isLocalStorageConfig(config.s3) ? config.s3.root : undefined;
+    const root =
+      env.AGENT_FS_LOCAL_ROOT || existingRoot || join(getHome(), "storage");
+    config.s3 = { provider: "local", root };
+  } else {
+    // Not the local backend → S3 variant. `provider` is an open string so it is
+    // not a usable discriminant; cast to a mutable S3-typed reference (same
+    // object) for the in-place field overrides.
+    const s3 = config.s3 as S3StorageConfig;
+    if (env.AGENT_FS_STORAGE_PROVIDER) s3.provider = env.AGENT_FS_STORAGE_PROVIDER;
+
+    // S3 overrides (AWS_* takes precedence over S3_*)
+    if (env.AWS_ENDPOINT_URL_S3 || env.S3_ENDPOINT)
+      s3.endpoint = (env.AWS_ENDPOINT_URL_S3 || env.S3_ENDPOINT)!;
+    if (env.AWS_ACCESS_KEY_ID || env.S3_ACCESS_KEY_ID)
+      s3.accessKeyId = (env.AWS_ACCESS_KEY_ID || env.S3_ACCESS_KEY_ID)!;
+    if (env.AWS_SECRET_ACCESS_KEY || env.S3_SECRET_ACCESS_KEY)
+      s3.secretAccessKey = (env.AWS_SECRET_ACCESS_KEY || env.S3_SECRET_ACCESS_KEY)!;
+    if (env.BUCKET_NAME || env.S3_BUCKET)
+      s3.bucket = (env.BUCKET_NAME || env.S3_BUCKET)!;
+    if (env.AWS_REGION || env.S3_REGION)
+      s3.region = (env.AWS_REGION || env.S3_REGION)!;
+    if (env.S3_PROVIDER) s3.provider = env.S3_PROVIDER;
+    if (env.S3_PUBLIC_ENDPOINT) s3.publicEndpoint = env.S3_PUBLIC_ENDPOINT;
+  }
 
   // Server overrides (SERVER_* takes precedence over generic PORT/HOST)
   if (env.SERVER_PORT || env.PORT)

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -155,14 +155,18 @@ function deepMergeConfig(
   const result = { ...defaults };
   for (const key of Object.keys(overrides) as (keyof AgentFSConfig)[]) {
     const ov = overrides[key];
-    // Storage is a tagged union: when the override switches `provider` to a
-    // different-shaped variant (e.g. "local"), a shallow 2-level merge would
-    // leave stale S3 fields (bucket/endpoint/…) bleeding under it. Replace
-    // wholesale on a provider switch; otherwise shallow-merge (same/unset
-    // provider) so partial S3 overrides keep their sibling defaults.
+    // Storage is a tagged union. The only genuine *shape* switch is to/from the
+    // local variant ({ provider, root }); all S3-compatible providers
+    // (minio/s3/r2/tigris/…) share the one S3 shape. A shallow 2-level merge
+    // across a shape switch would leave stale S3 fields (bucket/endpoint/…)
+    // bleeding under a local override, so replace wholesale ONLY on a local⇄S3
+    // switch; otherwise shallow-merge so a partial S3 override (e.g. just
+    // `{ provider: "s3", bucket }`) keeps its sibling S3 defaults.
     if (key === "s3" && ov && typeof ov === "object" && !Array.isArray(ov)) {
       const ovS3 = ov as Partial<AgentFSStorageConfig>;
-      if (ovS3.provider && ovS3.provider !== defaults.s3.provider) {
+      const overrideIsLocal = ovS3.provider === "local";
+      const defaultsAreLocal = defaults.s3.provider === "local";
+      if (overrideIsLocal !== defaultsAreLocal) {
         result.s3 = { ...(ovS3 as AgentFSStorageConfig) };
       } else {
         result.s3 = {
@@ -190,20 +194,33 @@ function applyEnvOverrides(config: AgentFSConfig): AgentFSConfig {
 
   // Storage backend selection. AGENT_FS_STORAGE_PROVIDER switches the backend;
   // for the local-FS variant AGENT_FS_LOCAL_ROOT points at the managed dir.
-  // When local is selected we REPLACE config.s3 with the local-shaped variant
-  // (so no stale S3 fields linger) and SKIP the S3_*/AWS_* block below — those
-  // env vars are meaningless for a filesystem backend.
-  if (env.AGENT_FS_STORAGE_PROVIDER === "local" || config.s3.provider === "local") {
+  // An explicit env provider WINS over the persisted config (so a deployment
+  // can switch a machine that was onboarded `--filesystem` over to S3/MinIO via
+  // env); we only fall back to a persisted `local` provider when the env var
+  // doesn't force a backend. When local is selected we REPLACE config.s3 with
+  // the local-shaped variant (so no stale S3 fields linger) and SKIP the
+  // S3_*/AWS_* block below — those env vars are meaningless for a filesystem
+  // backend.
+  const envProvider = env.AGENT_FS_STORAGE_PROVIDER;
+  const useLocal =
+    envProvider === "local" || (!envProvider && config.s3.provider === "local");
+  if (useLocal) {
     const existingRoot = isLocalStorageConfig(config.s3) ? config.s3.root : undefined;
     const root =
       env.AGENT_FS_LOCAL_ROOT || existingRoot || join(getHome(), "storage");
     config.s3 = { provider: "local", root };
   } else {
-    // Not the local backend → S3 variant. `provider` is an open string so it is
-    // not a usable discriminant; cast to a mutable S3-typed reference (same
-    // object) for the in-place field overrides.
+    // Not the local backend → S3 variant. If the persisted config is the
+    // local-shaped variant (the env var is switching backends), seed the S3
+    // defaults so the override block has the full field set to populate instead
+    // of leaving bucket/region/endpoint undefined.
+    if (isLocalStorageConfig(config.s3)) {
+      config.s3 = { ...DEFAULT_CONFIG.s3 };
+    }
+    // `provider` is an open string so it is not a usable discriminant; cast to a
+    // mutable S3-typed reference (same object) for the in-place field overrides.
     const s3 = config.s3 as S3StorageConfig;
-    if (env.AGENT_FS_STORAGE_PROVIDER) s3.provider = env.AGENT_FS_STORAGE_PROVIDER;
+    if (envProvider) s3.provider = envProvider;
 
     // S3 overrides (AWS_* takes precedence over S3_*)
     if (env.AWS_ENDPOINT_URL_S3 || env.S3_ENDPOINT)

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -107,3 +107,34 @@ export class ValidationError extends AgentFSError {
     };
   }
 }
+
+export class UnsupportedOperation extends AgentFSError {
+  readonly operation: string;
+  readonly backend?: string;
+
+  constructor(
+    operation: string,
+    backend?: string,
+    opts?: { suggestion?: string }
+  ) {
+    const message = backend
+      ? `Operation '${operation}' is not supported by the '${backend}' storage backend`
+      : `Operation '${operation}' is not supported by the current storage backend`;
+    super(
+      "UNSUPPORTED_OPERATION",
+      message,
+      opts?.suggestion ??
+        "Use a backend that supports this operation (e.g. an S3/MinIO or local-FS drive)"
+    );
+    this.operation = operation;
+    this.backend = backend;
+  }
+
+  toJSON() {
+    return {
+      ...super.toJSON(),
+      operation: this.operation,
+      ...(this.backend && { backend: this.backend }),
+    };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export type {
   StorageAdapter,
   StorageCapabilities,
 } from "./storage/adapter.js";
+export { LocalStorageAdapter } from "./storage/local-adapter.js";
+export type { LocalStorageAdapterOptions } from "./storage/local-adapter.js";
 export {
   AgentFSError,
   NotFoundError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,10 @@ export type {
   GetObjectResult,
   HeadObjectResult,
 } from "./s3/index.js";
+export type {
+  StorageAdapter,
+  StorageCapabilities,
+} from "./storage/adapter.js";
 export {
   AgentFSError,
   NotFoundError,
@@ -24,6 +28,7 @@ export {
   EditConflictError,
   IndexingInProgressError,
   ValidationError,
+  UnsupportedOperation,
 } from "./errors.js";
 export {
   dispatchOp,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,13 @@ export {
   getDbPath,
   getHome,
 } from "./config.js";
-export type { AgentFSConfig } from "./config.js";
+export { isLocalStorageConfig } from "./config.js";
+export type {
+  AgentFSConfig,
+  AgentFSStorageConfig,
+  S3StorageConfig,
+  LocalStorageConfig,
+} from "./config.js";
 export { AgentS3Client } from "./s3/index.js";
 export type {
   S3Object,
@@ -23,6 +29,7 @@ export type {
 } from "./storage/adapter.js";
 export { LocalStorageAdapter } from "./storage/local-adapter.js";
 export type { LocalStorageAdapterOptions } from "./storage/local-adapter.js";
+export { createStorageAdapter } from "./storage/factory.js";
 export {
   AgentFSError,
   NotFoundError,

--- a/packages/core/src/ops/__tests__/revert.test.ts
+++ b/packages/core/src/ops/__tests__/revert.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "bun:test";
+import { dispatchOp } from "../index.js";
+import { revert } from "../revert.js";
+import { diff } from "../diff.js";
+import { createTestContext } from "../../test-utils.js";
+import { UnsupportedOperation } from "../../errors.js";
+
+describe("capability gating: revert", () => {
+  test("revert on a no-versioning backend throws UnsupportedOperation", async () => {
+    const { ctx } = createTestContext({ capabilities: { versioning: false } });
+
+    await dispatchOp(ctx, "write", { path: "/r.txt", content: "v1" });
+    await dispatchOp(ctx, "edit", {
+      path: "/r.txt",
+      old_string: "v1",
+      new_string: "v2",
+    });
+
+    // Call the op directly so we can assert on the concrete error instance/code.
+    await expect(
+      revert(ctx, { path: "/r.txt", version: 1 })
+    ).rejects.toBeInstanceOf(UnsupportedOperation);
+
+    try {
+      await revert(ctx, { path: "/r.txt", version: 1 });
+      throw new Error("expected revert to throw");
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(UnsupportedOperation);
+      expect(err.code).toBe("UNSUPPORTED_OPERATION");
+      expect(err.operation).toBe("revert");
+      expect(err.suggestion).toBeTruthy();
+    }
+  });
+
+  test("revert through dispatchOp also surfaces the typed code", async () => {
+    const { ctx } = createTestContext({ capabilities: { versioning: false } });
+    await dispatchOp(ctx, "write", { path: "/r2.txt", content: "hello" });
+
+    try {
+      await dispatchOp(ctx, "revert", { path: "/r2.txt", version: 1 });
+      throw new Error("expected revert to throw");
+    } catch (err: any) {
+      expect(err.code).toBe("UNSUPPORTED_OPERATION");
+    }
+  });
+});
+
+describe("capability gating: diff degrades, never throws", () => {
+  test("historical diff on a no-versioning backend returns the diffSummary fallback", async () => {
+    const { ctx } = createTestContext({ capabilities: { versioning: false } });
+
+    await dispatchOp(ctx, "write", { path: "/d.txt", content: "old" });
+    await dispatchOp(ctx, "edit", {
+      path: "/d.txt",
+      old_string: "old",
+      new_string: "new",
+    });
+
+    // Must NOT throw UnsupportedOperation — diff degrades to the stored summary.
+    const result = (await diff(ctx, { path: "/d.txt", v1: 1, v2: 2 })) as any;
+    expect(Array.isArray(result.changes)).toBe(true);
+    // The edit op records a diffSummary, so the fallback produces changes.
+    expect(result.changes.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/ops/diff.ts
+++ b/packages/core/src/ops/diff.ts
@@ -41,8 +41,12 @@ export async function diff(
     );
   }
 
-  // If both versions have S3 version IDs, fetch and diff the actual content
-  if (v1Record.s3VersionId && v2Record.s3VersionId) {
+  // If the backend supports versioning AND both versions have version handles,
+  // fetch and diff the actual content. Unlike `revert` (which hard-throws
+  // UnsupportedOperation), historical `diff` degrades gracefully: a backend
+  // without versioning skips the doomed version-handle fetch and falls back to
+  // the stored `diffSummary` below — it must never throw UnsupportedOperation.
+  if (ctx.s3.capabilities.versioning && v1Record.s3VersionId && v2Record.s3VersionId) {
     const s3Key = getS3Key(ctx.orgId, ctx.driveId, params.path);
 
     try {

--- a/packages/core/src/ops/revert.ts
+++ b/packages/core/src/ops/revert.ts
@@ -8,6 +8,7 @@ import {
   assertExpectedVersion,
 } from "./versioning.js";
 import { NotFoundError, AgentFSError } from "../errors.js";
+import { assertCapability } from "../storage/capabilities.js";
 import { detectMimeType } from "./mime.js";
 import { indexBytesForSearch } from "./search-index.js";
 
@@ -15,6 +16,12 @@ export async function revert(
   ctx: OpContext,
   params: RevertParams
 ): Promise<RevertResult> {
+  // Capability gate: a backend without object versioning can never retrieve
+  // old content by version handle, so fail fast with a typed, friendly error
+  // rather than a raw S3/FS error later. (The narrower VERSIONING_REQUIRED
+  // case below covers a versioning-capable backend whose row lacks a handle.)
+  assertCapability(ctx.s3, "versioning", "revert");
+
   // Optimistic concurrency: head must match expectedVersion before
   // a new revert version is created on top of it.
   if (params.expectedVersion !== undefined) {

--- a/packages/core/src/ops/signed-url.ts
+++ b/packages/core/src/ops/signed-url.ts
@@ -1,7 +1,8 @@
 import type { OpContext } from "./types.js";
 import { getS3Key } from "./versioning.js";
+import { buildAppUrl } from "./urls.js";
 import { normalizePath } from "./paths.js";
-import { NotFoundError } from "../errors.js";
+import { NotFoundError, UnsupportedOperation } from "../errors.js";
 import { detectMimeType } from "./mime.js";
 
 export interface SignedUrlParams {
@@ -13,7 +14,14 @@ export interface SignedUrlResult {
   url: string;
   path: string;
   expiresIn: number;
+  /** ISO expiry for a `presigned` URL; empty for a non-expiring `app` link. */
   expiresAt: string;
+  /**
+   * `"presigned"` — a native, time-limited download URL (public, no auth).
+   * `"app"` — an authenticated in-app link (the daemon `/raw` route + viewer
+   * require sign-in) for backends without presigned URLs. It does not expire.
+   */
+  kind: "presigned" | "app";
 }
 
 export async function signedUrl(
@@ -36,6 +44,27 @@ export async function signedUrl(
     throw err;
   }
 
+  // Capability gate: backends that can't mint native presigned URLs (e.g. the
+  // local-FS adapter) fall back to the daemon app URL instead of hard-failing.
+  // NOTE: the daemon `GET …/raw` route and the `/file/~/…` viewer are auth-gated
+  // (see server `routes/files.ts` + `authMiddleware`), so this is an
+  // *authenticated in-app link* (requires sign-in), NOT a public/presigned URL.
+  if (!ctx.s3.capabilities.presignedUrls) {
+    if (!ctx.appUrl) {
+      throw new UnsupportedOperation("signed-url", undefined, {
+        suggestion:
+          "This storage backend cannot mint presigned URLs and no app URL is configured to fall back to.",
+      });
+    }
+    return {
+      url: buildAppUrl(ctx.appUrl, ctx.orgId, ctx.driveId, normalizedPath),
+      path: normalizedPath,
+      expiresIn: 0,
+      expiresAt: "",
+      kind: "app",
+    };
+  }
+
   const contentType = detectMimeType(normalizedPath);
   const url = await ctx.s3.getPresignedUrl(
     key,
@@ -48,5 +77,6 @@ export async function signedUrl(
     path: normalizedPath,
     expiresIn,
     expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+    kind: "presigned",
   };
 }

--- a/packages/core/src/ops/stat.ts
+++ b/packages/core/src/ops/stat.ts
@@ -15,7 +15,15 @@ export async function stat(
   try {
     s3Head = await ctx.s3.headObject(s3Key);
   } catch (err: any) {
-    if (err?.name === "NotFound" || err?.$metadata?.httpStatusCode === 404) {
+    // S3 `headObject` misses surface as `NotFound`; the local-FS adapter
+    // translates misses to the `NoSuchKey` shape every other op branches on
+    // (cat/append/edit/tail/signed-url). Handle both so a missing file is a
+    // clean NOT_FOUND on every backend rather than a raw 500.
+    if (
+      err?.name === "NotFound" ||
+      err?.name === "NoSuchKey" ||
+      err?.$metadata?.httpStatusCode === 404
+    ) {
       throw new NotFoundError(`File not found: ${params.path}`, {
         path: params.path,
       });

--- a/packages/core/src/ops/types.ts
+++ b/packages/core/src/ops/types.ts
@@ -1,10 +1,10 @@
-import type { AgentS3Client } from "../s3/client.js";
+import type { StorageAdapter } from "../storage/adapter.js";
 import type { DB } from "../db/index.js";
 import type { EmbeddingProvider } from "../search/embeddings/provider.js";
 
 export interface OpContext {
   db: DB;
-  s3: AgentS3Client;
+  s3: StorageAdapter;
   orgId: string;
   driveId: string;
   userId: string;

--- a/packages/core/src/s3/__tests__/client.test.ts
+++ b/packages/core/src/s3/__tests__/client.test.ts
@@ -30,6 +30,25 @@ describe("S3 Client", () => {
     expect(client.versioningEnabled).toBe(true);
   });
 
+  test("capabilities.versioning tracks the mutable versioningEnabled flag (startup reconciliation)", () => {
+    // The daemon reconciles `versioningEnabled` with the bucket's real state at
+    // startup (`s3.versioningEnabled = await s3.checkVersioningEnabled()`); this
+    // only fixes the revert/diff gate if the `capabilities` getter reads the
+    // live field rather than a value frozen at construction.
+    const client = new AgentS3Client({
+      provider: "minio",
+      bucket: "test-bucket",
+      region: "us-east-1",
+      endpoint: "http://localhost:9000",
+      accessKeyId: "minioadmin",
+      secretAccessKey: "minioadmin",
+    });
+
+    expect(client.capabilities.versioning).toBe(false);
+    client.versioningEnabled = true;
+    expect(client.capabilities.versioning).toBe(true);
+  });
+
   test("getPresignedUrl uses publicEndpoint host when set", async () => {
     const client = new AgentS3Client({
       provider: "minio",

--- a/packages/core/src/s3/client.ts
+++ b/packages/core/src/s3/client.ts
@@ -12,47 +12,36 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import type { AgentFSConfig } from "../config.js";
+import type {
+  StorageAdapter,
+  StorageCapabilities,
+  S3Object,
+  S3ObjectVersion,
+  PutObjectResult,
+  GetObjectResult,
+  HeadObjectResult,
+} from "../storage/adapter.js";
 
-export interface S3Object {
-  key: string;
-  size: number;
-  lastModified: Date;
-  etag?: string;
-}
+// These value/result types now live in storage/adapter.ts (canonical home).
+// Re-exported here for back-compat with existing `s3/client.js` / `@/core` imports.
+export type {
+  S3Object,
+  S3ObjectVersion,
+  PutObjectResult,
+  GetObjectResult,
+  HeadObjectResult,
+} from "../storage/adapter.js";
 
-export interface S3ObjectVersion {
-  versionId: string;
-  lastModified: Date;
-  size: number;
-  isLatest: boolean;
-}
-
-export interface PutObjectResult {
-  etag?: string;
-  versionId?: string;
-}
-
-export interface GetObjectResult {
-  body: Uint8Array;
-  contentType?: string;
-  size?: number;
-  versionId?: string;
-  etag?: string;
-}
-
-export interface HeadObjectResult {
-  contentType?: string;
-  size: number;
-  lastModified?: Date;
-  etag?: string;
-  versionId?: string;
-}
-
-export class AgentS3Client {
+export class AgentS3Client implements StorageAdapter {
   private client: S3Client;
   private presignClient: S3Client;
   private bucket: string;
   versioningEnabled: boolean = false;
+
+  /** S3/MinIO supports both bucket versioning and native presigned URLs. */
+  get capabilities(): StorageCapabilities {
+    return { versioning: this.versioningEnabled, presignedUrls: true };
+  }
 
   constructor(config: AgentFSConfig["s3"]) {
     this.bucket = config.bucket;

--- a/packages/core/src/s3/client.ts
+++ b/packages/core/src/s3/client.ts
@@ -11,7 +11,7 @@ import {
   PutBucketVersioningCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import type { AgentFSConfig } from "../config.js";
+import type { S3StorageConfig } from "../config.js";
 import type {
   StorageAdapter,
   StorageCapabilities,
@@ -43,7 +43,7 @@ export class AgentS3Client implements StorageAdapter {
     return { versioning: this.versioningEnabled, presignedUrls: true };
   }
 
-  constructor(config: AgentFSConfig["s3"]) {
+  constructor(config: S3StorageConfig) {
     this.bucket = config.bucket;
     const credentials = {
       accessKeyId: config.accessKeyId,

--- a/packages/core/src/storage/__tests__/adapter.test.ts
+++ b/packages/core/src/storage/__tests__/adapter.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from "bun:test";
+import type { StorageAdapter } from "../adapter.js";
+import { MockS3Client } from "../../test-utils.js";
+import { AgentS3Client } from "../../s3/client.js";
+import { UnsupportedOperation } from "../../errors.js";
+
+describe("StorageAdapter contract", () => {
+  test("MockS3Client implements the full surface (capabilities + getPresignedUrl)", async () => {
+    const mock = new MockS3Client();
+    expect(mock.capabilities).toEqual({
+      versioning: false,
+      presignedUrls: true,
+    });
+
+    const mockVersioned = new MockS3Client({ versioningEnabled: true });
+    expect(mockVersioned.capabilities).toEqual({
+      versioning: true,
+      presignedUrls: true,
+    });
+
+    const url = await mock.getPresignedUrl("k");
+    expect(typeof url).toBe("string");
+    expect(url).toContain("k");
+  });
+
+  test("MockS3Client and AgentS3Client are assignable to StorageAdapter", () => {
+    // Type-level assignability check — compiles only if both fully implement the interface.
+    const _mock: StorageAdapter = new MockS3Client();
+    const _s3: StorageAdapter = new AgentS3Client({
+      provider: "minio",
+      bucket: "test-bucket",
+      region: "us-east-1",
+      endpoint: "http://localhost:9000",
+      accessKeyId: "minioadmin",
+      secretAccessKey: "minioadmin",
+    });
+    expect(_mock.capabilities.presignedUrls).toBe(true);
+    expect(_s3.capabilities.presignedUrls).toBe(true);
+  });
+});
+
+describe("UnsupportedOperation", () => {
+  test("carries code, operation, backend, and message", () => {
+    const err = new UnsupportedOperation("revert", "local");
+    expect(err.code).toBe("UNSUPPORTED_OPERATION");
+    expect(err.operation).toBe("revert");
+    expect(err.backend).toBe("local");
+
+    const json = err.toJSON();
+    expect(json.operation).toBe("revert");
+    expect(json.backend).toBe("local");
+    expect(json.message).toContain("revert");
+    expect(json.message).toContain("local");
+  });
+
+  test("works without a backend label", () => {
+    const err = new UnsupportedOperation("signed-url");
+    expect(err.code).toBe("UNSUPPORTED_OPERATION");
+    expect(err.operation).toBe("signed-url");
+    expect(err.backend).toBeUndefined();
+    expect(err.toJSON().backend).toBeUndefined();
+  });
+});

--- a/packages/core/src/storage/__tests__/factory.test.ts
+++ b/packages/core/src/storage/__tests__/factory.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { createStorageAdapter } from "../factory.js";
+import { LocalStorageAdapter } from "../local-adapter.js";
+import { AgentS3Client } from "../../s3/client.js";
+import type { AgentFSConfig } from "../../config.js";
+
+const S3_CFG: AgentFSConfig["s3"] = {
+  provider: "minio",
+  bucket: "agentfs",
+  region: "us-east-1",
+  endpoint: "http://localhost:9000",
+  accessKeyId: "minioadmin",
+  secretAccessKey: "minioadmin",
+};
+
+const LOCAL_CFG: AgentFSConfig["s3"] = {
+  provider: "local",
+  root: "/tmp/agent-fs-factory-test",
+};
+
+describe("createStorageAdapter", () => {
+  const savedOverride = process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+
+  afterEach(() => {
+    if (savedOverride === undefined) {
+      delete process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+    } else {
+      process.env.AGENT_FS_CAPABILITY_OVERRIDE = savedOverride;
+    }
+  });
+
+  test('provider "local" selects LocalStorageAdapter', () => {
+    delete process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+    const adapter = createStorageAdapter(LOCAL_CFG);
+    expect(adapter).toBeInstanceOf(LocalStorageAdapter);
+    expect(adapter.capabilities).toEqual({ versioning: true, presignedUrls: false });
+  });
+
+  test('provider "minio" selects AgentS3Client', () => {
+    delete process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+    const adapter = createStorageAdapter(S3_CFG);
+    expect(adapter).toBeInstanceOf(AgentS3Client);
+    expect(adapter.capabilities.presignedUrls).toBe(true);
+  });
+
+  test("custom S3-compatible provider string still selects AgentS3Client", () => {
+    delete process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+    const adapter = createStorageAdapter({ ...S3_CFG, provider: "tigris" });
+    expect(adapter).toBeInstanceOf(AgentS3Client);
+  });
+
+  test("AGENT_FS_CAPABILITY_OVERRIDE overlays advertised capabilities (test-only hook)", () => {
+    process.env.AGENT_FS_CAPABILITY_OVERRIDE = JSON.stringify({ versioning: false });
+    const adapter = createStorageAdapter(LOCAL_CFG);
+    expect(adapter.capabilities.versioning).toBe(false);
+    // Untouched capabilities are preserved.
+    expect(adapter.capabilities.presignedUrls).toBe(false);
+  });
+});

--- a/packages/core/src/storage/__tests__/local-adapter-ops.test.ts
+++ b/packages/core/src/storage/__tests__/local-adapter-ops.test.ts
@@ -1,0 +1,92 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalStorageAdapter } from "../local-adapter.js";
+import { createTestContext } from "../../test-utils.js";
+import { getS3Key } from "../../ops/versioning.js";
+import { write, edit, append, log, diff, revert, signedUrl } from "../../ops/index.js";
+import { UnsupportedOperation } from "../../errors.js";
+import type { OpContext } from "../../ops/types.js";
+
+const PATH = "/doc.txt";
+const APP_URL = "http://localhost:7777";
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+
+/**
+ * Proves the local-FS adapter gets the FULL versioning tier end-to-end: the
+ * version-critical ops (`diff`/`revert`) return REAL historical content via the
+ * content-addressed blob handles, with no native object versioning.
+ */
+describe("LocalStorageAdapter — op-level versioning (full tier)", () => {
+  let root: string;
+  let ctx: OpContext;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "afs-local-ops-"));
+    const base = createTestContext();
+    ctx = {
+      ...base.ctx,
+      s3: new LocalStorageAdapter({ root }),
+      appUrl: APP_URL,
+    };
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("write → edit → append → log → diff(v1,v2) → revert(v1) round-trips real content", async () => {
+    const w = await write(ctx, { path: PATH, content: "line1\n" });
+    expect(w.version).toBe(1);
+
+    const e = await edit(ctx, {
+      path: PATH,
+      old_string: "line1",
+      new_string: "LINE-ONE",
+    });
+    expect(e.version).toBe(2);
+
+    const a = await append(ctx, { path: PATH, content: "line2\n" });
+    expect(a.version).toBe(3);
+
+    const history = await log(ctx, { path: PATH });
+    expect(history.versions.length).toBeGreaterThanOrEqual(3);
+
+    // diff must read the two versions' actual bytes (by hash handle), not the
+    // stored diffSummary fallback. v1 "line1\n" → v3 "LINE-ONE\n…line2\n".
+    const d = await diff(ctx, { path: PATH, v1: 1, v2: 3 });
+    expect(d.changes.length).toBeGreaterThan(0);
+    expect(d.changes.some((c) => c.type === "remove" && c.content.includes("line1"))).toBe(true);
+    expect(d.changes.some((c) => c.type === "add" && c.content.includes("LINE-ONE"))).toBe(true);
+    expect(d.changes.some((c) => c.type === "add" && c.content.includes("line2"))).toBe(true);
+
+    // revert reads v1's bytes by hash and writes them as the new head.
+    const r = await revert(ctx, { path: PATH, version: 1 });
+    expect(r.revertedTo).toBe(1);
+    expect(r.version).toBe(4);
+
+    // The current object now holds exactly the v1 content again.
+    const current = await ctx.s3.getObject(getS3Key(ctx.orgId, ctx.driveId, PATH));
+    expect(dec(current.body)).toBe("line1\n");
+  });
+
+  test("signed-url falls back to an app link (no presigned URL) and is marked kind:'app'", async () => {
+    await write(ctx, { path: PATH, content: "hi" });
+
+    const res = await signedUrl(ctx, { path: PATH });
+    expect(res.kind).toBe("app");
+    expect(res.url).toBe(`${APP_URL}/file/~/${ctx.orgId}/${ctx.driveId}/doc.txt`);
+    expect(res.expiresIn).toBe(0);
+    expect(res.url).not.toContain("X-Amz-Signature"); // not a presigned S3 URL
+  });
+
+  test("signed-url throws UnsupportedOperation when no appUrl is configured to fall back to", async () => {
+    await write(ctx, { path: PATH, content: "hi" });
+    const noAppUrlCtx: OpContext = { ...ctx, appUrl: undefined };
+
+    await expect(signedUrl(noAppUrlCtx, { path: PATH })).rejects.toBeInstanceOf(
+      UnsupportedOperation,
+    );
+  });
+});

--- a/packages/core/src/storage/__tests__/local-adapter-ops.test.ts
+++ b/packages/core/src/storage/__tests__/local-adapter-ops.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import { LocalStorageAdapter } from "../local-adapter.js";
 import { createTestContext } from "../../test-utils.js";
 import { getS3Key } from "../../ops/versioning.js";
-import { write, edit, append, log, diff, revert, signedUrl } from "../../ops/index.js";
-import { UnsupportedOperation } from "../../errors.js";
+import { write, edit, append, log, diff, revert, signedUrl, stat } from "../../ops/index.js";
+import { UnsupportedOperation, NotFoundError } from "../../errors.js";
 import type { OpContext } from "../../ops/types.js";
 
 const PATH = "/doc.txt";
@@ -87,6 +87,15 @@ describe("LocalStorageAdapter — op-level versioning (full tier)", () => {
 
     await expect(signedUrl(noAppUrlCtx, { path: PATH })).rejects.toBeInstanceOf(
       UnsupportedOperation,
+    );
+  });
+
+  test("stat on a missing file maps the adapter's NoSuchKey miss to NotFoundError", async () => {
+    // The local adapter translates a miss to the `NoSuchKey` shape (not S3's
+    // `NotFound`); stat must still surface a clean NOT_FOUND rather than letting
+    // the raw error bubble as a 500.
+    await expect(stat(ctx, { path: "/does-not-exist.txt" })).rejects.toBeInstanceOf(
+      NotFoundError,
     );
   });
 });

--- a/packages/core/src/storage/__tests__/local-adapter.test.ts
+++ b/packages/core/src/storage/__tests__/local-adapter.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { LocalStorageAdapter } from "../local-adapter.js";
+import { UnsupportedOperation } from "../../errors.js";
+
+const DRIVE_PREFIX = "org1/drives/drive1/";
+const key = (p: string) => DRIVE_PREFIX + p;
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+
+describe("LocalStorageAdapter", () => {
+  let root: string;
+  let adapter: LocalStorageAdapter;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "afs-local-adapter-"));
+    adapter = new LocalStorageAdapter({ root });
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  test("advertises full-versioning / no-presign capabilities", () => {
+    expect(adapter.versioningEnabled).toBe(true);
+    expect(adapter.capabilities).toEqual({
+      versioning: true,
+      presignedUrls: false,
+    });
+  });
+
+  test("put → get round-trip returns identical bytes + a hash version handle", async () => {
+    const put = await adapter.putObject(key("a.txt"), "hello world", undefined, "text/plain");
+    expect(put.versionId).toMatch(/^[0-9a-f]{64}$/); // sha-256 hex
+    expect(put.etag).toBe(put.versionId);
+
+    const got = await adapter.getObject(key("a.txt"));
+    expect(dec(got.body)).toBe("hello world");
+    expect(got.size).toBe(11);
+  });
+
+  test("head returns size; head on a missing key throws name === 'NoSuchKey'", async () => {
+    await adapter.putObject(key("h.txt"), "12345");
+    const head = await adapter.headObject(key("h.txt"));
+    expect(head.size).toBe(5);
+
+    await expect(adapter.headObject(key("missing.txt"))).rejects.toMatchObject({
+      name: "NoSuchKey",
+    });
+  });
+
+  test("getObject on a missing key throws name === 'NoSuchKey'", async () => {
+    await expect(adapter.getObject(key("nope.txt"))).rejects.toMatchObject({
+      name: "NoSuchKey",
+    });
+  });
+
+  test("delete removes the plain key but leaves version blobs intact", async () => {
+    const put = await adapter.putObject(key("d.txt"), "to-delete");
+    await adapter.deleteObject(key("d.txt"));
+
+    // Plain key gone…
+    await expect(adapter.getObject(key("d.txt"))).rejects.toMatchObject({
+      name: "NoSuchKey",
+    });
+    // …but the historical blob is still retrievable by handle.
+    const blob = await adapter.getObject(key("d.txt"), put.versionId);
+    expect(dec(blob.body)).toBe("to-delete");
+
+    // Deleting a missing key is a no-op (does not throw).
+    await adapter.deleteObject(key("d.txt"));
+  });
+
+  test("copy materializes destination bytes", async () => {
+    await adapter.putObject(key("src.txt"), "copy me");
+    const res = await adapter.copyObject(key("src.txt"), key("dst.txt"));
+    expect(res.versionId).toMatch(/^[0-9a-f]{64}$/);
+
+    const got = await adapter.getObject(key("dst.txt"));
+    expect(dec(got.body)).toBe("copy me");
+  });
+
+  test("version round-trip: getObject(key) is latest; getObject(key, oldHash) is the older bytes", async () => {
+    const v1 = await adapter.putObject(key("ver.txt"), "version one");
+    const v2 = await adapter.putObject(key("ver.txt"), "version two");
+    expect(v1.versionId).not.toBe(v2.versionId);
+
+    // Current key resolves to the latest write.
+    expect(dec((await adapter.getObject(key("ver.txt"))).body)).toBe("version two");
+    // Old content retrievable by its hash handle.
+    expect(dec((await adapter.getObject(key("ver.txt"), v1.versionId!)).body)).toBe("version one");
+    expect(dec((await adapter.getObject(key("ver.txt"), v2.versionId!)).body)).toBe("version two");
+  });
+
+  test("identical content across keys dedups to a single content-addressed blob", async () => {
+    await adapter.putObject(key("dup-a.txt"), "same bytes");
+    await adapter.putObject(key("dup-b.txt"), "same bytes");
+
+    const blobDir = join(root, "_afs-blobs", "sha256");
+    expect(existsSync(blobDir)).toBe(true);
+    // The fs adapter writes a `<key>.meta.json` sidecar per object; count only
+    // the actual content blobs. Identical content → one content-addressed blob.
+    const blobs = readdirSync(blobDir).filter((f) => !f.endsWith(".meta.json"));
+    expect(blobs.length).toBe(1);
+  });
+
+  test("listObjects(prefix, {delimiter}) returns files in objects, subdirs in prefixes, and NEVER surfaces _afs-blobs", async () => {
+    await adapter.putObject(key("top.txt"), "t");
+    await adapter.putObject(key("sub/nested.txt"), "n");
+
+    const { objects, prefixes } = await adapter.listObjects(DRIVE_PREFIX, {
+      delimiter: "/",
+    });
+
+    const objectKeys = objects.map((o) => o.key);
+    expect(objectKeys).toContain(key("top.txt"));
+    // Nested file is folded into the common prefix, not listed directly.
+    expect(objectKeys).not.toContain(key("sub/nested.txt"));
+    expect(prefixes).toContain(key("sub/"));
+
+    // The reserved blob prefix is a top-level sibling of the drive prefix and
+    // must never appear under a drive-scoped listing.
+    const allKeys = [...objectKeys, ...prefixes].join("\n");
+    expect(allKeys).not.toContain("_afs-blobs");
+  });
+
+  test("getPresignedUrl throws UnsupportedOperation (defensive — op gate should fall back first)", async () => {
+    await expect(adapter.getPresignedUrl()).rejects.toBeInstanceOf(UnsupportedOperation);
+  });
+
+  test("listObjectVersions returns [] (versioning is content-addressed, not native)", async () => {
+    await adapter.putObject(key("lv.txt"), "x");
+    expect(await adapter.listObjectVersions(key("lv.txt"))).toEqual([]);
+  });
+});

--- a/packages/core/src/storage/adapter.ts
+++ b/packages/core/src/storage/adapter.ts
@@ -1,0 +1,119 @@
+/**
+ * Storage contract shared by every agent-fs storage backend.
+ *
+ * The object store is intentionally a dumb keyed blob store: almost all
+ * "filesystem" semantics (version numbering, history, dedup, optimistic
+ * concurrency, FTS search, comments) live in SQLite, not here. An adapter only
+ * has to move bytes by key and report a small amount of metadata.
+ *
+ * ## Not-found error-shape contract
+ *
+ * Adapters MUST surface "object not found" as an error that agent-fs ops already
+ * branch on. Throw an `Error` (or provider error) whose shape matches ONE of:
+ *   - `err.name === "NoSuchKey"`, or
+ *   - `err.name === "NotFound"`, or
+ *   - `err.$metadata?.httpStatusCode === 404`
+ *
+ * Ops translate these into `NotFoundError` (see `ops/cat.ts:45`, `ops/stat.ts:18`,
+ * `ops/signed-url.ts:31`, and the server's `routes/files.ts:77`). Surfacing any
+ * other shape for a missing object would break those ~6 branches.
+ *
+ * These value/result types are the canonical home; `s3/client.ts` re-exports them
+ * for back-compat. The names retain their historical `S3`-prefix even though they
+ * are now backend-agnostic.
+ */
+
+export interface S3Object {
+  key: string;
+  size: number;
+  lastModified: Date;
+  etag?: string;
+}
+
+export interface S3ObjectVersion {
+  versionId: string;
+  lastModified: Date;
+  size: number;
+  isLatest: boolean;
+}
+
+export interface PutObjectResult {
+  etag?: string;
+  versionId?: string;
+}
+
+export interface GetObjectResult {
+  body: Uint8Array;
+  contentType?: string;
+  size?: number;
+  versionId?: string;
+  etag?: string;
+}
+
+export interface HeadObjectResult {
+  contentType?: string;
+  size: number;
+  lastModified?: Date;
+  etag?: string;
+  versionId?: string;
+}
+
+/**
+ * Static feature metadata an adapter advertises so ops can gate optional
+ * behavior and surface a typed `UnsupportedOperation` instead of a raw backend
+ * error when a backend can't satisfy a request.
+ */
+export interface StorageCapabilities {
+  /** Old-content retrieval by version handle — powers `revert` and historical `diff`. */
+  versioning: boolean;
+  /** Native presigned download URLs. Backends without this fall back to the daemon `/raw` URL. */
+  presignedUrls: boolean;
+}
+
+/**
+ * The contract every storage backend implements. The signatures are the exact
+ * 10-method surface that ops call through `OpContext.s3`, plus the mutable
+ * `versioningEnabled` flag and the static `capabilities` metadata.
+ */
+export interface StorageAdapter {
+  /** Whether object-level versioning is currently enabled on this backend. */
+  versioningEnabled: boolean;
+  /** Feature metadata for capability gating. */
+  readonly capabilities: StorageCapabilities;
+
+  putObject(
+    key: string,
+    body: string | Uint8Array,
+    metadata?: Record<string, string>,
+    contentType?: string,
+  ): Promise<PutObjectResult>;
+
+  getObject(
+    key: string,
+    versionId?: string,
+    opts?: { abortSignal?: AbortSignal },
+  ): Promise<GetObjectResult>;
+
+  deleteObject(key: string): Promise<void>;
+
+  copyObject(fromKey: string, toKey: string): Promise<PutObjectResult>;
+
+  listObjects(
+    prefix: string,
+    options?: { delimiter?: string },
+  ): Promise<{ objects: S3Object[]; prefixes: string[] }>;
+
+  headObject(key: string): Promise<HeadObjectResult>;
+
+  listObjectVersions(key: string): Promise<S3ObjectVersion[]>;
+
+  checkVersioningEnabled(): Promise<boolean>;
+
+  enableVersioning(): Promise<boolean>;
+
+  getPresignedUrl(
+    key: string,
+    expiresIn?: number,
+    responseContentType?: string,
+  ): Promise<string>;
+}

--- a/packages/core/src/storage/capabilities.ts
+++ b/packages/core/src/storage/capabilities.ts
@@ -1,0 +1,28 @@
+import type { StorageAdapter, StorageCapabilities } from "./adapter.js";
+import { UnsupportedOperation } from "../errors.js";
+
+/**
+ * Throw a typed `UnsupportedOperation` when the active storage backend cannot
+ * satisfy an optional capability, instead of letting the op fail later with a
+ * raw/confusing S3/FS error.
+ *
+ * Ops that depend on an optional capability (e.g. object versioning powering
+ * `revert`) call this at their entry point so a limited backend fails cleanly
+ * and the error surfaces with a friendly message + suggestion through the
+ * daemon's HTTP error layer → CLI and → MCP.
+ *
+ * @param adapter   the backend to inspect (`ctx.s3`)
+ * @param cap       which capability the op requires
+ * @param operation human-facing op name used in the error message (e.g. "revert")
+ * @param backend   optional backend label; omit to get a generic message
+ */
+export function assertCapability(
+  adapter: StorageAdapter,
+  cap: keyof StorageCapabilities,
+  operation: string,
+  backend?: string,
+): void {
+  if (!adapter.capabilities[cap]) {
+    throw new UnsupportedOperation(operation, backend);
+  }
+}

--- a/packages/core/src/storage/factory.ts
+++ b/packages/core/src/storage/factory.ts
@@ -1,0 +1,55 @@
+import type { AgentFSConfig } from "../config.js";
+import { isLocalStorageConfig } from "../config.js";
+import { AgentS3Client } from "../s3/client.js";
+import { LocalStorageAdapter } from "./local-adapter.js";
+import type { StorageAdapter, StorageCapabilities } from "./adapter.js";
+
+/**
+ * TEST-ONLY capability overlay. When `AGENT_FS_CAPABILITY_OVERRIDE` is set to a
+ * JSON object (e.g. `{"versioning":false}`), the adapter's advertised
+ * `capabilities` are shallow-merged with it. This lets the e2e suite drive the
+ * `UNSUPPORTED_OPERATION` path against a real backend that would otherwise have
+ * the capability. Not for production use — gated entirely on the env var being
+ * present.
+ *
+ * Folded here from `packages/server/src/index.ts` (step-2 placed it at the
+ * construction site; step-4 moves it into the factory so it applies regardless
+ * of which adapter is selected).
+ */
+function applyCapabilityOverride(adapter: StorageAdapter): void {
+  const raw = process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+  if (!raw) return;
+  try {
+    const override = JSON.parse(raw) as Partial<StorageCapabilities>;
+    const merged = { ...adapter.capabilities, ...override };
+    Object.defineProperty(adapter, "capabilities", {
+      value: merged,
+      configurable: true,
+    });
+    console.warn("[test-only] AGENT_FS_CAPABILITY_OVERRIDE applied:", merged);
+  } catch (err) {
+    console.warn("Failed to parse AGENT_FS_CAPABILITY_OVERRIDE:", err);
+  }
+}
+
+/**
+ * Select the process-wide storage backend from the tagged-union storage config.
+ *
+ *   - `provider: "local"` → {@link LocalStorageAdapter} (filesystem, app-level
+ *     versioning, no presigned URLs);
+ *   - everything else → {@link AgentS3Client} (S3/MinIO, behavior unchanged).
+ *
+ * This is the single construction site for the storage adapter (called from the
+ * daemon entrypoint and `config validate`). It also applies the test-only
+ * capability override (see {@link applyCapabilityOverride}).
+ */
+export function createStorageAdapter(cfg: AgentFSConfig["s3"]): StorageAdapter {
+  let adapter: StorageAdapter;
+  if (isLocalStorageConfig(cfg)) {
+    adapter = new LocalStorageAdapter({ root: cfg.root });
+  } else {
+    adapter = new AgentS3Client(cfg);
+  }
+  applyCapabilityOverride(adapter);
+  return adapter;
+}

--- a/packages/core/src/storage/local-adapter.ts
+++ b/packages/core/src/storage/local-adapter.ts
@@ -1,0 +1,248 @@
+import { createHash } from "node:crypto";
+import { Files } from "files-sdk";
+import { fs } from "files-sdk/fs";
+import { UnsupportedOperation } from "../errors.js";
+import type {
+  StorageAdapter,
+  StorageCapabilities,
+  S3Object,
+  S3ObjectVersion,
+  PutObjectResult,
+  GetObjectResult,
+  HeadObjectResult,
+} from "./adapter.js";
+
+/**
+ * Local-filesystem `StorageAdapter` backed by the `files-sdk` `fs` adapter.
+ *
+ * The first non-S3 backend. It gets the **full** versioning tier (`revert` +
+ * historical `diff`) without any object-versioning primitive by storing every
+ * version's bytes content-addressed:
+ *
+ *   - the *current* bytes live at the plain key (`<orgId>/drives/<driveId>/…`),
+ *     exactly like S3 — so `ls`/`cat`/`/raw` read it directly;
+ *   - every version's bytes ALSO live at a reserved top-level blob key
+ *     `_afs-blobs/sha256/<hash>`. That prefix sits *outside* any drive listing
+ *     prefix, so it never surfaces in `ls`/`glob`.
+ *
+ * The opaque per-adapter "version handle" the ops persist in
+ * `file_versions.s3_version_id` is simply the SHA-256 hash. `revert`/`diff`
+ * pass that handle back into {@link getObject}, which reads the blob. Identical
+ * content dedups to a single blob for free (same hash → same key).
+ *
+ * ### Cross-store atomicity (see step-3 Change #4)
+ * The write path stays object-then-commit (`putObject` then `createVersion`),
+ * unchanged from the S3 path. Inside `putObject` the **blob is written first**,
+ * then the plain key — so a crash between the two writes can only ever leave a
+ * content-addressed blob with no referencing version row. Such an orphan is
+ * dedup-shared and harmless (the hash may back another version), so it is
+ * deliberately NOT cleaned up on failure. The partial-failure window matches
+ * today's S3 path; real reconciliation/retry is deferred to the
+ * remote/consumer adapter (follow-up plan).
+ */
+
+const BLOB_PREFIX = "_afs-blobs/sha256/";
+
+/** Reserved, never-listed key where a version's content-addressed bytes live. */
+function blobKey(hash: string): string {
+  return BLOB_PREFIX + hash;
+}
+
+/** files-sdk surfaces a missing object as `FilesError { code: "NotFound" }`. */
+function isFilesNotFound(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "NotFound"
+  );
+}
+
+/**
+ * Translate a files-sdk error into the S3-compatible not-found shape every op
+ * already branches on (`err.name === "NoSuchKey"`). Non-not-found errors are
+ * returned unchanged so the caller can rethrow the original.
+ */
+function translateError(err: unknown, key: string): unknown {
+  if (isFilesNotFound(err)) {
+    const e = new Error(`NoSuchKey: ${key}`);
+    e.name = "NoSuchKey";
+    (e as { cause?: unknown }).cause = err;
+    return e;
+  }
+  return err;
+}
+
+export interface LocalStorageAdapterOptions {
+  /** Directory the backend manages. Keys map to nested paths under it. */
+  root: string;
+  /** Optional URL prefix for files-sdk `url()` (unused — local never presigns). */
+  urlBaseUrl?: string;
+}
+
+export class LocalStorageAdapter implements StorageAdapter {
+  private files: Files;
+
+  /** App-level (content-addressed) versioning is always on for local. */
+  versioningEnabled = true;
+
+  /** Local gets full versioning but cannot mint native presigned URLs. */
+  get capabilities(): StorageCapabilities {
+    return { versioning: true, presignedUrls: false };
+  }
+
+  constructor(opts: LocalStorageAdapterOptions) {
+    this.files = new Files({
+      adapter: fs({
+        root: opts.root,
+        ...(opts.urlBaseUrl ? { urlBaseUrl: opts.urlBaseUrl } : {}),
+      }),
+    });
+  }
+
+  async putObject(
+    key: string,
+    body: string | Uint8Array,
+    _metadata?: Record<string, string>,
+    contentType?: string,
+  ): Promise<PutObjectResult> {
+    const bytes =
+      typeof body === "string" ? new TextEncoder().encode(body) : body;
+    const hash = createHash("sha256").update(bytes).digest("hex");
+
+    // Blob-first: persist the content-addressed history blob before the plain
+    // key so a crash between the two never loses version history. Dedup:
+    // identical content shares one blob, so skip the re-upload when present.
+    const bk = blobKey(hash);
+    if (!(await this.files.exists(bk))) {
+      await this.files.upload(bk, bytes);
+    }
+
+    // Then the current/plain key — read directly by ls/cat/`/raw`.
+    await this.files.upload(
+      key,
+      bytes,
+      contentType ? { contentType } : undefined,
+    );
+
+    return { etag: hash, versionId: hash };
+  }
+
+  async getObject(
+    key: string,
+    versionId?: string,
+    opts?: { abortSignal?: AbortSignal },
+  ): Promise<GetObjectResult> {
+    // A version handle reads the content-addressed blob; otherwise the plain
+    // current key.
+    const target = versionId ? blobKey(versionId) : key;
+    try {
+      const stored = await this.files.download(
+        target,
+        opts?.abortSignal ? { signal: opts.abortSignal } : undefined,
+      );
+      const body = new Uint8Array(await stored.arrayBuffer());
+      return {
+        body,
+        contentType: stored.type,
+        size: stored.size,
+        versionId,
+        etag: stored.etag,
+      };
+    } catch (err) {
+      throw translateError(err, key);
+    }
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    // Delete the plain key only — blobs ARE the version history and stay put
+    // (mirrors S3 delete-marker semantics: prior versions stay retrievable by
+    // handle). A missing key is a no-op.
+    try {
+      await this.files.delete(key);
+    } catch (err) {
+      if (isFilesNotFound(err)) return;
+      throw err;
+    }
+  }
+
+  async copyObject(fromKey: string, toKey: string): Promise<PutObjectResult> {
+    // Read source bytes, then re-put — ensures the blob exists for `toKey`'s
+    // history and writes the plain destination key.
+    const src = await this.getObject(fromKey);
+    return this.putObject(toKey, src.body, undefined, src.contentType);
+  }
+
+  async listObjects(
+    prefix: string,
+    options?: { delimiter?: string },
+  ): Promise<{ objects: S3Object[]; prefixes: string[] }> {
+    const objects: S3Object[] = [];
+    const prefixes = new Set<string>();
+    let cursor: string | undefined;
+
+    // Drain every page (fs caps at ~1000 items/page and returns a cursor).
+    // The `_afs-blobs/…` prefix is a top-level sibling of `<orgId>/…`, so a
+    // drive-scoped prefix never matches it — blobs never surface here.
+    do {
+      const page = await this.files.list({
+        prefix,
+        ...(options?.delimiter ? { delimiter: options.delimiter } : {}),
+        ...(cursor ? { cursor } : {}),
+      });
+      for (const it of page.items) {
+        objects.push({
+          key: it.key,
+          size: it.size,
+          lastModified:
+            it.lastModified != null ? new Date(it.lastModified) : new Date(),
+          etag: it.etag,
+        });
+      }
+      for (const p of page.prefixes ?? []) prefixes.add(p);
+      cursor = page.cursor;
+    } while (cursor);
+
+    return { objects, prefixes: Array.from(prefixes) };
+  }
+
+  async headObject(key: string): Promise<HeadObjectResult> {
+    try {
+      const stored = await this.files.head(key);
+      return {
+        contentType: stored.type,
+        size: stored.size,
+        lastModified:
+          stored.lastModified != null
+            ? new Date(stored.lastModified)
+            : undefined,
+        etag: stored.etag,
+      };
+    } catch (err) {
+      throw translateError(err, key);
+    }
+  }
+
+  /** Unused by ops on this backend (versioning is content-addressed, not native). */
+  async listObjectVersions(_key: string): Promise<S3ObjectVersion[]> {
+    return [];
+  }
+
+  async checkVersioningEnabled(): Promise<boolean> {
+    return true;
+  }
+
+  async enableVersioning(): Promise<boolean> {
+    // App-level versioning is always on — nothing to toggle.
+    this.versioningEnabled = true;
+    return true;
+  }
+
+  /**
+   * Defensive: local can't mint native presigned URLs. The op-level capability
+   * check (`signed-url` op) should fall back to the daemon app URL *before*
+   * reaching here; this throw guards any caller that bypasses that gate.
+   */
+  async getPresignedUrl(): Promise<string> {
+    throw new UnsupportedOperation("signed-url", "local");
+  }
+}

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -14,12 +14,14 @@ import { listDrives } from "./identity/drives.js";
 import type { DB } from "./db/index.js";
 import type { OpContext } from "./ops/types.js";
 import type {
+  StorageAdapter,
+  StorageCapabilities,
   PutObjectResult,
   GetObjectResult,
   HeadObjectResult,
   S3Object,
   S3ObjectVersion,
-} from "./s3/client.js";
+} from "./storage/adapter.js";
 
 // Check if MinIO is available at localhost:9000
 export async function isMinioAvailable(): Promise<boolean> {
@@ -47,7 +49,7 @@ export function createTestDb(): DB {
 /**
  * In-memory mock of AgentS3Client for testing without MinIO.
  */
-export class MockS3Client {
+export class MockS3Client implements StorageAdapter {
   private store = new Map<string, {
     body: Uint8Array;
     metadata?: Record<string, string>;
@@ -63,6 +65,11 @@ export class MockS3Client {
 
   constructor(opts?: { versioningEnabled?: boolean }) {
     this.versioningEnabled = opts?.versioningEnabled ?? false;
+  }
+
+  /** Mirrors AgentS3Client: versioning tracks the flag, presigned URLs are faked. */
+  get capabilities(): StorageCapabilities {
+    return { versioning: this.versioningEnabled, presignedUrls: true };
   }
 
   async putObject(
@@ -193,6 +200,17 @@ export class MockS3Client {
     return true;
   }
 
+  async getPresignedUrl(
+    key: string,
+    expiresIn: number = 86400,
+    responseContentType?: string
+  ): Promise<string> {
+    const ct = responseContentType
+      ? `&ct=${encodeURIComponent(responseContentType)}`
+      : "";
+    return `https://mock.local/${key}?e=${expiresIn}${ct}`;
+  }
+
   /** Reset all stored objects */
   clear(): void {
     this.store.clear();
@@ -222,7 +240,7 @@ export function createTestContext(opts?: {
 
   const ctx: OpContext = {
     db,
-    s3: s3 as any, // MockS3Client implements the same interface
+    s3,
     orgId: orgs[0].id,
     driveId: drives[0].id,
     userId: user.id,

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -62,14 +62,32 @@ export class MockS3Client implements StorageAdapter {
     }>;
   }>();
   versioningEnabled: boolean;
+  private capabilityOverride?: Partial<StorageCapabilities>;
 
-  constructor(opts?: { versioningEnabled?: boolean }) {
+  constructor(opts?: {
+    versioningEnabled?: boolean;
+    /**
+     * Force specific capabilities for capability-gating tests (e.g.
+     * `{ versioning: false }` to model a backend that can't `revert`). The
+     * override is merged over the defaults derived from `versioningEnabled`.
+     */
+    capabilities?: Partial<StorageCapabilities>;
+  }) {
     this.versioningEnabled = opts?.versioningEnabled ?? false;
+    this.capabilityOverride = opts?.capabilities;
   }
 
-  /** Mirrors AgentS3Client: versioning tracks the flag, presigned URLs are faked. */
+  /**
+   * Mirrors AgentS3Client: versioning tracks the flag, presigned URLs are
+   * faked. Any constructor `capabilities` override wins so tests can model a
+   * limited backend.
+   */
   get capabilities(): StorageCapabilities {
-    return { versioning: this.versioningEnabled, presignedUrls: true };
+    return {
+      versioning: this.versioningEnabled,
+      presignedUrls: true,
+      ...this.capabilityOverride,
+    };
   }
 
   async putObject(
@@ -222,6 +240,8 @@ export class MockS3Client implements StorageAdapter {
  */
 export function createTestContext(opts?: {
   versioningEnabled?: boolean;
+  /** Force adapter capabilities (e.g. `{ versioning: false }`) for gating tests. */
+  capabilities?: Partial<StorageCapabilities>;
 }): {
   ctx: OpContext;
   db: DB;
@@ -232,7 +252,10 @@ export function createTestContext(opts?: {
   apiKey: string;
 } {
   const db = createTestDb();
-  const s3 = new MockS3Client({ versioningEnabled: opts?.versioningEnabled ?? false });
+  const s3 = new MockS3Client({
+    versioningEnabled: opts?.versioningEnabled ?? false,
+    capabilities: opts?.capabilities,
+  });
 
   const { user, apiKey } = createUser(db, { email: "test@example.com" });
   const orgs = listUserOrgs(db, user.id);

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/mcp/src/__tests__/tools.test.ts
+++ b/packages/mcp/src/__tests__/tools.test.ts
@@ -89,6 +89,35 @@ describe("registerTools", () => {
   });
 });
 
+describe("ops tool error surfacing", () => {
+  test("revert on a no-versioning backend returns isError with the message (no raw throw)", async () => {
+    const handlers = new Map<string, (params: any, extra: any) => Promise<any>>();
+    const mockServer = {
+      tool: (name: string, _desc: string, _schema: any, handler: any) => {
+        handlers.set(name, handler);
+      },
+    };
+
+    const { ctx } = createTestContext({ capabilities: { versioning: false } });
+    registerTools(mockServer as any, () => ctx);
+
+    // Seed a file via the captured write handler so a version row exists.
+    const write = handlers.get("write")!;
+    await write({ path: "/mcp-cap.txt", content: "v1" }, {});
+
+    const revertHandler = handlers.get("revert")!;
+    // Must resolve to an isError result, NOT reject — surfaced cleanly to the agent.
+    const result = await revertHandler({ path: "/mcp-cap.txt", version: 1 }, {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].type).toBe("text");
+    const body = JSON.parse(result.content[0].text);
+    expect(body.error).toBe("UNSUPPORTED_OPERATION");
+    expect(body.message).toContain("not supported");
+    expect(body.suggestion).toBeTruthy();
+  });
+});
+
 // --- Identity tool harness ---
 
 type ToolHandler = (params: any, extra: any) => Promise<any>;

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -21,14 +21,14 @@ import {
   assertDriveInOrg,
   VERSION,
 } from "@/core";
-import type { OpContext, DB, EmbeddingProvider, AgentS3Client } from "@/core";
+import type { OpContext, DB, EmbeddingProvider, StorageAdapter } from "@/core";
 import { registerTools } from "./tools.js";
 
 export type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
 
 export interface McpServerOptions {
   db: DB;
-  s3: AgentS3Client;
+  s3: StorageAdapter;
   embeddingProvider: EmbeddingProvider | null;
   appUrl?: string;
 }

--- a/packages/mcp/src/tools.ts
+++ b/packages/mcp/src/tools.ts
@@ -25,15 +25,38 @@ export function registerTools(
         : { params: z.any() },
       async (params: any, extra: Extra) => {
         const ctx = getContext(extra);
-        const result = await dispatchOp(ctx, opName, params);
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(result, null, 2),
-            },
-          ],
-        };
+        try {
+          const result = await dispatchOp(ctx, opName, params);
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(result, null, 2),
+              },
+            ],
+          };
+        } catch (err: any) {
+          // Surface op failures (e.g. UnsupportedOperation on a limited
+          // backend, NotFound, RBAC denials) as a clean MCP error result
+          // instead of a raw throw — mirrors the member-management tools.
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  {
+                    error: err?.code ?? "ERROR",
+                    message: err?.message ?? String(err),
+                    ...(err?.suggestion && { suggestion: err.suggestion }),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+            isError: true,
+          };
+        }
       }
     );
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/src/__tests__/capability-gating.test.ts
+++ b/packages/server/src/__tests__/capability-gating.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeAll } from "bun:test";
+import { createTestDb, MockS3Client } from "../../../core/src/test-utils.js";
+import { createApp } from "../app.js";
+
+// In-process daemon test: point createApp at a forced no-versioning backend and
+// prove an unsupported op surfaces cleanly as HTTP 422 with the typed body —
+// no raw S3/FS stack escaping the error layer.
+
+let app: ReturnType<typeof createApp>;
+let apiKey: string;
+let orgId: string;
+
+beforeAll(async () => {
+  const db = createTestDb();
+  const s3 = new MockS3Client({ capabilities: { versioning: false } });
+  app = createApp(db, s3 as any);
+
+  const reg = await app.request("/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: "cap-gating@example.com" }),
+  });
+  const body = await reg.json();
+  apiKey = body.apiKey;
+  orgId = body.orgId;
+
+  // Seed a file so the version row exists; revert must still be gated.
+  const write = await app.request(`/orgs/${orgId}/ops`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ op: "write", path: "/cap.txt", content: "v1" }),
+  });
+  expect(write.status).toBe(200);
+});
+
+describe("UnsupportedOperation surfacing through the daemon", () => {
+  test("POST ops op=revert on a no-versioning backend returns 422 with typed body", async () => {
+    const res = await app.request(`/orgs/${orgId}/ops`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ op: "revert", path: "/cap.txt", version: 1 }),
+    });
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("UNSUPPORTED_OPERATION");
+    expect(body.message).toContain("not supported");
+    expect(body.suggestion).toBeTruthy();
+    expect(body.operation).toBe("revert");
+  });
+});

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { bodyLimit } from "hono/body-limit";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { VERSION, getConfig } from "@/core";
-import type { DB, AgentS3Client, EmbeddingProvider } from "@/core";
+import type { DB, StorageAdapter, EmbeddingProvider } from "@/core";
 import { createMcpServer } from "@/mcp/server.js";
 import type { AppEnv } from "./types.js";
 import { authMiddleware } from "./middleware/auth.js";
@@ -15,7 +15,7 @@ import { orgRoutes } from "./routes/orgs.js";
 import { docsRoutes } from "./routes/docs.js";
 import { fileRoutes } from "./routes/files.js";
 
-export function createApp(db: DB, s3: AgentS3Client, embeddingProvider: EmbeddingProvider | null = null) {
+export function createApp(db: DB, s3: StorageAdapter, embeddingProvider: EmbeddingProvider | null = null) {
   const app = new Hono<AppEnv>();
   const config = getConfig();
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -12,6 +12,26 @@ const db = createDatabase();
 // Initialize S3 client
 const s3 = new AgentS3Client(config.s3);
 
+// TEST-ONLY: overlay the adapter's advertised capabilities from a JSON env var
+// (e.g. AGENT_FS_CAPABILITY_OVERRIDE='{"versioning":false}'). This lets the e2e
+// suite drive the UNSUPPORTED_OPERATION path against a real backend that would
+// otherwise have the capability. Not for production use — gated on the env var
+// being present. (step-4 may fold this into the storage adapter factory.)
+const capOverrideRaw = process.env.AGENT_FS_CAPABILITY_OVERRIDE;
+if (capOverrideRaw) {
+  try {
+    const override = JSON.parse(capOverrideRaw);
+    const merged = { ...s3.capabilities, ...override };
+    Object.defineProperty(s3, "capabilities", {
+      value: merged,
+      configurable: true,
+    });
+    console.warn("[test-only] AGENT_FS_CAPABILITY_OVERRIDE applied:", merged);
+  } catch (err) {
+    console.warn("Failed to parse AGENT_FS_CAPABILITY_OVERRIDE:", err);
+  }
+}
+
 // Initialize embedding provider (graceful failure — semantic search unavailable if this fails)
 let embeddingProvider: EmbeddingProvider | null = null;
 try {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import { createDatabase, getConfig, getHome, AgentS3Client, createEmbeddingProviderFromEnv } from "@/core";
+import { createDatabase, getConfig, getHome, createStorageAdapter, createEmbeddingProviderFromEnv } from "@/core";
 import type { EmbeddingProvider } from "@/core";
 import { join } from "node:path";
 import { createApp } from "./app.js";
@@ -9,28 +9,10 @@ const config = getConfig();
 // Initialize database
 const db = createDatabase();
 
-// Initialize S3 client
-const s3 = new AgentS3Client(config.s3);
-
-// TEST-ONLY: overlay the adapter's advertised capabilities from a JSON env var
-// (e.g. AGENT_FS_CAPABILITY_OVERRIDE='{"versioning":false}'). This lets the e2e
-// suite drive the UNSUPPORTED_OPERATION path against a real backend that would
-// otherwise have the capability. Not for production use — gated on the env var
-// being present. (step-4 may fold this into the storage adapter factory.)
-const capOverrideRaw = process.env.AGENT_FS_CAPABILITY_OVERRIDE;
-if (capOverrideRaw) {
-  try {
-    const override = JSON.parse(capOverrideRaw);
-    const merged = { ...s3.capabilities, ...override };
-    Object.defineProperty(s3, "capabilities", {
-      value: merged,
-      configurable: true,
-    });
-    console.warn("[test-only] AGENT_FS_CAPABILITY_OVERRIDE applied:", merged);
-  } catch (err) {
-    console.warn("Failed to parse AGENT_FS_CAPABILITY_OVERRIDE:", err);
-  }
-}
+// Initialize the storage adapter for the configured backend (S3/MinIO or
+// local-FS). The factory also applies the test-only AGENT_FS_CAPABILITY_OVERRIDE
+// overlay used by the e2e suite (folded in from here in step-4).
+const s3 = createStorageAdapter(config.s3);
 
 // Initialize embedding provider (graceful failure — semantic search unavailable if this fails)
 let embeddingProvider: EmbeddingProvider | null = null;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,6 +14,21 @@ const db = createDatabase();
 // overlay used by the e2e suite (folded in from here in step-4).
 const s3 = createStorageAdapter(config.s3);
 
+// Reconcile the advertised versioning capability with the backend's ACTUAL
+// state. The S3 adapter otherwise derives `versioningEnabled` purely from a
+// config flag that onboarding never writes, so a bucket with versioning enabled
+// would report `versioning: false` and the revert/diff capability gate would
+// wrongly reject operations that would in fact succeed. checkVersioningEnabled()
+// queries the bucket (the local-FS adapter returns true unconditionally). The
+// test-only AGENT_FS_CAPABILITY_OVERRIDE (applied in the factory via
+// Object.defineProperty) shadows the `capabilities` getter, so this field write
+// cannot clobber a forced-off override used by the e2e gating tests.
+try {
+  s3.versioningEnabled = await s3.checkVersioningEnabled();
+} catch (err) {
+  console.warn("Could not reconcile storage versioning capability:", err);
+}
+
 // Initialize embedding provider (graceful failure — semantic search unavailable if this fails)
 let embeddingProvider: EmbeddingProvider | null = null;
 try {

--- a/packages/server/src/ipc/handlers.ts
+++ b/packages/server/src/ipc/handlers.ts
@@ -25,11 +25,11 @@ import {
   getUserByApiKey,
   getS3Key,
 } from "@/core";
-import type { DB, AgentS3Client, EmbeddingProvider } from "@/core";
+import type { DB, StorageAdapter, EmbeddingProvider } from "@/core";
 
 export interface IpcContext {
   db: DB;
-  s3: AgentS3Client;
+  s3: StorageAdapter;
   embeddingProvider: EmbeddingProvider | null;
   appUrl?: string;
   /**

--- a/packages/server/src/middleware/error.ts
+++ b/packages/server/src/middleware/error.ts
@@ -5,6 +5,7 @@ import {
   EditConflictError,
   IndexingInProgressError,
   ValidationError,
+  UnsupportedOperation,
 } from "@/core";
 
 function getStatusCode(err: Error): number {
@@ -13,6 +14,10 @@ function getStatusCode(err: Error): number {
   if (err instanceof EditConflictError) return 409;
   if (err instanceof IndexingInProgressError) return 503;
   if (err instanceof ValidationError) return 400;
+  // 422 Unprocessable: the request was well-formed but the active storage
+  // backend can't satisfy it. Distinct from the generic 400 so clients don't
+  // treat an unsupported-backend op as a malformed request / server bug.
+  if (err instanceof UnsupportedOperation) return 422;
   if ("code" in err) return 400; // AgentFSError base
   return 500;
 }

--- a/packages/server/src/routes/files.ts
+++ b/packages/server/src/routes/files.ts
@@ -5,13 +5,13 @@ import {
   getHeadVersionRow,
   getS3Key,
 } from "@/core";
-import type { DB, AgentS3Client, EmbeddingProvider } from "@/core";
+import type { DB, StorageAdapter, EmbeddingProvider } from "@/core";
 import { normalizePath } from "@/core/ops/paths.js";
 import type { AppEnv } from "../types.js";
 
 export function fileRoutes(
   db: DB,
-  s3: AgentS3Client,
+  s3: StorageAdapter,
   embeddingProvider: EmbeddingProvider | null = null,
   appUrl?: string
 ) {

--- a/packages/server/src/routes/ops.ts
+++ b/packages/server/src/routes/ops.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { dispatchOp, resolveContext } from "@/core";
-import type { DB, AgentS3Client, EmbeddingProvider } from "@/core";
+import type { DB, StorageAdapter, EmbeddingProvider } from "@/core";
 import type { AppEnv } from "../types.js";
 
-export function opsRoutes(db: DB, s3: AgentS3Client, embeddingProvider: EmbeddingProvider | null = null, appUrl?: string) {
+export function opsRoutes(db: DB, s3: StorageAdapter, embeddingProvider: EmbeddingProvider | null = null, appUrl?: string) {
   const router = new Hono<AppEnv>();
 
   router.post("/:orgId/ops", async (c) => {

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -54,6 +54,9 @@ let skipped = 0;
 const failures: string[] = [];
 let fuseReady = false;
 let fuseSkipReason = "";
+// step-5: local-FS daemons spun up for the cross-backend matrix. Tracked so
+// `cleanup()` can stop each daemon and remove its isolated AGENT_FS_HOME.
+const localBackends: Backend[] = [];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -119,6 +122,188 @@ function run(args: string): string {
 
 function runJson(args: string): any {
   return JSON.parse(run(`--json ${args}`));
+}
+
+// ---------------------------------------------------------------------------
+// Multi-backend support (step-5)
+//
+// The same backend-agnostic op suite runs against MinIO (S3 object versioning)
+// AND a local-FS drive (content-addressed `_afs-blobs` versioning). A `Backend`
+// bundles a daemon's home/port/credentials; `runOn`/`runJsonOn` target it.
+// ---------------------------------------------------------------------------
+
+interface Backend {
+  label: string;
+  home: string;
+  daemonPort: number;
+  apiKey: string;
+  orgId: string;
+  driveId: string;
+  /** Env for CLI invocations targeting this backend's daemon (sans API URL/key). */
+  env: () => NodeJS.ProcessEnv;
+}
+
+/** Run a CLI command against a specific backend's daemon (full API context). */
+function runOn(b: Backend, args: string): string {
+  return execSync(`${cmd} ${args}`, {
+    encoding: "utf-8",
+    env: {
+      ...b.env(),
+      AGENT_FS_API_URL: `http://127.0.0.1:${b.daemonPort}`,
+      AGENT_FS_API_KEY: b.apiKey,
+    } as NodeJS.ProcessEnv,
+    timeout: 30_000,
+  }).trim();
+}
+
+function runJsonOn(b: Backend, args: string): any {
+  return JSON.parse(runOn(b, `--json ${args}`));
+}
+
+/** Build a `Backend` view over the already-running MinIO daemon + globals. */
+function makeMinioBackend(): Backend {
+  return {
+    label: "minio",
+    home: testDir,
+    daemonPort,
+    apiKey,
+    orgId: personalOrgId,
+    driveId: personalDriveId,
+    env: () => testEnv(),
+  };
+}
+
+/**
+ * Env that forces the daemon/CLI onto the local-FS backend (no MinIO/Docker).
+ * The S3_ and AWS_ vars are explicitly blanked so a stray endpoint can't bleed
+ * in — the local branch in `applyEnvOverrides` ignores them, but be defensive.
+ */
+function localEnv(
+  home: string,
+  storageRoot: string,
+  appUrl: string,
+  extra: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    AGENT_FS_HOME: home,
+    AGENT_FS_STORAGE_PROVIDER: "local",
+    AGENT_FS_LOCAL_ROOT: storageRoot,
+    AGENT_FS_APP_URL: appUrl,
+    S3_ENDPOINT: "",
+    S3_BUCKET: "",
+    S3_ACCESS_KEY_ID: "",
+    S3_SECRET_ACCESS_KEY: "",
+    S3_REGION: "",
+    S3_PROVIDER: "",
+    AWS_ENDPOINT_URL_S3: "",
+    AWS_ACCESS_KEY_ID: "",
+    AWS_SECRET_ACCESS_KEY: "",
+    AWS_REGION: "",
+    BUCKET_NAME: "",
+    ...extra,
+  };
+}
+
+/**
+ * Boot an isolated local-FS daemon (own AGENT_FS_HOME + storage dir + port),
+ * register a user, and return its `Backend`. No MinIO/Docker.
+ *
+ * `capabilityOverride` (JSON, e.g. `{"versioning":false}`) is threaded through
+ * the spawned daemon's env so the step-2 test-only overlay forces a degraded
+ * backend — used to prove the unsupported-op gating surfaces cleanly.
+ */
+async function setupLocalBackend(opts: {
+  label: string;
+  capabilityOverride?: string;
+}): Promise<Backend> {
+  const home = join(tmpdir(), `${containerName}-${opts.label}`);
+  const storageRoot = join(home, "storage");
+  mkdirSync(storageRoot, { recursive: true });
+
+  const port = await findFreePort();
+  const appUrl = `http://127.0.0.1:${port}`;
+
+  writeFileSync(
+    join(home, "config.json"),
+    JSON.stringify(
+      {
+        s3: { provider: "local", root: storageRoot },
+        embedding: { provider: "local", model: "", apiKey: "" },
+        server: { port, host: "127.0.0.1", rateLimit: { requestsPerMinute: 5000 } },
+        auth: { apiKey: "" },
+        minio: { containerId: "", managed: false },
+        // Needed so `signed-url` can fall back to an authenticated app link on a
+        // backend without presigned URLs (instead of throwing UnsupportedOperation).
+        appUrl,
+      },
+      null,
+      2,
+    ),
+  );
+
+  const env = localEnv(
+    home,
+    storageRoot,
+    appUrl,
+    opts.capabilityOverride ? { AGENT_FS_CAPABILITY_OVERRIDE: opts.capabilityOverride } : {},
+  );
+
+  // Start the daemon. The spawned `server` child inherits this env (startDaemon
+  // calls spawn() without an explicit env), so the capability override reaches
+  // the storage factory.
+  execSync(`${cmd} daemon start`, { encoding: "utf-8", env, timeout: 30_000, stdio: "pipe" });
+
+  // Wait for health.
+  const start = Date.now();
+  while (Date.now() - start < 15_000) {
+    try {
+      const res = await fetch(`${appUrl}/health`);
+      if (res.ok) break;
+    } catch {}
+    await Bun.sleep(300);
+  }
+  const health = await fetch(`${appUrl}/health`).catch(() => null);
+  if (!health?.ok) {
+    throw new Error(`local daemon (${opts.label}) failed to start on port ${port}`);
+  }
+
+  // Register a user → API key + personal org.
+  const regRes = await fetch(`${appUrl}/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: `${opts.label}@e2e.local` }),
+  });
+  if (!regRes.ok) {
+    throw new Error(`local register (${opts.label}) failed: ${regRes.status} ${await regRes.text()}`);
+  }
+  const reg = (await regRes.json()) as { apiKey: string; orgId: string };
+  const backendApiKey = reg.apiKey;
+  const orgId = reg.orgId;
+
+  const drivesRes = await fetch(`${appUrl}/orgs/${orgId}/drives`, {
+    headers: { Authorization: `Bearer ${backendApiKey}` },
+  });
+  const drivesData = (await drivesRes.json()) as any;
+  const driveId = drivesData.drives[0]?.id;
+
+  // Persist the key into config so IPC handlers can resolve it (parity w/ MinIO setup).
+  const cfgPath = join(home, "config.json");
+  const cfg = JSON.parse(readFileSync(cfgPath, "utf-8"));
+  cfg.auth.apiKey = backendApiKey;
+  writeFileSync(cfgPath, JSON.stringify(cfg, null, 2));
+
+  const backend: Backend = {
+    label: opts.label,
+    home,
+    daemonPort: port,
+    apiKey: backendApiKey,
+    orgId,
+    driveId,
+    env: () => env,
+  };
+  localBackends.push(backend);
+  return backend;
 }
 
 function assert(actual: any, expected: any, msg?: string) {
@@ -374,6 +559,16 @@ function cleanup() {
   try {
     runRaw("daemon stop");
   } catch {}
+  // step-5: stop every local-FS daemon spun up for the cross-backend matrix and
+  // remove its isolated AGENT_FS_HOME.
+  for (const b of localBackends) {
+    try {
+      execSync(`${cmd} daemon stop`, { env: b.env(), stdio: "ignore", timeout: 15_000 });
+    } catch {}
+    try {
+      rmSync(b.home, { recursive: true, force: true });
+    } catch {}
+  }
   // Remove MinIO container + the per-run docker network we created for it
   try {
     execSync(`docker rm -f ${containerName}`, { stdio: "ignore" });
@@ -651,7 +846,20 @@ async function runTests() {
   if (fuseOnly) console.log(`Mode: --fuse-only (skipping CLI/MCP/API tests)`);
   console.log("");
 
-  if (!fuseOnly) await runStandardTests(daemonUrl);
+  if (!fuseOnly) {
+    await runStandardTests(daemonUrl);
+
+    // step-5: prove the backend-agnostic op suite on BOTH backends.
+    const minioBackend = makeMinioBackend();
+    await coreOpsSuite(minioBackend);
+
+    const localBackend = await setupLocalBackend({ label: "local" });
+    await coreOpsSuite(localBackend);
+
+    // Capability gating (no-versioning) + signed-url presigned/app fallback.
+    await unsupportedOpSuite();
+    await signedUrlMatrix(minioBackend, localBackend);
+  }
   await runFuseTests();
 }
 
@@ -1822,6 +2030,184 @@ async function runStandardTests(daemonUrl: string) {
     assert(body.result?.isError, true, "Expected isError for cross-org driveId");
     const text = body.result?.content?.[0]?.text ?? "";
     assertIncludes(text, "Drive not found");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cross-backend op suite (step-5)
+//
+// The backend-agnostic ops — write/cat/ls/stat/edit/append/cp/mv/glob/recent/
+// log/diff/revert/rm — run identically against MinIO (S3 object versioning) and
+// a local-FS drive (content-addressed `_afs-blobs`). Paths are namespaced under
+// `/cos` so a re-run on the shared MinIO daemon never collides with the inline
+// MinIO suite above. Includes the full-tier assertions: historical `diff`
+// returns real content, `revert` appends a NEW version, and `ls` never leaks
+// the reserved `_afs-blobs` prefix.
+// ---------------------------------------------------------------------------
+
+async function coreOpsSuite(b: Backend) {
+  console.log(`\n-- core ops [${b.label}] --`);
+  const P = "/cos";
+  const rj = (a: string) => runJsonOn(b, a);
+
+  await test(`[${b.label}] write + cat roundtrip`, () => {
+    const res = rj(`write ${P}/hello.txt --content "Hello, agent-fs!"`);
+    assert(res.version, 1);
+    assert(rj(`cat ${P}/hello.txt`).content, "Hello, agent-fs!");
+  });
+
+  await test(`[${b.label}] ls shows dirs and never lists _afs-blobs`, () => {
+    rj(`write ${P}/sub/nested.txt --content "nested body"`);
+    const rootNames = rj(`ls /`).entries.map((e: any) => e.name);
+    assert(rootNames.includes("cos"), true, `expected 'cos' dir at root, got ${JSON.stringify(rootNames)}`);
+    // The content-addressed blob store lives at a reserved top-level key
+    // outside the drive prefix — it must NEVER surface in a drive listing.
+    assert(rootNames.includes("_afs-blobs"), false, "ls must never surface the _afs-blobs reserved prefix");
+    const cosNames = rj(`ls ${P}`).entries.map((e: any) => e.name);
+    assert(cosNames.includes("hello.txt"), true, `expected hello.txt under ${P}, got ${JSON.stringify(cosNames)}`);
+    assert(cosNames.includes("sub"), true, "ls must surface subdirectories");
+  });
+
+  await test(`[${b.label}] append + cat`, () => {
+    rj(`append ${P}/hello.txt --content " Appended."`);
+    assert(rj(`cat ${P}/hello.txt`).content, "Hello, agent-fs! Appended.");
+  });
+
+  await test(`[${b.label}] edit + cat`, () => {
+    rj(`edit ${P}/hello.txt --old "Appended." --new "Edited!"`);
+    assert(rj(`cat ${P}/hello.txt`).content, "Hello, agent-fs! Edited!");
+  });
+
+  await test(`[${b.label}] stat`, () => {
+    const s = rj(`stat ${P}/hello.txt`);
+    assert(s.path, `${P}/hello.txt`);
+    assert(typeof s.size, "number");
+    assert(s.currentVersion >= 3, true, `expected version >= 3, got ${s.currentVersion}`);
+  });
+
+  await test(`[${b.label}] cp + cat`, () => {
+    rj(`cp ${P}/hello.txt ${P}/hello-copy.txt`);
+    assert(rj(`cat ${P}/hello-copy.txt`).content, "Hello, agent-fs! Edited!");
+  });
+
+  await test(`[${b.label}] mv + cat + ls`, () => {
+    rj(`mv ${P}/hello-copy.txt ${P}/hello-moved.txt`);
+    assert(rj(`cat ${P}/hello-moved.txt`).content, "Hello, agent-fs! Edited!");
+    const names = rj(`ls ${P}`).entries.map((e: any) => e.name);
+    assert(names.includes("hello-copy.txt"), false, "source gone after mv");
+    assert(names.includes("hello-moved.txt"), true, "dest present after mv");
+  });
+
+  await test(`[${b.label}] glob`, () => {
+    const paths = rj(`glob 'cos/*.txt'`).matches.map((m: any) => m.path);
+    assert(paths.includes(`${P}/hello.txt`), true, `expected ${P}/hello.txt in glob, got ${JSON.stringify(paths)}`);
+  });
+
+  await test(`[${b.label}] recent`, () => {
+    assert(rj(`recent`).entries.length > 0, true, "expected recent entries");
+  });
+
+  await test(`[${b.label}] log (version history)`, () => {
+    assert(rj(`log ${P}/hello.txt`).versions.length >= 3, true, "expected >= 3 versions");
+  });
+
+  // -- Tier: historical diff returns real content (S3 object versions / local blobs) --
+  await test(`[${b.label}] diff (v1 vs v2) returns real content changes`, () => {
+    const d = rj(`diff ${P}/hello.txt --v1 1 --v2 2`);
+    assert(Array.isArray(d.changes), true);
+    assert(d.changes.length > 0, true, "expected real content diff between v1 and v2");
+  });
+
+  // -- Tier: revert restores prior content AS A NEW VERSION (not a rewind) --
+  await test(`[${b.label}] revert restores prior content as a new version`, () => {
+    const before = rj(`stat ${P}/hello.txt`).currentVersion;
+    const rev = rj(`revert ${P}/hello.txt --to 1`);
+    assert(rev.revertedTo, 1);
+    assert(rj(`cat ${P}/hello.txt`).content, "Hello, agent-fs!");
+    const after = rj(`stat ${P}/hello.txt`).currentVersion;
+    assert(after > before, true, `revert must append a new version (before=${before}, after=${after})`);
+  });
+
+  await test(`[${b.label}] rm + ls`, () => {
+    rj(`rm ${P}/hello-moved.txt`);
+    const names = rj(`ls ${P}`).entries.map((e: any) => e.name);
+    assert(names.includes("hello-moved.txt"), false, "file gone after rm");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Unsupported-op gating (step-5)
+//
+// Force a no-versioning local backend via the step-2 test-only
+// AGENT_FS_CAPABILITY_OVERRIDE hook and assert `revert` fails cleanly: the real
+// CLI→daemon path prints a friendly message (no stack trace), and the daemon
+// returns HTTP 422 with the typed UNSUPPORTED_OPERATION body. (The CLI renders
+// `body.message`, so the literal code token is asserted on the API response.)
+// ---------------------------------------------------------------------------
+
+async function unsupportedOpSuite() {
+  console.log(`\n-- capability gating: unsupported op (local, versioning forced off) --`);
+  const capped = await setupLocalBackend({
+    label: "local-capped",
+    capabilityOverride: JSON.stringify({ versioning: false }),
+  });
+
+  await test(`[capped] seed file (write works without versioning capability)`, () => {
+    assert(runJsonOn(capped, `write /cap.txt --content "v1"`).version, 1);
+  });
+
+  await test(`[capped] revert exits non-zero with a clean message (no stack trace)`, () => {
+    let threw = false;
+    let combined = "";
+    try {
+      runOn(capped, `revert /cap.txt --to 1`);
+    } catch (e: any) {
+      threw = true;
+      combined = `${e.stdout ?? ""}\n${e.stderr ?? ""}\n${e.message ?? ""}`;
+    }
+    assert(threw, true, "expected revert to exit non-zero on a no-versioning backend");
+    assertIncludes(combined, "not supported", "expected a clean unsupported-op message");
+    assert(/\n\s+at\s+\S/.test(combined), false, "must not leak a stack trace into the CLI error");
+  });
+
+  await test(`[capped] revert via API → HTTP 422 UNSUPPORTED_OPERATION`, async () => {
+    const res = await fetch(`http://127.0.0.1:${capped.daemonPort}/orgs/${capped.orgId}/ops`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${capped.apiKey}` },
+      body: JSON.stringify({ op: "revert", path: "/cap.txt", version: 1 }),
+    });
+    assert(res.status, 422, `expected 422, got ${res.status}`);
+    const body = (await res.json()) as any;
+    assert(body.error, "UNSUPPORTED_OPERATION");
+    assert(body.operation, "revert");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// signed-url backend matrix (step-5)
+//
+// MinIO mints a real, time-limited presigned URL (regression). The local-FS
+// backend has no presigned URLs, so `signed-url` falls back to an authenticated
+// in-app link (kind="app", non-expiring) instead of erroring.
+// ---------------------------------------------------------------------------
+
+async function signedUrlMatrix(minio: Backend, local: Backend) {
+  console.log(`\n-- signed-url backend matrix (presigned vs app fallback) --`);
+
+  await test(`[minio] signed-url returns a real presigned URL`, () => {
+    runJsonOn(minio, `write /su-probe.txt --content "su"`);
+    const res = runJsonOn(minio, `signed-url /su-probe.txt`);
+    assert(res.kind, "presigned");
+    assertIncludes(res.url, "agentfs", "expected presigned URL to reference the bucket");
+    assert(res.expiresIn, 86400);
+  });
+
+  await test(`[local] signed-url falls back to an app URL (not an error)`, () => {
+    runJsonOn(local, `write /su-probe.txt --content "su"`);
+    const res = runJsonOn(local, `signed-url /su-probe.txt`);
+    assert(res.kind, "app", `expected app-URL fallback, got kind=${res.kind}`);
+    assert(res.expiresIn, 0);
+    assertIncludes(res.url, "/file/~/", "expected an in-app (non-presigned) link");
   });
 }
 

--- a/skills/agent-fs/SKILL.md
+++ b/skills/agent-fs/SKILL.md
@@ -17,19 +17,37 @@ description: >-
   "fuse", "remote mount", "sandbox mount", "expose drives as files",
   "use cat/grep/mv on my agent-fs files", "umount the drive", "mount a remote
   drive", "mount from sprite", "mount from e2b", "mount from hetzner"). Also use
-  when the user wants to use agent-fs as a just-bash filesystem. If the user
+  when the user wants to use agent-fs as a just-bash filesystem. Also use when the
+  user wants to set up agent-fs without Docker or S3 ("local filesystem backend",
+  "filesystem storage", "no docker", "onboard --filesystem", "store files on disk").
+  If the user
   mentions agent-fs in any context, always consult this skill.
 ---
 
 # agent-fs CLI
 
-agent-fs is an agent-first filesystem backed by S3 with full versioning, full-text search (FTS5), and semantic search. It provides a CLI that outputs JSON, making it ideal for agent workflows. Files are organized in drives within orgs.
+agent-fs is an agent-first filesystem with full versioning, full-text search (FTS5), and semantic search. It provides a CLI that outputs JSON, making it ideal for agent workflows. Files are organized in drives within orgs.
+
+## Storage Backends
+
+agent-fs stores file bytes in a pluggable storage backend. The durable value — version history, comments, and search — lives in SQLite and works identically on every backend.
+
+| Backend | Setup | Versioning tier | `signed-url` |
+|---------|-------|-----------------|--------------|
+| **S3 / MinIO** (default) | `agent-fs onboard -y` (local MinIO, needs Docker) or `--s3-*` flags for AWS/R2/etc. | Full — `revert` + historical `diff` via S3 object versioning | Real presigned URL (public, time-limited) |
+| **Local filesystem** | `agent-fs onboard --filesystem` (no Docker, no S3) | Full — `revert` + historical `diff` via content-addressed blobs on disk | Falls back to an authenticated in-app link (requires sign-in; does not expire) |
+
+Both backends are **full-tier**: every op — including `revert` and historical `diff` — works. Future backends may be **basic-tier** (no object versioning): on those, `revert` and historical `diff` are unavailable and fail cleanly with an `UNSUPPORTED_OPERATION` error (HTTP 422) rather than a raw storage error — current content, listing, comments, and search keep working. Check a backend's capabilities before relying on versioning if you're unsure which backend a drive uses.
 
 ## Quick Start
 
 ```bash
 # 1. Set up (local MinIO — requires Docker)
 agent-fs onboard -y
+
+#    ...or with no Docker/S3 at all — store bytes on the local filesystem:
+agent-fs onboard --filesystem            # uses ~/.agent-fs/storage
+agent-fs onboard --filesystem --storage-root /data/agent-fs   # custom dir
 
 # 2. Optionally start the daemon (CLI auto-detects and works without it)
 agent-fs daemon start
@@ -40,6 +58,8 @@ agent-fs cat docs/readme.txt
 ```
 
 For custom S3 (AWS, R2, etc.), use flags: `agent-fs onboard --s3-endpoint <url> --s3-bucket <name> --s3-access-key <key> --s3-secret-key <key>`.
+
+The local-filesystem backend (`--filesystem`, equivalently `--storage local`) needs no Docker and no S3 — bytes are stored under `--storage-root` (default `~/.agent-fs/storage`), with every version content-addressed so `revert` and historical `diff` work the same as on S3.
 
 ## just-bash Adapter
 
@@ -113,7 +133,7 @@ symlinks are unsupported and throw `EPERM`.
 | `rm` | `agent-fs rm <path>` | Delete a file |
 | `mv` | `agent-fs mv <from> <to> [-m <msg>]` | Move or rename a file |
 | `cp` | `agent-fs cp <from> <to>` | Copy a file |
-| `signed-url` | `agent-fs signed-url <path> [--expires-in <seconds>]` | Generate a presigned URL for direct download (default: 24h, max: 7 days) |
+| `signed-url` | `agent-fs signed-url <path> [--expires-in <seconds>]` | Generate a download URL. On S3/MinIO: a presigned URL (default 24h, max 7 days, `kind: "presigned"`). On local-FS: an authenticated in-app link (`kind: "app"`, requires sign-in, non-expiring). |
 | `download` | `agent-fs download <path> [-o <local-path>]` | Download raw bytes |
 
 ### Versioning
@@ -123,6 +143,8 @@ symlinks are unsupported and throw `EPERM`.
 | `log` | `agent-fs log <path> [--limit <n>]` | Show version history |
 | `diff` | `agent-fs diff <path> --v1 <n> --v2 <n>` | Diff between versions |
 | `revert` | `agent-fs revert <path> --version <n>` | Revert to a previous version |
+
+`log` works on every backend (version metadata is in SQLite). `revert` and historical `diff` (comparing two stored versions) need a **full-tier** backend — S3/MinIO and local-filesystem both qualify. On a basic-tier backend without object versioning, `revert` and historical `diff` fail cleanly with `UNSUPPORTED_OPERATION` (HTTP 422); `diff` then degrades to the stored summary instead of full content.
 
 ### Search & Discovery
 
@@ -165,7 +187,7 @@ Supported formats: csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also `.gz` 
 
 | Command | Usage | Description |
 |---------|-------|-------------|
-| `onboard` | `agent-fs onboard [--local] [-y] [--embeddings <provider>]` | Set up agent-fs (S3 + database + user) |
+| `onboard` | `agent-fs onboard [--local] [--filesystem] [--storage <minio\|local>] [--storage-root <dir>] [-y] [--embeddings <provider>]` | Set up agent-fs (storage backend + database + user). `--filesystem` (or `--storage local`) uses an on-disk backend — no Docker/S3; `--storage-root <dir>` sets its directory. |
 | `init` | `agent-fs init [--local] [-y]` | Alias for `onboard` |
 | `auth register` | `agent-fs auth register <email>` | Register a new user |
 | `auth whoami` | `agent-fs auth whoami` | Show current user info |
@@ -362,7 +384,9 @@ agent-fs signed-url docs/report.pdf --json
 # → { "url": "https://...", "path": "/docs/report.pdf", "expiresIn": 86400, "expiresAt": "2026-03-20T..." }
 ```
 
-The presigned URL requires no authentication — anyone with the link can download the file until it expires. Access is RBAC-checked only at generation time (viewer-or-better on the drive); after that the URL is a bearer secret. Don't log it or paste it anywhere you wouldn't paste a credential, and prefer the shortest workable `--expires-in`. Signed URLs serve the correct `Content-Type` header based on file extension (e.g., `application/pdf` for `.pdf`, `image/png` for `.png`), so browsers render them natively.
+On an S3/MinIO backend (`kind: "presigned"`) the URL requires no authentication — anyone with the link can download the file until it expires. Access is RBAC-checked only at generation time (viewer-or-better on the drive); after that the URL is a bearer secret. Don't log it or paste it anywhere you wouldn't paste a credential, and prefer the shortest workable `--expires-in`. Signed URLs serve the correct `Content-Type` header based on file extension (e.g., `application/pdf` for `.pdf`, `image/png` for `.png`), so browsers render them natively.
+
+On a backend without presigned URLs (the local-filesystem backend), `signed-url` does **not** fail — it falls back to an authenticated in-app link (`kind: "app"`, `expiresIn: 0`) of the form `<appUrl>/file/~/<org>/<drive>/<path>`. Unlike a presigned URL this link is **not** a public bearer secret: the daemon's `/raw` route and the web viewer require sign-in, so the recipient must be an authenticated member of the drive. Set `AGENT_FS_APP_URL` (or `appUrl` in config) so the link points at your deployment.
 
 **MIME types on upload:** `write`, `edit`, `append`, and `revert` automatically detect and set the correct `Content-Type` on S3 objects based on file extension. The content type is also stored in the database and visible in `stat` output via the `contentType` field. Raw stdin and `--file` uploads preserve bytes exactly; text search/indexing is applied only when the payload is valid, indexable UTF-8 text.
 

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
@@ -1,0 +1,135 @@
+---
+date: 2026-06-25T12:00:00-00:00
+author: Taras (planned by Claude)
+plan_type: dag
+status: in-progress
+last_updated: 2026-06-25
+last_updated_by: Claude (for Taras)
+---
+
+# Multi-Adapter Storage via a thin `StorageAdapter` interface — Plan (DAG)
+
+## Overview
+
+Introduce a thin internal `StorageAdapter` interface so agent-fs storage supports multiple backends. Keep the existing `AgentS3Client` as the full-featured S3/MinIO adapter (behavior unchanged), and add a `files-sdk`-backed **local-filesystem** adapter for breadth. Backends are feature-tiered: S3/MinIO and local-FS get full versioning (`revert`/historical `diff`); other (future) adapters degrade gracefully. The durable value — file **comments** and **search** — is SQLite-side and keeps working on every backend.
+
+- **Motivation**: Get automatic support for a broad set of storage backends (S3/MinIO today, local-FS next, consumer providers like Dropbox/GDrive later) behind one internal interface, without re-litigating the proven S3 path.
+- **Related**: `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md` (research + locked Decisions), `packages/core/src/s3/client.ts`, `packages/core/src/ops/types.ts`, `packages/server/src/index.ts:13`.
+
+## Current State Analysis
+
+All object I/O flows through one concrete class, **`AgentS3Client`** (`packages/core/src/s3/client.ts:51`) — the only importer of `@aws-sdk/*`. Consumers see it solely as `ctx.s3: AgentS3Client` on `OpContext` (`packages/core/src/ops/types.ts:5-13`). ~16 ops call `ctx.s3.<method>()`; none import the AWS SDK. A duck-typed `MockS3Client` mirrors the surface for tests, wired in via an `as any` cast (`packages/core/src/test-utils.ts:225`) — there is **no shared interface yet**.
+
+The 10-method surface any adapter must satisfy (`client.ts`): `putObject` `:78-97`, `getObject(key, versionId?)` `:99-120`, `deleteObject` `:122-129`, `copyObject` `:131-143`, `listObjects(prefix,{delimiter})` `:145-165`, `headObject` `:167-181`, `listObjectVersions` `:183-198`, `checkVersioningEnabled` `:200-209`, `enableVersioning` `:211-224`, `getPresignedUrl(key,expiresIn,responseContentType?)` `:226-238`, plus the `versioningEnabled: boolean` field.
+
+Key facts that shape the design:
+- **Almost all "filesystem" semantics live in SQLite**, not S3: version numbering (`getNextVersion`, `versioning.ts:19-35`), history (`log.ts:11-22`), dedup, optimistic concurrency (`assertExpectedVersion`, `versioning.ts:92-109`), FTS5 search, comments. The object store is a dumb keyed blob store: `getS3Key` → `<orgId>/drives/<driveId>/<path>` (`versioning.ts:11-14`).
+- **The one S3 leak is object versioning** for old-content retrieval: `revert` hard-requires `s3_version_id` (`revert.ts:44-54`); historical `diff` reads two version-ids in parallel and degrades to a stored `diffSummary` when absent (`diff.ts:49-91`).
+- **Single construction site**: `new AgentS3Client(config.s3)` at `packages/server/src/index.ts:13`, threaded into routes/IPC/MCP by `createApp` (`app.ts:18-77`).
+- **Non-atomic write path**: `write.ts` does `putObject` then `createVersion` (a SQLite transaction) as two steps — object-first ordering, but no orphan cleanup today.
+- S3 error-shape coupling: ops branch on `err.name === "NoSuchKey"|"NotFound"` / `httpStatusCode === 404` → `NotFoundError` (`cat.ts:45`, `stat.ts:18`, `append.ts:30`, `edit.ts:31`, `signed-url.ts:31`, `routes/files.ts:77`). Adapters must translate.
+
+See the research doc for the full architecture map, the storage contract (§2), the files-sdk capability report (§6), and the locked **Decisions** (§ Decisions).
+
+## Desired End State
+
+- `StorageAdapter` interface + `StorageCapabilities` metadata type own the storage contract; `AgentS3Client implements StorageAdapter` (behavior untouched) and `MockS3Client` implements it too (the `as any` cast at `test-utils.ts:225` is gone). `OpContext.s3` is typed to the interface.
+- A typed `UnsupportedOperation` error is thrown by ops a backend can't satisfy and is surfaced cleanly in CLI + MCP. Each adapter advertises `capabilities` (`{ versioning, presignedUrls }`).
+- A `files-sdk`-backed **local-filesystem** adapter exists with **app-level per-version keys**, so `revert` and historical `diff` work on local without object versioning. `ls` directory listing works.
+- `AgentFSConfig.s3` is a tagged union keyed by `provider`; the adapter is selected at `packages/server/src/index.ts:13`; onboarding supports a local-FS backend.
+- E2E (`scripts/e2e.ts`) covers S3 **and** local (incl. revert/diff under each, plus an unsupported-op assertion). Release checklist done.
+
+## What We're NOT Doing
+
+- **No change to S3/MinIO behavior.** `AgentS3Client` only gains an `implements StorageAdapter` declaration; the S3 path stays green throughout.
+- **No consumer-provider adapter (Dropbox/GDrive) or OAuth in this plan** — deferred to a follow-up plan (new config + per-drive credential storage + token refresh is a separate feature). _Confirmed with Taras 2026-06-25._
+- **No multipart/streaming rewrite** of the buffered write path (independent improvement).
+- **No per-org/per-drive backend selection** — storage stays a process-wide singleton (no new DB columns).
+
+## Implementation Approach
+
+- **Foundation first (step-1):** extract the interface everything else depends on, **including** the `StorageCapabilities` type and the typed `UnsupportedOperation` error. Putting the error in the contract (not in the gating step) lets adapters throw it without depending on step-2. Mechanical, low-risk.
+- **Gating in parallel (step-2):** capability checks + clean surfacing of `UnsupportedOperation` through core ops → CLI → MCP, so limited backends fail cleanly instead of throwing raw S3/FS errors. Depends only on step-1.
+- **Local adapter in parallel (step-3):** the first non-S3 adapter, with app-level versioning so local gets the full tier (revert/diff). Depends only on step-1 (throws the step-1 `UnsupportedOperation` for `signed-url`; QA'd via direct adapter integration tests). This is where the versioning-key scheme and the cross-store atomicity decision land.
+- **Config + selection fourth (step-4):** tagged-union config + startup selection + onboarding, making the local backend reachable end-to-end by users. Needs the adapter (step-3).
+- **Integration/E2E last (step-5):** cross-backend E2E + release checklist — the terminal node that proves S3 and local both pass, including an unsupported-op assertion.
+- **Why this shape:** step-1 is the single foundation; **steps 2 and 3 are independent and run in parallel** after it; step-4 needs the adapter to select; step-5 gates on all. Consumer-provider/OAuth is pushed to a follow-up plan so it never blocks the core.
+
+## Quick Verification Reference
+
+- Typecheck: `bun run typecheck`
+- Tests: `bun test` (manual/integration tests auto-skip without env)
+- CLI help: `bun run packages/cli/src/index.ts -- <cmd> --help`
+- E2E (Docker/MinIO): `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`
+
+## DAG
+
+```mermaid
+graph TD
+    step-1[step-1: StorageAdapter interface + capabilities + UnsupportedOperation]
+    step-2[step-2: Capability gating + clean surfacing core→CLI→MCP]
+    step-3[step-3: files-sdk local-FS adapter + app-level versioning]
+    step-4[step-4: Config tagged-union + adapter selection + onboarding]
+    step-5[step-5: Cross-backend E2E + release checklist]
+    step-1 --> step-2
+    step-1 --> step-3
+    step-1 --> step-4
+    step-3 --> step-4
+    step-1 --> step-5
+    step-2 --> step-5
+    step-3 --> step-5
+    step-4 --> step-5
+```
+
+## Steps
+
+| ID | Name | Depends on | Status | File |
+|----|------|------------|--------|------|
+| step-1 | StorageAdapter interface + capabilities + UnsupportedOperation | — | ready | [step-1.md](./step-1.md) |
+| step-2 | Capability gating + clean surfacing (core→CLI→MCP) | step-1 | ready | [step-2.md](./step-2.md) |
+| step-3 | files-sdk local-FS adapter + app-level versioning | step-1 | ready | [step-3.md](./step-3.md) |
+| step-4 | Config tagged-union + adapter selection + onboarding | step-1, step-3 | ready | [step-4.md](./step-4.md) |
+| step-5 | Cross-backend E2E + release checklist | step-1, step-2, step-3, step-4 | ready | [step-5.md](./step-5.md) |
+
+> **Canonical dependencies and execution status live in each `step-<n>.md`'s frontmatter.** This table is a derived snapshot at plan creation.
+
+## Pre-flight Verification
+
+- [ ] Working tree is clean (or only intentional in-flight work)
+- [ ] Baseline tests pass: `bun test`
+- [ ] Baseline typecheck passes: `bun run typecheck`
+- [ ] Docker available for MinIO E2E (`scripts/e2e.ts`)
+
+## Global Verification
+
+- [ ] Whole-repo typecheck: `bun run typecheck`
+- [ ] Full test suite: `bun test`
+- [ ] E2E suite passes against MinIO **and** a local-FS drive: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`
+- [ ] S3 path behavior unchanged (existing E2E + revert/diff still pass on MinIO)
+- [ ] Release checklist done: `skills/agent-fs/SKILL.md` updated, `.claude-plugin/plugin.json` + root `package.json` bumped
+
+## Confirmed Decisions (Taras, 2026-06-25)
+
+1. **DAG shape** — 5 steps as above; consumer providers (Dropbox/GDrive) + OAuth deferred to a follow-up plan.
+2. **Local-FS versioning** — **content-addressed blobs**: each version's bytes also stored at a reserved top-level `_afs-blobs/sha256/<hash>` key (outside any drive listing prefix); current version stays at the plain path key. `file_versions.s3_version_id` (now an opaque per-adapter version handle) holds the hash. revert/diff read by hash; dedup is free (reuses the existing `content_hash`, `write.ts:75-77`).
+3. **`signed-url` on local** — capability metadata reports `presignedUrls:false` and the op **falls back to the daemon `/raw` URL** via `buildAppUrl` (`packages/core/src/ops/urls.ts`) rather than hard-failing. (step-3 must verify the `/raw` route's auth model.)
+4. **Commits** — commit after each step once its manual verification passes (`[step-N] <desc>`).
+
+## files-sdk Verification (live source check, 2026-06-25)
+
+Verified against `github.com/haydenbleasel/files-sdk@main` (v2.0.0):
+- **fs adapter** = `import { fs } from "files-sdk/fs"`; `import { Files } from "files-sdk"`. Constructor `fs({ root /* required */, urlBaseUrl? })`. Keys map to **nested paths** mirroring the key (`path.join(root, ...key.split("/"))`); `mkdir(recursive)` on write; traversal outside `root` throws.
+- **Delimiter listing CONFIRMED** — `list({ prefix, delimiter: "/" })` → `{ items: StoredFile[], prefixes?: string[] }`; `items` = immediate files, `prefixes` = immediate subdirs (full keys w/ trailing `/`). fs sets `supportsDelimiter: true`. Maps cleanly onto the current `listObjects` → `{ objects, prefixes }` contract — **no `.raw` / client-side derivation needed**.
+- **fs `url()` never presigns** — returns a `file://` URL (or `${urlBaseUrl}/${key}`); `signedUrl.supported = false`; `signedUploadUrl()` rejects. Confirms the `/raw` fallback for `signed-url`. `responseContentDisposition` is supported on S3's `url()` but **`responseContentType` is not** (needs `.raw` + `GetObjectCommand`) — moot here since S3 stays on `AgentS3Client` and local doesn't presign.
+- **copy/move/head/download(range) CONFIRMED** on fs (`supportsRange: true`).
+- **Error model** — `FilesError { code: "NotFound"|"Unauthorized"|"Conflict"|"ReadOnly"|"Provider" }`. Adapter translates `code === "NotFound"` into the S3-compatible not-found shape ops already branch on (`err.name ∈ {NoSuchKey, NotFound}` / `httpStatusCode 404`).
+- **`head` returns `StoredFile`** `{ name, key, size, type, lastModified?, etag?, metadata?, arrayBuffer(), stream(), … }`; `download` returns the same lazy `StoredFile`. `exists(key) → boolean`.
+- **Bun CONFIRMED** — package uses `bun test`, `packageManager: bun@1.3.14`, ships a `bun-s3` adapter; no Bun caveat for `fs`/`s3`.
+
+## Appendix
+
+- **Follow-up plans**: Consumer-provider adapter (Dropbox/GDrive) at the basic tier + OAuth token storage/refresh (deferred from this plan).
+- **Derail notes**: Cross-store atomicity — the write path is `putObject` then `createVersion` (object-then-commit). For S3 and local the partial-failure window is unchanged/narrow (content-addressed blobs are dedup-shared and harmless to leave); real reconciliation/retry belongs with the remote/consumer adapter. Multipart/streaming for large uploads is an independent improvement.
+- **References**:
+  - Research: `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md`
+  - files-sdk: `https://files-sdk.dev/`, `https://github.com/haydenbleasel/files-sdk`, npm `files-sdk` v2.0.0

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
@@ -2,8 +2,8 @@
 date: 2026-06-25T12:00:00-00:00
 author: Taras (planned by Claude)
 plan_type: dag
-status: in-progress
-last_updated: 2026-06-25
+status: completed
+last_updated: 2026-06-26
 last_updated_by: Claude (for Taras)
 ---
 
@@ -95,18 +95,18 @@ graph TD
 
 ## Pre-flight Verification
 
-- [ ] Working tree is clean (or only intentional in-flight work)
-- [ ] Baseline tests pass: `bun test`
-- [ ] Baseline typecheck passes: `bun run typecheck`
-- [ ] Docker available for MinIO E2E (`scripts/e2e.ts`)
+- [x] Working tree is clean (or only intentional in-flight work)
+- [x] Baseline tests pass: `bun test` (832 pass / 114 skip / 0 fail at baseline)
+- [x] Baseline typecheck passes: `bun run typecheck`
+- [x] Docker available for MinIO E2E (`scripts/e2e.ts`) — confirmed by step-5's real MinIO run
 
 ## Global Verification
 
-- [ ] Whole-repo typecheck: `bun run typecheck`
-- [ ] Full test suite: `bun test`
-- [ ] E2E suite passes against MinIO **and** a local-FS drive: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"`
-- [ ] S3 path behavior unchanged (existing E2E + revert/diff still pass on MinIO)
-- [ ] Release checklist done: `skills/agent-fs/SKILL.md` updated, `.claude-plugin/plugin.json` + root `package.json` bumped
+- [x] Whole-repo typecheck: `bun run typecheck`
+- [x] Full test suite: `bun test` (898 pass / 114 skip / 0 fail)
+- [x] E2E suite passes against MinIO **and** a local-FS drive: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (127/127, 10 FUSE skipped on Darwin)
+- [x] S3 path behavior unchanged (existing E2E + revert/diff still pass on MinIO)
+- [x] Release checklist done: `skills/agent-fs/SKILL.md` updated, `.claude-plugin/plugin.json` + root `package.json` bumped (0.10.0)
 
 ## Confirmed Decisions (Taras, 2026-06-25)
 

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
@@ -133,3 +133,15 @@ Verified against `github.com/haydenbleasel/files-sdk@main` (v2.0.0):
 - **References**:
   - Research: `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md`
   - files-sdk: `https://files-sdk.dev/`, `https://github.com/haydenbleasel/files-sdk`, npm `files-sdk` v2.0.0
+
+## Review Errata
+
+_Reviewed: 2026-06-26 by Claude (post-implementation, autonomy=critical). Verification audit: `AUDIT: clean` — 0 blocking, 0 warnings. All findings below are Minor._
+
+### Resolved
+- [x] **Imprecise file path (step-4)** — step-4's "Retype the server-wide storage seam" listed `packages/server/src/ipc/server.ts`, but the retype actually landed in `ipc/handlers.ts` (`ipc/server.ts` only references the `IpcContext` type and was unchanged); `routes/ops.ts` was also retyped. — auto-fixed in `step-4.md`.
+
+### Noted (no action required)
+- [ ] **QA labeling** — steps report `QA: n/a`, which refers to "no separate `desplega:qa` doc." Each step nonetheless shipped substantial *automated* integration QA (e.g. `storage/__tests__/local-adapter-ops.test.ts`, the dual-backend `scripts/e2e.ts` matrix). The `n/a` undersells the actual coverage; wording only.
+- [ ] **Cross-store atomicity / local blob GC** — consciously deferred (see Derail notes). The object-then-commit write path leaves a narrow partial-failure window, and local content-addressed blobs under `_afs-blobs/sha256/` are never garbage-collected, so local version history grows unbounded. Harmless today (orphans are dedup-shared); track reconciliation + a GC/retention story before local sees heavy churn. Candidate for the consumer-provider follow-up plan.
+- [ ] **`--local` vs `--filesystem` naming** — `--local` means *local MinIO Docker* while `--filesystem`/`--storage local` mean *local filesystem*; a user could reasonably expect `--local` to mean the filesystem. Consider an alias/rename in a future onboarding-UX pass.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-1.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-1.md
@@ -2,7 +2,7 @@
 id: step-1
 name: StorageAdapter interface + capabilities + UnsupportedOperation
 depends_on: []
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -46,15 +46,15 @@ Extract the storage contract that every other step builds on. Define a `StorageA
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Whole-repo typecheck passes — this is the core proof; removing `as any` must compile cleanly: `bun run typecheck`
-- [ ] Full test suite still green (zero behavior change): `bun test`
-- [ ] The cast is gone: `! grep -n "s3 as any" packages/core/src/test-utils.ts`
-- [ ] No op imports `AgentS3Client` as a value (interface-only seam): `! grep -rn "new AgentS3Client" packages/core/src/ops`
+- [x] Whole-repo typecheck passes — this is the core proof; removing `as any` must compile cleanly: `bun run typecheck`
+- [x] Full test suite still green (zero behavior change): `bun test` — 840 pass, 114 skip, 0 fail
+- [x] The cast is gone: `! grep -n "s3 as any" packages/core/src/test-utils.ts`
+- [x] No op imports `AgentS3Client` as a value (interface-only seam): `! grep -rn "new AgentS3Client" packages/core/src/ops` — op *source* is clean (verified with `--glob '!**/__tests__/**'`). The literal grep still matches two **pre-existing, untouched** MinIO integration test files under `ops/__tests__/`; the interface-only-seam intent (no op implementation constructs the concrete client) is satisfied.
 
 #### Automated QA:
-- [ ] A unit test (`packages/core/src/storage/__tests__/adapter.test.ts`) instantiates `MockS3Client`, asserts `.capabilities` returns `{ versioning, presignedUrls: true }` and `.getPresignedUrl("k")` returns a string — proving the mock fully implements the surface (no longer needs the cast).
-- [ ] A type-level assignability check (e.g. `const _a: StorageAdapter = new MockS3Client()` and `= new AgentS3Client(cfg)`) compiles.
-- [ ] A unit test constructs `new UnsupportedOperation("revert", "local")` and asserts `.code === "UNSUPPORTED_OPERATION"` and `.toJSON()` carries `operation`/`backend`/`message`.
+- [x] A unit test (`packages/core/src/storage/__tests__/adapter.test.ts`) instantiates `MockS3Client`, asserts `.capabilities` returns `{ versioning, presignedUrls: true }` and `.getPresignedUrl("k")` returns a string — proving the mock fully implements the surface (no longer needs the cast).
+- [x] A type-level assignability check (e.g. `const _a: StorageAdapter = new MockS3Client()` and `= new AgentS3Client(cfg)`) compiles.
+- [x] A unit test constructs `new UnsupportedOperation("revert", "local")` and asserts `.code === "UNSUPPORTED_OPERATION"` and `.toJSON()` carries `operation`/`backend`/`message`.
 
 #### Manual Verification:
 - [ ] Skim the diff to confirm `AgentS3Client` method bodies are byte-for-byte unchanged (only the `implements` clause + `capabilities` getter + import path added).

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-1.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-1.md
@@ -1,0 +1,62 @@
+---
+id: step-1
+name: StorageAdapter interface + capabilities + UnsupportedOperation
+depends_on: []
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-1: StorageAdapter interface + capabilities + UnsupportedOperation
+
+## Overview
+Extract the storage contract that every other step builds on. Define a `StorageAdapter` interface (the existing 10-method surface + `versioningEnabled` + a new `capabilities` field), a `StorageCapabilities` metadata type, and a typed `UnsupportedOperation` error. Make `AgentS3Client implements StorageAdapter` (behavior 100% unchanged — it only gains the declaration + a `capabilities` getter) and `MockS3Client implements StorageAdapter`, which forces us to add the **missing `getPresignedUrl`** to the mock and **remove the `as any` cast** at `test-utils.ts:225`. Re-type `OpContext.s3` to the interface. No op behavior changes; the proof of this slice is that everything still typechecks and all existing tests pass with the cast gone.
+
+## Changes Required:
+
+#### 1. Storage contract (new file)
+**File**: `packages/core/src/storage/adapter.ts` (new `storage/` directory)
+**Changes**:
+- Define `export interface StorageCapabilities { versioning: boolean; presignedUrls: boolean }`.
+- Define `export interface StorageAdapter` with the exact signatures from `packages/core/src/s3/client.ts` (`:78-238`): `putObject`, `getObject(key, versionId?, opts?: { abortSignal?: AbortSignal })`, `deleteObject`, `copyObject`, `listObjects(prefix, opts?: { delimiter?: string })`, `headObject`, `listObjectVersions`, `checkVersioningEnabled`, `enableVersioning`, `getPresignedUrl(key, expiresIn?, responseContentType?)`, plus `versioningEnabled: boolean` and `readonly capabilities: StorageCapabilities`.
+- **Move** the shared result/value types currently in `s3/client.ts:16-49` (`S3Object`, `S3ObjectVersion`, `PutObjectResult`, `GetObjectResult`, `HeadObjectResult`) into this file (canonical home) to avoid a circular import (`client.ts` will import the interface from here). Re-export them from `s3/client.ts` for back-compat if any external import path relies on them.
+- Add a doc comment stating the **not-found error-shape contract**: adapters MUST surface "object not found" as an error matching what ops already branch on — `err.name ∈ {"NoSuchKey","NotFound"}` or `err.$metadata?.httpStatusCode === 404` (see `cat.ts:45`, `stat.ts:18`, `signed-url.ts:31`, `routes/files.ts:77`). This keeps the ~6 op error branches unchanged.
+
+#### 2. Typed unsupported-operation error
+**File**: `packages/core/src/errors.ts`
+**Changes**: Add `export class UnsupportedOperation extends AgentFSError` mirroring the existing class pattern (`:1-35`): `constructor(operation: string, backend?: string, opts?: { suggestion?: string })` → `super("UNSUPPORTED_OPERATION", message, suggestion)`. Store `readonly operation` / `readonly backend`; override `toJSON()` to include them. Default message e.g. ``\`Operation '${operation}' is not supported by the '${backend}' storage backend\``` with a suggestion pointing at the capable tiers.
+
+#### 3. AgentS3Client conforms (no behavior change)
+**File**: `packages/core/src/s3/client.ts`
+**Changes**: `export class AgentS3Client implements StorageAdapter`. Import the moved shared types from `../storage/adapter.js`. Add `get capabilities(): StorageCapabilities { return { versioning: this.versioningEnabled, presignedUrls: true }; }` (a getter so it tracks `enableVersioning()` mutating `versioningEnabled`). **Do not change any method body.**
+
+#### 4. MockS3Client conforms (close the drift the cast hid)
+**File**: `packages/core/src/test-utils.ts`
+**Changes**: `export class MockS3Client implements StorageAdapter`. Add the currently-missing `async getPresignedUrl(key, expiresIn = 86400, responseContentType?): Promise<string>` returning a deterministic fake (e.g. ``\`https://mock.local/${key}?e=${expiresIn}\``). Add `get capabilities(): StorageCapabilities { return { versioning: this.versioningEnabled, presignedUrls: true }; }`. Remove the `as any` cast at `:225` — change `s3: s3 as any` to `s3,`. (If typecheck reveals any other signature drift between mock and interface, reconcile it here — surfacing that drift is the point.)
+
+#### 5. Re-type the injection seam
+**File**: `packages/core/src/ops/types.ts`
+**Changes**: Change `s3: AgentS3Client` (`:7`) to `s3: StorageAdapter`; replace the `import type { AgentS3Client }` (`:1`) with `import type { StorageAdapter } from "../storage/adapter.js"`. **Keep the field name `s3`** to avoid churn across the ~16 ops (research §7; field rename is explicitly out of scope).
+
+#### 6. Barrel exports
+**File**: `packages/core/src/index.ts`
+**Changes**: Export `StorageAdapter`, `StorageCapabilities`, `UnsupportedOperation`, and ensure the moved shared storage types remain exported (server/CLI import `AgentS3Client` + types from `@/core`). Do **not** change server-side `s3: AgentS3Client` annotations yet — `AgentS3Client` still satisfies them; the server-wide retype to `StorageAdapter` happens in step-4 when a non-S3 adapter actually flows through.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Whole-repo typecheck passes — this is the core proof; removing `as any` must compile cleanly: `bun run typecheck`
+- [ ] Full test suite still green (zero behavior change): `bun test`
+- [ ] The cast is gone: `! grep -n "s3 as any" packages/core/src/test-utils.ts`
+- [ ] No op imports `AgentS3Client` as a value (interface-only seam): `! grep -rn "new AgentS3Client" packages/core/src/ops`
+
+#### Automated QA:
+- [ ] A unit test (`packages/core/src/storage/__tests__/adapter.test.ts`) instantiates `MockS3Client`, asserts `.capabilities` returns `{ versioning, presignedUrls: true }` and `.getPresignedUrl("k")` returns a string — proving the mock fully implements the surface (no longer needs the cast).
+- [ ] A type-level assignability check (e.g. `const _a: StorageAdapter = new MockS3Client()` and `= new AgentS3Client(cfg)`) compiles.
+- [ ] A unit test constructs `new UnsupportedOperation("revert", "local")` and asserts `.code === "UNSUPPORTED_OPERATION"` and `.toJSON()` carries `operation`/`backend`/`message`.
+
+#### Manual Verification:
+- [ ] Skim the diff to confirm `AgentS3Client` method bodies are byte-for-byte unchanged (only the `implements` clause + `capabilities` getter + import path added).
+
+**Implementation Note**: Vertical slice — the storage contract exists and compiles, the mock-vs-real drift is closed, and the whole suite is green. After completing this step, pause for manual confirmation. Commit-per-step is enabled: commit as `[step-1] StorageAdapter interface + capabilities + UnsupportedOperation` after verification passes.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-2.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-2.md
@@ -2,7 +2,7 @@
 id: step-2
 name: Capability gating + clean surfacing (core→CLI→MCP)
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -45,14 +45,14 @@ Wire capability checks into the version-critical ops so a backend that lacks a c
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
-- [ ] Unit: `revert` against `new MockS3Client({ capabilities: { versioning: false } })`-backed ctx throws `UnsupportedOperation` with `code === "UNSUPPORTED_OPERATION"` (`packages/core/src/ops/__tests__/revert.test.ts`).
-- [ ] Unit: `diff` against the same backend returns the `diffSummary` fallback and does **not** throw.
+- [x] Typecheck + tests: `bun run typecheck` && `bun test`
+- [x] Unit: `revert` against `new MockS3Client({ capabilities: { versioning: false } })`-backed ctx throws `UnsupportedOperation` with `code === "UNSUPPORTED_OPERATION"` (`packages/core/src/ops/__tests__/revert.test.ts`).
+- [x] Unit: `diff` against the same backend returns the `diffSummary` fallback and does **not** throw.
 
 #### Automated QA:
-- [ ] In-process daemon test (Hono `app.fetch`, `createApp(db, forcedMock, …)`): `POST /…/ops` op=`revert` → HTTP **422** with body `{ error: "UNSUPPORTED_OPERATION", message, suggestion }`.
-- [ ] MCP server test: invoking the `revert` tool against the no-versioning backend returns `isError: true` with the message text (not a raw throw).
-- [ ] CLI surfacing test: simulate the api-client receiving the 422 JSON and assert the thrown `Error.message` is the clean `message` + `Suggestion:` line (no stack trace).
+- [x] In-process daemon test (Hono `app.fetch`, `createApp(db, forcedMock, …)`): `POST /…/ops` op=`revert` → HTTP **422** with body `{ error: "UNSUPPORTED_OPERATION", message, suggestion }`.
+- [x] MCP server test: invoking the `revert` tool against the no-versioning backend returns `isError: true` with the message text (not a raw throw).
+- [x] CLI surfacing test: simulate the api-client receiving the 422 JSON and assert the thrown `Error.message` is the clean `message` + `Suggestion:` line (no stack trace).
 
 #### Manual Verification:
 - [ ] Read the rendered CLI error string for an unsupported `revert` — confirm the wording + suggestion are friendly and actionable.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-2.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-2.md
@@ -1,0 +1,60 @@
+---
+id: step-2
+name: Capability gating + clean surfacing (core→CLI→MCP)
+depends_on: [step-1]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-2: Capability gating + clean surfacing (core→CLI→MCP)
+
+## Overview
+Wire capability checks into the version-critical ops so a backend that lacks a capability throws the step-1 `UnsupportedOperation` (instead of a raw/confusing S3/FS error), and prove it surfaces cleanly all the way out through the daemon's HTTP error layer → CLI and → MCP. This slice is independent of the local adapter (step-3): it is QA-able today by pointing an `OpContext` (and the in-process Hono app + the MCP server) at a `MockS3Client` whose `capabilities` are forced off. **File-disjoint from step-3** — they touch different ops (`revert`/`diff` here, `signed-url` there) and can run in parallel.
+
+## Changes Required:
+
+#### 1. Capability assertion helper
+**File**: `packages/core/src/storage/capabilities.ts` (new)
+**Changes**: `export function assertCapability(adapter: StorageAdapter, cap: keyof StorageCapabilities, operation: string): void` — throws `new UnsupportedOperation(operation, /* backend label */, …)` when `!adapter.capabilities[cap]`. (Optionally accept a backend label; otherwise derive a generic one.)
+
+#### 2. Gate the version-critical ops
+**File**: `packages/core/src/ops/revert.ts`
+**Changes**: At the top of `revert` (before the existing `VERSIONING_REQUIRED` throw at `:45`), call `assertCapability(ctx.s3, "versioning", "revert")`. Keep the existing `VERSIONING_REQUIRED` `AgentFSError` for the narrower "versioning-capable backend but this row has no version handle" case. Net: no-versioning backend → `UnsupportedOperation`; versioning backend w/ missing handle → `VERSIONING_REQUIRED` (unchanged).
+
+**File**: `packages/core/src/ops/diff.ts`
+**Changes**: Confirm/keep the existing graceful degradation (`:81-91`) — historical-content `diff` on a no-versioning backend must **fall back to the stored `diffSummary`, never throw** `UnsupportedOperation`. Add a guard so that when `!ctx.s3.capabilities.versioning` it goes straight to the summary path (no version-id fetch attempt). Document that `diff` degrades, `revert` hard-throws — this asymmetry matches research §3.
+
+#### 3. Refine the daemon error→HTTP mapping
+**File**: `packages/server/src/middleware/error.ts`
+**Changes**: Add `if (err instanceof UnsupportedOperation) return 422;` to `errorToStatus` (alongside the existing `NotFoundError`→404 etc. at `:11-16`). The base `"code" in err → 400` branch (`:16`) already catches it, so this is a status refinement; the body already serializes via `err.toJSON()` (`:24-25`). (Pick 422 Unprocessable; 501 Not Implemented is also defensible — 422 avoids clients treating it as a server bug.)
+
+#### 4. MockS3Client: allow forcing capabilities (test affordance)
+**File**: `packages/core/src/test-utils.ts`
+**Changes**: Extend the `MockS3Client` constructor opts with `capabilities?: Partial<StorageCapabilities>` so tests can construct a no-versioning / no-presign backend. The `capabilities` getter merges the override over the defaults from step-1. Thread an optional `capabilities` through `createTestContext` opts.
+
+#### 5. Test-only capability override at startup (for the step-5 CLI e2e)
+**File**: `packages/core/src/config.ts` (env handling) + `packages/core/src/storage/factory.ts` (created in step-4 — see note) **or** `packages/server/src/index.ts`
+**Changes**: Honor a **test-only** env var `AGENT_FS_CAPABILITY_OVERRIDE` (JSON, e.g. `{"versioning":false}`) that, when set, overlays the constructed adapter's `capabilities`. This lets step-5's e2e drive a real CLI→daemon `UNSUPPORTED_OPERATION` path against a backend that otherwise has the capability. Gate it behind an obvious "test-only" comment. (Adapter construction currently lives at `server/index.ts:13`; if step-4 lands the `createStorageAdapter` factory first, apply the override there. To keep this step independent, apply it at `server/index.ts` against the constructed adapter and let step-4 fold it into the factory.)
+
+#### 6. CLI + MCP surfacing (verify; minimal/no code change)
+**Files**: `packages/cli/src/commands/ops.ts` (`:182-192`), `packages/cli/src/api-client.ts` (`:46-50`), `packages/mcp/src/tools.ts`, `packages/mcp/src/server.ts`
+**Changes**: The CLI api-client already surfaces `body.message` + `body.suggestion` (`api-client.ts:47-49`) and `commands/ops.ts:191` prints `Error: ${err.message}` + exit 1 — confirm `UnsupportedOperation` flows through as a clean line (no stack). For MCP, confirm the ops tool path returns `{ isError: true, content: [{ text: <message> }] }` for a daemon error (member tools already do this — `server.ts:176-179`); if the ops proxy swallows or rethrows raw, add the same `isError` mapping. Prefer assertions over code where it already works.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
+- [ ] Unit: `revert` against `new MockS3Client({ capabilities: { versioning: false } })`-backed ctx throws `UnsupportedOperation` with `code === "UNSUPPORTED_OPERATION"` (`packages/core/src/ops/__tests__/revert.test.ts`).
+- [ ] Unit: `diff` against the same backend returns the `diffSummary` fallback and does **not** throw.
+
+#### Automated QA:
+- [ ] In-process daemon test (Hono `app.fetch`, `createApp(db, forcedMock, …)`): `POST /…/ops` op=`revert` → HTTP **422** with body `{ error: "UNSUPPORTED_OPERATION", message, suggestion }`.
+- [ ] MCP server test: invoking the `revert` tool against the no-versioning backend returns `isError: true` with the message text (not a raw throw).
+- [ ] CLI surfacing test: simulate the api-client receiving the 422 JSON and assert the thrown `Error.message` is the clean `message` + `Suggestion:` line (no stack trace).
+
+#### Manual Verification:
+- [ ] Read the rendered CLI error string for an unsupported `revert` — confirm the wording + suggestion are friendly and actionable.
+
+**Implementation Note**: Vertical slice — an unsupported op now fails with one clean, typed message from core through CLI and MCP, proven against a forced-capability mock without needing the local adapter. After completing this step, pause for manual confirmation. Commit-per-step is enabled: commit as `[step-2] Capability gating + clean UnsupportedOperation surfacing` after verification passes.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-3.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-3.md
@@ -2,7 +2,7 @@
 id: step-3
 name: files-sdk local-FS adapter + app-level versioning
 depends_on: [step-1]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -49,13 +49,13 @@ Implement `LocalStorageAdapter` — a `StorageAdapter` backed by the `files-sdk`
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `files-sdk` recorded in `packages/core/package.json`; `bun install` clean.
-- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
-- [ ] Adapter integration test (`packages/core/src/storage/__tests__/local-adapter.test.ts`, temp dir via `mkdtemp`): put/get/head/delete/copy round-trip; `listObjects(prefix, { delimiter: "/" })` returns files in `objects` + subdirs in `prefixes` and **never** surfaces `_afs-blobs`; `getObject(key)` after two writes returns latest, `getObject(key, oldHash)` returns the older bytes; `headObject` on a missing key throws an error with `name === "NoSuchKey"`.
+- [x] `files-sdk` recorded in `packages/core/package.json`; `bun install` clean.
+- [x] Typecheck + tests: `bun run typecheck` && `bun test`
+- [x] Adapter integration test (`packages/core/src/storage/__tests__/local-adapter.test.ts`, temp dir via `mkdtemp`): put/get/head/delete/copy round-trip; `listObjects(prefix, { delimiter: "/" })` returns files in `objects` + subdirs in `prefixes` and **never** surfaces `_afs-blobs`; `getObject(key)` after two writes returns latest, `getObject(key, oldHash)` returns the older bytes; `headObject` on a missing key throws an error with `name === "NoSuchKey"`.
 
 #### Automated QA:
-- [ ] Op-level end-to-end test with `ctx.s3 = new LocalStorageAdapter({ root: tmp })` + a test DB: `write → edit → append → log → diff(v1,v2) → revert(v1)` all succeed and **`revert`/`diff` return real content** (full tier proven on local).
-- [ ] `signed-url` op against the local adapter (with `ctx.appUrl` set) returns the `buildAppUrl` fallback URL, asserts it does **not** throw, and the result is marked as an app/non-presigned link; with `ctx.appUrl` unset it throws `UnsupportedOperation`.
+- [x] Op-level end-to-end test with `ctx.s3 = new LocalStorageAdapter({ root: tmp })` + a test DB: `write → edit → append → log → diff(v1,v2) → revert(v1)` all succeed and **`revert`/`diff` return real content** (full tier proven on local).
+- [x] `signed-url` op against the local adapter (with `ctx.appUrl` set) returns the `buildAppUrl` fallback URL, asserts it does **not** throw, and the result is marked as an app/non-presigned link; with `ctx.appUrl` unset it throws `UnsupportedOperation`.
 
 #### Manual Verification:
 - [ ] Confirm the signed-url fallback semantics are acceptable: given `/raw` + the viewer require auth, an authenticated app link (not a public URL) is the right "share" behavior for a local backend — sign off or adjust the labeling/UX.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-3.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-3.md
@@ -1,0 +1,64 @@
+---
+id: step-3
+name: files-sdk local-FS adapter + app-level versioning
+depends_on: [step-1]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-3: files-sdk local-FS adapter + app-level versioning
+
+## Overview
+Implement `LocalStorageAdapter` — a `StorageAdapter` backed by the `files-sdk` filesystem adapter (`files-sdk/fs`) — that gives local storage the **full** versioning tier via **content-addressed app-level blobs**, so `revert` and historical `diff` work without object versioning. Capabilities are `{ versioning: true, presignedUrls: false }`; the `signed-url` op falls back to the daemon app URL. QA-able on its own by driving the adapter and the version-critical ops against a temp directory — no server wiring needed (that's step-4). **File-disjoint from step-2** (touches `signed-url.ts`, not `revert.ts`/`diff.ts`), so the two run in parallel after step-1.
+
+## Changes Required:
+
+#### 1. Add the dependency
+**File**: `packages/core/package.json` (+ lockfile)
+**Changes**: `cd packages/core && bun add files-sdk` (v2.0.0). The `files-sdk/fs` adapter needs only `node:fs` (no extra peer); the `@aws-sdk/*` peers for the s3 adapter are already present. Bun compatibility is confirmed (root uses `bun test`, `packageManager: bun@1.3.14`).
+
+#### 2. The local adapter
+**File**: `packages/core/src/storage/local-adapter.ts` (new)
+**Changes**: `export class LocalStorageAdapter implements StorageAdapter`.
+- Construct: `import { Files } from "files-sdk"; import { fs } from "files-sdk/fs";` → `this.files = new Files({ adapter: fs({ root: opts.root }) })`. Keys map to nested paths under `root` (verified); `mkdir(recursive)` is automatic on write.
+- `versioningEnabled = true`; `get capabilities() { return { versioning: true, presignedUrls: false }; }`.
+- **Content-addressed blob scheme** (confirmed decision): every version's bytes are stored at a reserved top-level key `_afs-blobs/sha256/<hash>` (optionally fanned out `_afs-blobs/sha256/<hash[0:2]>/<hash>`). This prefix is **outside** any `<orgId>/drives/<driveId>/…` listing prefix, so it never surfaces in `ls`/`glob`. The opaque version handle = the sha-256 hash (stored in `file_versions.s3_version_id` by the ops). Reuses the same hash the write path already computes (`write.ts:75-77`), so the handle is free and identical content dedups.
+- `putObject(key, body, _metadata, contentType)`: compute `hash = sha256(bytes)`. **Write the blob first** (`exists(_afs-blobs/sha256/<hash>)` → skip if present, else `upload`), **then** write the plain current key via `files.upload(key, bytes, { contentType })`. Blob-first guarantees history durability even if the plain-key write fails. Return `{ etag: hash, versionId: hash }`.
+- `getObject(key, versionId?, _opts?)`: if `versionId` → `download("_afs-blobs/sha256/" + versionId)`; else `download(key)`. Materialize `await stored.arrayBuffer()` → `Uint8Array`; map to `{ body, contentType: stored.type, size: stored.size, versionId, etag: stored.etag }`. **Translate `FilesError` with `code === "NotFound"`** into the S3-compatible not-found shape the ops branch on (`const e = new Error(...); e.name = "NoSuchKey"; throw e;`).
+- `deleteObject(key)`: delete the plain key only (`files.delete(key)`); **leave blobs intact** (they are the version history). Swallow `NotFound`. (Matches S3 delete-marker semantics: prior versions stay retrievable by handle — research §2 item 6.)
+- `copyObject(from, to)`: read `from`'s bytes → `putObject(to, bytes, …)` (ensures the blob exists + writes the plain `to` key). Return `{ etag: hash, versionId: hash }`.
+- `listObjects(prefix, opts?)`: `files.list({ prefix, delimiter: opts?.delimiter })` → map page `items` → `S3Object[]` (`{ key, size, lastModified, etag }`) and `prefixes` → `string[]`. Drain the paginated/async-iterable result (handle `cursor`). Verified: fs synthesizes `/`-delimited common prefixes, so `ls` works with no `.raw`.
+- `headObject(key)`: `files.head(key)` → `{ contentType: stored.type, size, lastModified, etag }`; translate `NotFound`.
+- `listObjectVersions(key)`: unused by ops — return `[]`.
+- `checkVersioningEnabled()`: `true`. `enableVersioning()`: `true` (no-op; app-level versioning is always on).
+- `getPresignedUrl()`: `throw new UnsupportedOperation("signed-url", "local")` — defensive; the op-level capability check (below) should fall back *before* calling this.
+
+#### 3. `signed-url` op: capability-gated fallback to the app URL
+**File**: `packages/core/src/ops/signed-url.ts`
+**Changes**: Before calling `ctx.s3.getPresignedUrl` (`:40`), branch on capability: if `!ctx.s3.capabilities.presignedUrls`, return a fallback URL built with `buildAppUrl(ctx.appUrl, ctx.orgId, ctx.driveId, normalizedPath)` (`ops/urls.ts:1-9`) instead of presigning.
+- **Verified caveat (must be surfaced):** the daemon `GET …/raw` route and the `/file/~/…` app viewer are **auth-gated** (`routes/files.ts:25` reads `c.get("user")`). So this fallback URL is an *authenticated in-app link*, **not** an unauthenticated public/presigned URL. Reflect this in the result: the app URL does not expire, so set `expiresIn: 0` / omit `expiresAt` (or document it as nominal), and add a field/marker (e.g. `kind: "app" | "presigned"`) so the CLI/UI can label it "app link (requires sign-in)". 
+- If `ctx.appUrl` is unset (can't build a URL), throw `UnsupportedOperation("signed-url", "local")`.
+- Keep the existing head-check + `NotFoundError` mapping (`:28-37`) unchanged.
+
+#### 4. Cross-store atomicity (call-out, minimal code)
+**File**: `packages/core/src/ops/write.ts` (no change) + adapter doc comment
+**Changes**: Document in `local-adapter.ts` that the write path stays object-then-commit (`putObject` then `createVersion`) — unchanged. Inside `putObject`, blob-first-then-plain-key ordering keeps history durable. On a `createVersion` failure the orphan is a content-addressed blob that is **dedup-shared and safe to leave** (do NOT delete on failure — the hash may back another version), so no new cleanup is needed; the local partial-failure window matches today's S3 path. Real reconciliation/retry is deferred to the remote/consumer adapter (follow-up plan).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `files-sdk` recorded in `packages/core/package.json`; `bun install` clean.
+- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
+- [ ] Adapter integration test (`packages/core/src/storage/__tests__/local-adapter.test.ts`, temp dir via `mkdtemp`): put/get/head/delete/copy round-trip; `listObjects(prefix, { delimiter: "/" })` returns files in `objects` + subdirs in `prefixes` and **never** surfaces `_afs-blobs`; `getObject(key)` after two writes returns latest, `getObject(key, oldHash)` returns the older bytes; `headObject` on a missing key throws an error with `name === "NoSuchKey"`.
+
+#### Automated QA:
+- [ ] Op-level end-to-end test with `ctx.s3 = new LocalStorageAdapter({ root: tmp })` + a test DB: `write → edit → append → log → diff(v1,v2) → revert(v1)` all succeed and **`revert`/`diff` return real content** (full tier proven on local).
+- [ ] `signed-url` op against the local adapter (with `ctx.appUrl` set) returns the `buildAppUrl` fallback URL, asserts it does **not** throw, and the result is marked as an app/non-presigned link; with `ctx.appUrl` unset it throws `UnsupportedOperation`.
+
+#### Manual Verification:
+- [ ] Confirm the signed-url fallback semantics are acceptable: given `/raw` + the viewer require auth, an authenticated app link (not a public URL) is the right "share" behavior for a local backend — sign off or adjust the labeling/UX.
+- [ ] Inspect a temp `root` after a few writes+revert: plain current files mirror the key paths, history lives under `_afs-blobs/sha256/…`, identical content deduped to one blob.
+
+**Implementation Note**: Vertical slice — a real local-FS backend with working revert/diff and a sensible signed-url fallback, proven against a temp directory without any server wiring (that's step-4). After completing this step, pause for manual confirmation. Commit-per-step is enabled: commit as `[step-3] files-sdk local-FS adapter with content-addressed versioning` after verification passes.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
@@ -34,7 +34,7 @@ Make the local-FS backend reachable end-to-end by users. Evolve `AgentFSConfig.s
 **Changes**: Replace `const s3 = new AgentS3Client(config.s3)` (`:13`) with `const s3 = createStorageAdapter(config.s3)`. Update the import.
 
 #### 4. Retype the server-wide storage seam
-**Files**: `packages/server/src/app.ts`, `packages/server/src/routes/files.ts` (`:8`, `:14`), `packages/server/src/ipc/handlers.ts`, `packages/server/src/ipc/server.ts`, `packages/mcp/src/server.ts` (context type)
+**Files**: `packages/server/src/app.ts`, `packages/server/src/routes/files.ts` (`:8`, `:14`), `packages/server/src/routes/ops.ts`, `packages/server/src/ipc/handlers.ts`, `packages/mcp/src/server.ts` (context type). _(Post-impl correction: the seam retype landed in `ipc/handlers.ts`, not `ipc/server.ts` — `ipc/server.ts` only references the `IpcContext` type and needed no change; `routes/ops.ts` was also retyped.)_
 **Changes**: Change `s3: AgentS3Client` parameter/field annotations to `s3: StorageAdapter` (import from `@/core`). Mostly type-only — `AgentS3Client` already satisfies it (step-1). This is the step where a non-S3 adapter actually flows through these call sites.
 
 #### 5. `config validate` handles local

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
@@ -2,7 +2,7 @@
 id: step-4
 name: Config tagged-union + adapter selection + onboarding
 depends_on: [step-1, step-3]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -48,14 +48,14 @@ Make the local-FS backend reachable end-to-end by users. Evolve `AgentFSConfig.s
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
-- [ ] Config unit tests (`packages/core/src/__tests__/config.test.ts`): a `{ provider: "local", root }` config round-trips through `getConfig`/`deepMergeConfig` **without** stale S3 fields; `applyEnvOverrides` skips `S3_*` for local and honors `AGENT_FS_LOCAL_ROOT`; an S3 config still merges/overrides exactly as before (regression).
-- [ ] `createStorageAdapter` unit test: `provider: "local"` → `LocalStorageAdapter`; `provider: "minio"` → `AgentS3Client`.
-- [ ] `bun run packages/cli/src/index.ts -- onboard --help` shows the new `--filesystem` flag; `… config --help` still works.
+- [x] Typecheck + tests: `bun run typecheck` && `bun test`
+- [x] Config unit tests (actual path `packages/core/src/config.test.ts`): a `{ provider: "local", root }` config round-trips through `getConfig`/`deepMergeConfig` **without** stale S3 fields; `applyEnvOverrides` skips `S3_*` for local and honors `AGENT_FS_LOCAL_ROOT`; an S3 config still merges/overrides exactly as before (regression).
+- [x] `createStorageAdapter` unit test: `provider: "local"` → `LocalStorageAdapter`; `provider: "minio"` → `AgentS3Client`.
+- [x] `bun run packages/cli/src/index.ts -- onboard --help` shows the new `--filesystem` flag; `… config --help` still works.
 
 #### Automated QA:
-- [ ] Daemon round-trip on local: start the daemon with a temp-root local config (env or written config.json), then via the CLI run `write → cat → ls → log → diff → revert` against it — all succeed, revert/diff return real content (full local tier through the real server, not just unit tests).
-- [ ] `agent-fs config validate` passes for a writable local `root` and fails with a clear message for an unwritable/bad `root`.
+- [x] Daemon round-trip on local: start the daemon with a temp-root local config (env or written config.json), then via the CLI run `write → cat → ls → log → diff → revert` against it — all succeed, revert/diff return real content (full local tier through the real server, not just unit tests).
+- [x] `agent-fs config validate` passes for a writable local `root` and fails with a clear message for an unwritable/bad `root`.
 
 #### Manual Verification:
 - [ ] Run `onboard --filesystem` from a clean `AGENT_FS_HOME`; confirm the flow wording, flag naming, and that the resulting daemon serves a local drive with no Docker involved.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-4.md
@@ -1,0 +1,63 @@
+---
+id: step-4
+name: Config tagged-union + adapter selection + onboarding
+depends_on: [step-1, step-3]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-4: Config tagged-union + adapter selection + onboarding
+
+## Overview
+Make the local-FS backend reachable end-to-end by users. Evolve `AgentFSConfig.s3` into a discriminated union keyed by `provider`, add a `createStorageAdapter` factory that selects `LocalStorageAdapter` vs `AgentS3Client` at the single construction site, retype the server-side `s3: AgentS3Client` annotations to `StorageAdapter`, and add an onboarding path for a local-FS drive. End state: a fresh `onboard` for a filesystem backend produces a daemon that serves a working local drive with full versioning.
+
+## Changes Required:
+
+#### 1. Config as a tagged union
+**File**: `packages/core/src/config.ts`
+**Changes**:
+- Change `AgentFSConfig.s3` (`:14-23`) into a discriminated union on `provider`:
+  - S3 variant (existing fields): `{ provider: "minio" | "s3" | "r2" | "tigris" | string; bucket; region; endpoint; publicEndpoint?; accessKeyId; secretAccessKey; versioningEnabled? }`.
+  - Local variant: `{ provider: "local"; root: string }`.
+- **Keep the field name `s3`** (the union lives under `config.s3`, discriminated by `config.s3.provider`) to minimize churn across all `config.s3` consumers; add a comment noting the legacy name. (Alternative — rename to `config.storage` — is a larger refactor; recorded as a derail in `root.md`, not done here.)
+- **Fix `deepMergeConfig` (`:109-126`)** so a `provider: "local"` override does **not** get the S3-shaped `DEFAULT_CONFIG.s3` fields merged under it (the 2-level merge would otherwise leave stale `bucket`/`endpoint`/etc.). When `overrides.s3?.provider` differs from the default provider, **replace** `s3` instead of shallow-merging.
+- **Guard `applyEnvOverrides` (`:132-147`)**: wrap the `S3_*`/`AWS_*` block in `if (config.s3.provider !== "local")`. Add `AGENT_FS_STORAGE_PROVIDER` and `AGENT_FS_LOCAL_ROOT` env overrides for the local variant. (The test-only `AGENT_FS_CAPABILITY_OVERRIDE` from step-2 is handled at adapter construction, not here.)
+
+#### 2. Adapter selection factory
+**File**: `packages/core/src/storage/factory.ts` (new)
+**Changes**: `export function createStorageAdapter(cfg: AgentFSConfig["s3"]): StorageAdapter` — switch on `cfg.provider`: `"local"` → `new LocalStorageAdapter({ root: cfg.root })`; default → `new AgentS3Client(cfg)`. Apply the step-2 `AGENT_FS_CAPABILITY_OVERRIDE` overlay here (fold in the temporary `server/index.ts` placement from step-2). Export from `@/core`.
+
+#### 3. Use the factory at the single construction site
+**File**: `packages/server/src/index.ts`
+**Changes**: Replace `const s3 = new AgentS3Client(config.s3)` (`:13`) with `const s3 = createStorageAdapter(config.s3)`. Update the import.
+
+#### 4. Retype the server-wide storage seam
+**Files**: `packages/server/src/app.ts`, `packages/server/src/routes/files.ts` (`:8`, `:14`), `packages/server/src/ipc/handlers.ts`, `packages/server/src/ipc/server.ts`, `packages/mcp/src/server.ts` (context type)
+**Changes**: Change `s3: AgentS3Client` parameter/field annotations to `s3: StorageAdapter` (import from `@/core`). Mostly type-only — `AgentS3Client` already satisfies it (step-1). This is the step where a non-S3 adapter actually flows through these call sites.
+
+#### 5. `config validate` handles local
+**File**: `packages/cli/src/commands/config-cmd.ts` (`:85-87`)
+**Changes**: The connectivity check currently does `new AgentS3Client(config.s3)`. Route it through `createStorageAdapter`; for the local provider, "validate" = ensure `root` exists or is creatable and writable (a probe write/delete under `root`), reporting a clear pass/fail.
+
+#### 6. Onboarding for a filesystem backend
+**File**: `packages/cli/src/commands/onboard.ts`
+**Changes**: Add a filesystem onboarding path. **Naming care:** the existing `onboard --local` already means "local **MinIO** container" (`:207-228`) — do **not** overload it. Add a distinct flag, recommended **`--filesystem`** (alias `--storage local`), that writes `config.s3 = { provider: "local", root: <default ~/.agent-fs/storage or a chosen dir> }`, skips MinIO/Docker setup, and prints next steps. Ensure the chosen `root` is created. Update `--help` text.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Typecheck + tests: `bun run typecheck` && `bun test`
+- [ ] Config unit tests (`packages/core/src/__tests__/config.test.ts`): a `{ provider: "local", root }` config round-trips through `getConfig`/`deepMergeConfig` **without** stale S3 fields; `applyEnvOverrides` skips `S3_*` for local and honors `AGENT_FS_LOCAL_ROOT`; an S3 config still merges/overrides exactly as before (regression).
+- [ ] `createStorageAdapter` unit test: `provider: "local"` → `LocalStorageAdapter`; `provider: "minio"` → `AgentS3Client`.
+- [ ] `bun run packages/cli/src/index.ts -- onboard --help` shows the new `--filesystem` flag; `… config --help` still works.
+
+#### Automated QA:
+- [ ] Daemon round-trip on local: start the daemon with a temp-root local config (env or written config.json), then via the CLI run `write → cat → ls → log → diff → revert` against it — all succeed, revert/diff return real content (full local tier through the real server, not just unit tests).
+- [ ] `agent-fs config validate` passes for a writable local `root` and fails with a clear message for an unwritable/bad `root`.
+
+#### Manual Verification:
+- [ ] Run `onboard --filesystem` from a clean `AGENT_FS_HOME`; confirm the flow wording, flag naming, and that the resulting daemon serves a local drive with no Docker involved.
+
+**Implementation Note**: Vertical slice — users can now configure/onboard and run a local-FS backend end-to-end through the real daemon. SKILL.md + version bumps are intentionally deferred to step-5 (the terminal node) to avoid parallel merge conflicts on `package.json`/`plugin.json`. After completing this step, pause for manual confirmation. Commit-per-step is enabled: commit as `[step-4] Tagged-union storage config + adapter selection + filesystem onboarding` after verification passes.

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-5.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-5.md
@@ -2,7 +2,7 @@
 id: step-5
 name: Cross-backend E2E + release checklist
 depends_on: [step-1, step-2, step-3, step-4]
-status: ready
+status: done
 ---
 
 <!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
@@ -44,13 +44,13 @@ The terminal integration node. Extend `scripts/e2e.ts` to run the backend-agnost
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Whole-repo typecheck: `bun run typecheck`
-- [ ] Full test suite: `bun test`
-- [ ] E2E passes for **both** backends: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (Docker available for the MinIO leg) — output shows a `minio` section and a `local` section, both green, including revert/diff and the unsupported-op assertion.
-- [ ] Version lockstep: `git grep -n '"version"' package.json .claude-plugin/plugin.json packages/*/package.json` all match the new version after `sync-versions.ts`.
+- [x] Whole-repo typecheck: `bun run typecheck`
+- [x] Full test suite: `bun test`
+- [x] E2E passes for **both** backends: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (Docker available for the MinIO leg) — output shows a `minio` section and a `local` section, both green, including revert/diff and the unsupported-op assertion.
+- [x] Version lockstep: `git grep -n '"version"' package.json .claude-plugin/plugin.json packages/*/package.json` all match the new version after `sync-versions.ts`.
 
 #### Automated QA:
-- [ ] E2E run log demonstrates: identical core-ops results on MinIO and local; `revert`/`diff` real-content on both; `UNSUPPORTED_OPERATION` clean error on the capability-overridden local daemon; `signed-url` returns presigned (MinIO) vs app-URL fallback (local).
+- [x] E2E run log demonstrates: identical core-ops results on MinIO and local; `revert`/`diff` real-content on both; `UNSUPPORTED_OPERATION` clean error on the capability-overridden local daemon; `signed-url` returns presigned (MinIO) vs app-URL fallback (local).
 
 #### Manual Verification:
 - [ ] Read the `skills/agent-fs/SKILL.md` diff for accuracy (capability tiers + onboarding flag + signed-url semantics described correctly).

--- a/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-5.md
+++ b/thoughts/taras/plans/2026-06-25-multi-adapter-storage/step-5.md
@@ -1,0 +1,62 @@
+---
+id: step-5
+name: Cross-backend E2E + release checklist
+depends_on: [step-1, step-2, step-3, step-4]
+status: ready
+---
+
+<!-- During /v-implement, `desplega:step-running` adds `assignee` and `claimed_at` while
+working, then transitions `status` to `done` (success) or back to `ready` (retry-able failure). -->
+
+# step-5: Cross-backend E2E + release checklist
+
+## Overview
+The terminal integration node. Extend `scripts/e2e.ts` to run the backend-agnostic op suite against **both** MinIO (S3) and a local-FS drive — including `revert`/historical `diff` under each tier and a clean **unsupported-op** assertion — and complete the project release checklist (SKILL.md, `.claude-plugin/plugin.json` + root `package.json` version bumps). This is the only step that touches `package.json`/`plugin.json`/`SKILL.md`, so the parallel steps never collide on them.
+
+## Changes Required:
+
+#### 1. Parameterize the E2E harness for two backends
+**File**: `scripts/e2e.ts`
+**Changes**:
+- Factor the **backend-agnostic** op tests (`write`/`cat`/`ls`/`stat`/`edit`/`append`/`rm`/`mv`/`cp`/`log`/`diff`/`revert`/`glob`/`recent`) out of the current inline flow into a reusable block, e.g. `async function coreOpsSuite(label: string)`, that uses the existing `run`/`runJson`/`assert`/`test` helpers.
+- Add a **local-FS backend** path alongside the MinIO one: a second `AGENT_FS_HOME` + daemon started with env `AGENT_FS_STORAGE_PROVIDER=local` (and `AGENT_FS_LOCAL_ROOT=<temp>`), **no MinIO container**. The current `testEnv()` (`:79-95`) hardcodes `S3_PROVIDER: "minio"` + MinIO endpoint — generalize it (or add `localEnv()`) so the daemon/CLI target the chosen backend. Reuse `findFreePort` + the daemon start/stop logic from `setup()` (`:253`).
+- Run `coreOpsSuite("minio")` and `coreOpsSuite("local")`. Keep FUSE/MinIO-specific tests under the MinIO backend only.
+- **Tier assertions**: on **both** backends, assert `revert` restores prior content as a new version and `diff(v1,v2)` returns real content changes (S3 via object versioning, local via content-addressed blobs). Assert `ls` shows directories and **never** lists `_afs-blobs`.
+
+#### 2. Unsupported-op + fallback assertions
+**File**: `scripts/e2e.ts`
+**Changes**:
+- **Unsupported path**: start a local daemon with the test-only `AGENT_FS_CAPABILITY_OVERRIDE='{"versioning":false}'` (from step-2) and assert `agent-fs revert …` exits non-zero with a clean message containing `UNSUPPORTED_OPERATION` (no stack trace) — proving the gating surfaces through the real CLI→daemon path.
+- **Fallback path**: on a normal local drive assert `agent-fs signed-url <path>` succeeds and returns the app-URL fallback (labeled as an app/non-presigned link), **not** an error. On MinIO assert `signed-url` still returns a real presigned URL (regression).
+
+#### 3. Release checklist — SKILL.md
+**File**: `skills/agent-fs/SKILL.md`
+**Changes**: Document (a) the new **local-filesystem backend** and its onboarding flag (`onboard --filesystem`); (b) the **per-backend capability tiers** (S3/MinIO + local = full versioning; future backends = basic), so agents know `revert`/historical `diff` availability depends on the backend; (c) the **`signed-url` fallback** on local (returns an authenticated app link, requires sign-in, not a public presigned URL). Update command/description triggers and any workflow examples if they assume S3-only.
+
+#### 4. Release checklist — version bumps (lockstep)
+**Files**: root `package.json`, `.claude-plugin/plugin.json`, and everything `scripts/sync-versions.ts` rewrites
+**Changes**: Bump the root `package.json` `version` (**minor** — new backend/feature, non-breaking) and run `bun run scripts/sync-versions.ts <version>` so every sub-package `package.json`, the FUSE `Cargo.toml`, and `.claude-plugin/plugin.json` move together. (Per project `CLAUDE.md` release checklist + the FUSE sub-package note.)
+
+#### 5. E2E coverage note (project CLAUDE.md requirement)
+**File**: `scripts/e2e.ts` (covered by #1–#2)
+**Changes**: Confirms the "new op/backend ⇒ extend `scripts/e2e.ts`" rule — the local backend + revert/diff + unsupported-op assertions satisfy it.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Whole-repo typecheck: `bun run typecheck`
+- [ ] Full test suite: `bun test`
+- [ ] E2E passes for **both** backends: `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (Docker available for the MinIO leg) — output shows a `minio` section and a `local` section, both green, including revert/diff and the unsupported-op assertion.
+- [ ] Version lockstep: `git grep -n '"version"' package.json .claude-plugin/plugin.json packages/*/package.json` all match the new version after `sync-versions.ts`.
+
+#### Automated QA:
+- [ ] E2E run log demonstrates: identical core-ops results on MinIO and local; `revert`/`diff` real-content on both; `UNSUPPORTED_OPERATION` clean error on the capability-overridden local daemon; `signed-url` returns presigned (MinIO) vs app-URL fallback (local).
+
+#### Manual Verification:
+- [ ] Read the `skills/agent-fs/SKILL.md` diff for accuracy (capability tiers + onboarding flag + signed-url semantics described correctly).
+- [ ] Confirm the version bump + `sync-versions.ts` followed the release checklist (no orphaned/mismatched versions), and the S3/MinIO behavior is unchanged versus `main` (existing MinIO E2E still green).
+
+**Implementation Note**: Vertical slice + integration gate — the whole DAG is proven on two backends and the repo is release-ready. After completing this step, pause for manual confirmation. Commit-per-step is enabled: commit as `[step-5] Cross-backend E2E (S3 + local) + release checklist` after verification passes.
+
+### QA Spec (optional):
+Not required — the dual-backend matrix is fully covered by the parameterized `scripts/e2e.ts` above; no separate `desplega:qa` evidence doc is warranted.

--- a/thoughts/taras/qa/2026-06-26-multi-adapter-storage.md
+++ b/thoughts/taras/qa/2026-06-26-multi-adapter-storage.md
@@ -1,0 +1,192 @@
+---
+date: 2026-06-26T16:25:00-00:00
+author: Claude (for Taras)
+topic: "Multi-adapter storage (files-sdk local-FS + S3) — PR refactor/files-sdk"
+tags: [qa, storage-adapter, files-sdk, local-fs, e2e, minio, autopilot]
+status: pass
+source_plan: thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md
+related_pr: refactor/files-sdk (vs main)
+environment: local
+last_updated: 2026-06-26
+last_updated_by: Claude (for Taras)
+---
+
+# Multi-Adapter Storage — QA Report
+
+## Context
+
+QA of the `refactor/files-sdk` branch (PR vs `main`), which introduces a thin internal
+`StorageAdapter` interface so agent-fs storage supports multiple backends:
+
+- `AgentS3Client implements StorageAdapter` (S3/MinIO behavior unchanged)
+- A new `files-sdk`-backed **local-filesystem** adapter with app-level (content-addressed
+  blob) versioning, so `revert` / historical `diff` work on local without object versioning
+- Typed `UnsupportedOperation` error + per-adapter `capabilities` gating, surfaced cleanly
+  core → CLI → MCP
+- Tagged-union `AgentFSConfig.s3` (keyed by `provider`) + startup adapter selection +
+  local-FS onboarding
+- Cross-backend E2E (S3 **and** local) + release checklist (v0.10.0)
+
+Executed in **Autopilot** mode (full auto), per `/desplega:qa`. Backend: **local MinIO via
+Docker** (Docker 29.2.0, UP). Runtime: **Bun 1.3.11** on Darwin.
+
+This QA reproduces the plan's claimed verification numbers against a real backend rather than
+trusting the recorded checkmarks.
+
+## Scope
+
+### In Scope
+- Whole-repo typecheck
+- Full unit/integration test suite (`bun test`)
+- Cross-backend CLI + MCP E2E against a real MinIO container and a real local-FS drive
+  (`scripts/e2e.ts`), incl. revert/diff on each backend, capability-gating of an unsupported
+  op, and the signed-url presigned-vs-app-fallback matrix
+- Release-version consistency (lockstep bump across all manifests)
+
+### Out of Scope
+- FUSE mount tests — skipped on Darwin (require `AGENT_FS_USE_DOCKER_FUSE=1`; 10 cases). Not a
+  regression of this PR; FUSE is exercised separately via the Docker harness.
+- Live S3 (AWS) / consumer providers (Dropbox/GDrive) — explicitly deferred to a follow-up plan.
+- Local blob GC / cross-store atomicity — consciously deferred (see Issues Found, non-blocking).
+
+## Test Cases
+
+### TC-1: Whole-repo typecheck
+**Steps:** `bun run typecheck` (`tsc --build`)
+**Expected:** Exit 0, no type errors (interface retype lands across core → server → CLI → MCP).
+**Actual:** Exit 0, clean.
+**Status:** pass
+
+### TC-2: Full unit/integration suite
+**Steps:** `bun test` (manual/integration tests auto-skip without env)
+**Expected:** Matches plan's recorded 898 pass / 114 skip / 0 fail.
+**Actual:** **898 pass / 114 skip / 0 fail**, 2956 expect() calls, 1012 tests across 103 files (13.37s). Exact match.
+**Status:** pass
+
+### TC-3: Cross-backend E2E against MinIO + local-FS
+**Steps:** `bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --"` (spins up an isolated
+`agent-fs-minio` container + a daemon on a random port; runs CLI + MCP end-to-end).
+**Expected:** Matches plan's recorded 127/127 (10 FUSE skipped on Darwin), exit 0.
+**Actual:** **127/127 passed (10 skipped), exit 0.** 0 failures. Section breakdown:
+- `core ops [minio]` — full S3/MinIO matrix
+- `core ops [local]` — full local-FS matrix (write/cat/append/edit/stat/cp/mv/glob/recent/log/diff/revert/rm)
+- `capability gating: unsupported op (local, versioning forced off)`
+- `signed-url backend matrix (presigned vs app fallback)`
+- `FUSE mount tests` — 10 skipped (Darwin)
+**Status:** pass
+
+### TC-4: Local-FS full-tier versioning (revert + diff)
+**Steps:** Within the `[local]` E2E section: write v1 → edit v2 → `log` → `diff v1 v2` → `revert`.
+**Expected:** `diff` returns real content changes (not a degraded stored summary); `revert`
+restores prior content as a **new** version — i.e. local gets the full S3-equivalent tier via
+content-addressed blobs.
+**Actual:** `[local] diff (v1 vs v2) returns real content changes` ✓; `[local] revert restores
+prior content as a new version` ✓.
+**Status:** pass
+
+### TC-5: `_afs-blobs` reserved prefix never leaks into listings
+**Steps:** `[local] ls shows dirs and never lists _afs-blobs`.
+**Expected:** The content-addressed blob store (`_afs-blobs/sha256/<hash>`) is invisible to `ls`.
+**Actual:** ✓ passed.
+**Status:** pass
+
+### TC-6: Capability gating — unsupported op surfaces cleanly (CLI + API)
+**Steps:** On a local drive with versioning capability forced off: seed a file, attempt `revert`
+via CLI and via API.
+**Expected:** Write still works (no versioning needed); `revert` exits non-zero with a clean
+message + suggestion (no stack trace); API returns HTTP 422 `UNSUPPORTED_OPERATION`.
+**Actual:**
+- `[capped] seed file (write works without versioning capability)` ✓
+- `[capped] revert exits non-zero with a clean message (no stack trace)` ✓ — emits
+  `Operation 'revert' is not supported by the current storage backend` + suggestion
+- `[capped] revert via API → HTTP 422 UNSUPPORTED_OPERATION` ✓
+**Status:** pass
+
+### TC-7: signed-url backend matrix
+**Steps:** Request a signed URL on MinIO and on local.
+**Expected:** MinIO returns a real presigned URL; local falls back to a daemon app `/raw` URL
+(reports `presignedUrls:false`) rather than hard-failing.
+**Actual:** `[minio] signed-url returns a real presigned URL` ✓; `[local] signed-url falls back
+to an app URL (not an error)` ✓.
+**Status:** pass
+
+### TC-8: S3/MinIO behavior unchanged (no regression)
+**Steps:** Full `core ops [minio]` E2E section + S3-backed unit tests.
+**Expected:** The S3 path stays green; `AgentS3Client` only gains an `implements` declaration.
+**Actual:** All `[minio]` cases pass; no S3 regressions in unit suite.
+**Status:** pass
+
+### TC-9: Release-version lockstep
+**Steps:** Compare versions across all manifests vs last published (`npm view`).
+**Expected:** All packages bumped together; no straggler at 0.9.0.
+**Actual:** Last published/tagged = **v0.9.0**. PR bumps to **0.10.0** in lockstep across:
+8× `package.json`, `packages/fuse-helper/Cargo.toml`, `.claude-plugin/plugin.json`,
+`docs/openapi.json`. `grep` for `0.9.0` stragglers → none.
+**Status:** pass
+
+## Edge Cases & Exploratory Testing
+- Every `Error:` line in the E2E log was verified to be an **intentional negative-path
+  assertion** (each immediately followed by ✓): `signed-url nonexistent file fails`, `sql via
+  API — syntax error is a 400`, `member remove last admin fails`, plus the capability-gating
+  revert errors. No unexpected errors.
+- MinIO container (`agent-fs-minio`) is torn down by the harness — no leftover containers/volumes
+  after the run (verified via `docker ps -a`).
+
+## Evidence
+
+### Logs & Output
+Typecheck:
+```
+$ tsc --build
+TYPECHECK_EXIT=0
+```
+
+Unit suite:
+```
+ 898 pass
+ 114 skip
+ 0 fail
+ 2956 expect() calls
+Ran 1012 tests across 103 files. [13.37s]
+```
+
+E2E (cross-backend, MinIO + local):
+```
+Results: 127/127 passed (10 skipped)
+E2E_EXIT=0
+PASS(✓): 127   SKIP(⊘): 10   FAIL(✗): 0
+Sections: [minio] core ops | [local] core ops | capability gating | signed-url matrix | FUSE (skipped, Darwin)
+```
+Full E2E log saved to scratchpad: `e2e-162027.log`.
+
+### External Links
+- Plan: `thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md`
+- Research: `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md`
+
+## Issues Found
+- [ ] **Local blob GC / cross-store atomicity** — severity: minor (consciously deferred). The
+  object-then-commit write path (`putObject` then `createVersion`) leaves a narrow partial-failure
+  window, and local content-addressed blobs under `_afs-blobs/sha256/` are never garbage-collected,
+  so local version history grows unbounded. Harmless today (orphans are dedup-shared); track a
+  GC/retention story before local sees heavy churn. Already noted in the plan's Review Errata.
+- [ ] **`--local` vs `--filesystem` naming** — severity: minor (UX). `--local` means *local MinIO
+  Docker* while `--filesystem` / `--storage local` mean *local filesystem*; a user could reasonably
+  expect `--local` to mean the filesystem. Consider an alias/rename in a future onboarding pass.
+  Already noted in the plan's Review Errata.
+
+No critical or major issues.
+
+## Verdict
+**Status**: PASS
+**Summary**: Multi-adapter storage passes QA across the board — typecheck clean, 898/0 unit
+pass/fail, and 127/127 cross-backend E2E (MinIO + local-FS) against a real MinIO container,
+including local revert/diff, clean capability-gating of unsupported ops (CLI exit + HTTP 422),
+and the signed-url presigned-vs-app-fallback matrix. S3/MinIO behavior is unchanged. Versions are
+already bumped to 0.10.0 in lockstep (last published 0.9.0); no further bump is warranted. Only two
+non-blocking minor items remain, both already tracked in the plan's Review Errata.
+
+## Appendix
+- **Plan**: `thoughts/taras/plans/2026-06-25-multi-adapter-storage/root.md`
+- **Research**: `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md`
+- **Notes**: FUSE mount tests skipped on Darwin (set `AGENT_FS_USE_DOCKER_FUSE=1` to run via
+  Docker). Run on `refactor/files-sdk` @ working tree clean.

--- a/thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md
+++ b/thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md
@@ -1,0 +1,265 @@
+---
+date: 2026-06-25T11:20:00-00:00
+researcher: Claude (for Taras)
+git_commit: 028667b60761aed5586b0bdca0407f69ae944ab2
+branch: main
+repository: desplega-ai/agent-fs
+topic: "Migrating agent-fs storage to files-sdk.dev with multi-adapter support"
+tags: [research, codebase, storage, s3, files-sdk, adapters, versioning]
+status: complete
+autonomy: critical
+last_updated: 2026-06-25
+last_updated_by: Claude (for Taras)
+---
+
+# Research: Migrating agent-fs storage to files-sdk.dev with multi-adapter support
+
+**Date**: 2026-06-25
+**Researcher**: Claude (for Taras)
+**Git Commit**: 028667b60761aed5586b0bdca0407f69ae944ab2
+**Branch**: main
+
+## Research Question
+
+How could we change the current implementation of agent-fs storage to use [files-sdk.dev](https://files-sdk.dev/) for the connection, bringing the option to support multiple storage adapters?
+
+## Summary
+
+agent-fs already has the structural prerequisite for multi-adapter storage: **every byte of object I/O flows through a single wrapper class, `AgentS3Client`** (`packages/core/src/s3/client.ts`), exposed to the rest of the system only as `ctx.s3` on `OpContext` (`packages/core/src/ops/types.ts:5-13`). There are **zero direct `@aws-sdk/client-s3` imports anywhere outside that one file** — the ~16 ops (`write`, `cat`, `ls`, `cp`, `mv`, `rm`, `append`, `edit`, `diff`, `revert`, `stat`, `glob`, `signed-url`, `reindex`, `tail`, `log`) all call `ctx.s3.<method>()`. A `MockS3Client` already implements the same shape for tests (`packages/core/src/test-utils.ts`). So introducing alternative backends is structurally a matter of (a) extracting a `StorageAdapter` interface from `AgentS3Client`'s 10-method surface, (b) writing one or more adapter implementations, and (c) choosing the concrete instance at the single construction site (`packages/server/src/index.ts:13`). No op code needs to change.
+
+The real question is **semantic, not structural**: the current backend leans on three S3-specific capabilities that `files-sdk`'s *unified* API deliberately does not model — (1) **per-object versioned reads** (`getObject(key, versionId)`), which `revert` and historical `diff` depend on and which `revert` hard-requires (`packages/core/src/ops/revert.ts:44-54`); (2) **prefix listing with a `/` delimiter** that returns directory "common prefixes," which `ls` consumes (`packages/core/src/ops/ls.ts:15`, `client.ts:145-165`); and (3) a **separate presign endpoint** (`publicEndpoint`) so signed URLs point at a public host while internal ops hit an internal one (`client.ts:69-74`). `files-sdk` (v2.0.0, by Hayden Bleasel, npm `files-sdk`) is a clean, Bun-tested, web-streams unified storage SDK with first-class S3/MinIO support, presigned GET (`url({expiresIn})`), presigned PUT (`signedUploadUrl`), byte-range reads, and multipart — but it pushes versioning, conditional/ETag writes, and arbitrary object metadata to its `files.raw` escape hatch (the native `S3Client`). 
+
+This means a `files-sdk`-based S3 adapter would use the unified API for the bulk of ops (put/get/head/copy/delete/upload-url) and drop to `files.raw` for the version-id-aware read in `revert`/`diff`, the delimiter listing in `ls`, and the bucket-versioning enable/check. Because so much of agent-fs's "filesystem" semantics (version numbering, dedup, concurrency, metadata, search) already lives in **SQLite, not S3** (`packages/core/src/db/raw.ts`, `packages/core/src/ops/versioning.ts`), the object store is genuinely "just a keyed blob store," which is exactly `files-sdk`'s sweet spot. The decision point worth surfacing before any plan: whether the abstraction earns its keep given the version-critical paths still need `.raw` — versus extracting agent-fs's *own* `StorageAdapter` interface and writing thin adapters directly (S3 via `@aws-sdk` or `Bun.s3`, plus e.g. GCS/local), with `files-sdk` as one possible adapter implementation rather than the interface itself.
+
+## Detailed Findings
+
+### 1. Current storage architecture — a single-boundary S3 wrapper
+
+> **Ease of abstraction:** Very easy. The expensive part of an abstraction refactor — finding and rerouting scattered direct-SDK call sites — is already done: `AgentS3Client` is the *only* file importing `@aws-sdk`, and every consumer goes through `ctx.s3`. A second working implementation of the surface already exists — `MockS3Client` (`packages/core/src/test-utils.ts:50`) — though it currently **duck-types** the surface and is wired into `OpContext` via an `as any` cast (`test-utils.ts:225`), as there is **no shared interface yet**. So extracting a real `StorageAdapter` interface is near-mechanical (and would also remove that cast, surfacing any latent Mock-vs-real drift the cast hides); the substantive work is the *semantic* gap (versioning on non-S3 backends), not the plumbing.
+
+All S3 access is funneled through one concrete class with no abstract interface and no leakage:
+
+- **The wrapper**: `export class AgentS3Client` — `packages/core/src/s3/client.ts:51`. It owns the only imports of `@aws-sdk/client-s3` (`client.ts:1-12`) and `@aws-sdk/s3-request-presigner` (`client.ts:13`).
+- **Construction**: builds **two** `S3Client` instances — `this.client` against `config.endpoint` (`client.ts:63-68`) and `this.presignClient` against `config.publicEndpoint ?? config.endpoint` (`client.ts:69-74`), both with `forcePathStyle: true` hardcoded (`client.ts:67`, `:73`).
+- **The seam**: `OpContext` carries `s3: AgentS3Client` (`packages/core/src/ops/types.ts:5-13`). Every op receives `ctx` and calls `ctx.s3.*`. No op imports the AWS SDK.
+- **Single construction site**: `const s3 = new AgentS3Client(config.s3)` — `packages/server/src/index.ts:13`. This `s3` is threaded into HTTP routes, IPC handlers (FUSE), and the MCP server via `createApp` (`packages/server/src/app.ts:18-77`).
+- **Already mocked**: `MockS3Client` (`packages/core/src/test-utils.ts:50`) is a second working implementation of the surface for unit tests — wired into `OpContext` via an `as any` cast (`test-utils.ts:225`), since there is no shared interface yet (the conformance is structural/duck-typed, not typechecked).
+- **Other touch points** (none import the SDK; all use the wrapper type): `packages/cli/src/commands/config-cmd.ts:85-87` (constructs `new AgentS3Client(config.s3)` purely for a `config validate` connectivity check), `packages/mcp/src/server.ts` (types `s3: AgentS3Client` in its context), `packages/server/src/ipc/handlers.ts:30-42`, `routes/ops.ts`, `routes/files.ts`.
+
+**The full method surface that any replacement adapter must satisfy** (`packages/core/src/s3/client.ts`):
+
+| Method | Lines | Returns | Underlying S3 |
+|--------|-------|---------|---------------|
+| `putObject(key, body, metadata?, contentType?)` | `:78-97` | `{ etag?, versionId? }` | `PutObjectCommand` |
+| `getObject(key, versionId?, { abortSignal? })` | `:99-120` | `{ body: Uint8Array, contentType?, size?, versionId?, etag? }` | `GetObjectCommand` |
+| `deleteObject(key)` | `:122-129` | `void` | `DeleteObjectCommand` |
+| `copyObject(fromKey, toKey)` | `:131-143` | `{ etag?, versionId? }` | `CopyObjectCommand` |
+| `listObjects(prefix, { delimiter? })` | `:145-165` | `{ objects: S3Object[], prefixes: string[] }` | `ListObjectsV2Command` |
+| `headObject(key)` | `:167-181` | `{ contentType?, size, lastModified?, etag?, versionId? }` | `HeadObjectCommand` |
+| `listObjectVersions(key)` | `:183-198` | `S3ObjectVersion[]` | `ListObjectVersionsCommand` |
+| `checkVersioningEnabled()` | `:200-209` | `boolean` | `GetBucketVersioningCommand` |
+| `enableVersioning()` | `:211-224` | `boolean` | `PutBucketVersioningCommand` |
+| `getPresignedUrl(key, expiresIn=86400, responseContentType?)` | `:226-238` | `string` | `GetObjectCommand` + `getSignedUrl` |
+
+Plus a public `versioningEnabled: boolean` field set from config at construction (`client.ts:55`, `:75`). There is **no multipart upload** anywhere — every put sends the whole body in one `PutObjectCommand` (`client.ts:78-97`).
+
+### 2. The storage backend contract (what an adapter actually has to provide)
+
+The object store is a **flat key/value blob store**. Keys are derived purely from path, not content:
+
+- **Key derivation**: `getS3Key(orgId, driveId, path)` → `` `${orgId}/drives/${driveId}/${normalized}` `` (`packages/core/src/ops/versioning.ts:11-14`). Called per-op. Multi-tenancy = key prefixing; there is **one bucket** for all orgs/drives.
+- **Content hashing is app-side, not key-level**: SHA-256 via `node:crypto` (`packages/core/src/ops/write.ts:75-77`), stored in `file_versions.content_hash`, used only for the dedup short-circuit (`write.ts:80-102`) — not for addressing.
+- **Buffered, whole-object I/O**: `getObject` materializes the whole object via `result.Body!.transformToByteArray()` (`client.ts:112`); reads return bytes, not a redirect. No range reads, no streaming, no multipart in current code.
+- **`edit`/`append` are read-modify-write of the entire object** (`packages/core/src/ops/edit.ts:13-99`, `append.ts:13-69`) — no partial/range writes.
+
+**S3-specific dependencies the code actually relies on** (the migration-critical list):
+
+1. **Per-object versioned reads** — `getObject(key, versionId)` passes `VersionId` (`client.ts:108`); used by `revert` (`packages/core/src/ops/revert.ts:54`) and historical `diff` (`packages/core/src/ops/diff.ts:49-52`). `revert` throws `VERSIONING_REQUIRED` if the target row's `s3VersionId` is empty (`revert.ts:44-50`). **This is the single hard S3-semantic dependency.**
+2. **`VersionId` returned from writes** — `putObject`/`copyObject` surface `result.VersionId` (`client.ts:95`, `:141`), persisted to `file_versions.s3_version_id`.
+3. **Prefix + `/` delimiter listing** — `ls` calls `listObjects(prefix, { delimiter: "/" })` and consumes `CommonPrefixes` as directories + `Contents` as files (`ls.ts:15`, `client.ts:145-165`); `glob` uses prefix listing too (`glob.ts:55`).
+4. **Presigned GET URLs** with `expiresIn` + optional `ResponseContentType` override (`client.ts:226-238`), minted against a **separate public endpoint** (`presignClient`, `client.ts:69-74`).
+5. **Bucket-versioning enable/check** (`GetBucketVersioning`/`PutBucketVersioning`, `client.ts:200-224`) — only called from tests, not the production daemon startup.
+6. **Delete markers** — `rm` relies on S3 delete-marker semantics when versioning is on (`rm.ts:23-24`); prior versions stay retrievable by `s3VersionId`.
+7. **S3 error-shape coupling** — ops branch on `err?.name === "NoSuchKey" | "NotFound"` and `err?.$metadata?.httpStatusCode === 404` to map to `NotFoundError` (`cat.ts:45`, `stat.ts:18`, `append.ts:30`, `edit.ts:31`, `signed-url.ts:31`, `routes/files.ts:77`). An adapter must reproduce or translate these.
+8. **`forcePathStyle: true`** on both clients (`client.ts:67`, `:73`) — required for MinIO/S3-compatible.
+9. **No conditional/ETag writes** — optimistic concurrency is enforced in **SQLite** via `assertExpectedVersion` (`versioning.ts:92-109`), not S3 `If-Match`. ETags are stored but never used as preconditions.
+
+**What is NOT S3's job** (all SQLite): version numbering (`getNextVersion`, `versioning.ts:19-35`), history listing (`log.ts:11-22`), head/version lookups, dedup, optimistic concurrency, FTS5 search, embeddings/vectors, comments.
+
+### 3. Versioning model — dual-layer (SQLite + optional S3 object versioning)
+
+This is the heart of why the backend choice matters:
+
+- **App-level (always on)**: every mutating op calls `createVersion` (`versioning.ts:152-258`), which assigns a monotonic per-`(path, driveId)` integer `version`, writes a `file_versions` row, and upserts the `files` current-state row — all inside one `ctx.db.transaction` (`versioning.ts:172`). Atomicity/concurrency comes from the SQLite unique index `(path, drive_id, version)` (`db/raw.ts:70-72`), mapped to `EditConflictError` on violation (`versioning.ts:236-255`).
+- **S3-level (optional)**: when bucket versioning is enabled, writes return distinct S3 version IDs captured into `file_versions.s3_version_id`. This is what makes **old-version content** retrievable:
+  - `revert` (`revert.ts:14-77`): `getObject(key, s3VersionId)` to fetch old bytes → re-PUT as a new head → new `"revert"` version. **Forward-moving, not an S3 rollback.** Hard-fails without `s3VersionId`.
+  - `diff` (`diff.ts:8-94`): fetches both versions' bytes by `s3VersionId` in parallel; **falls back to a stored `diffSummary` JSON** when version IDs are absent or fetch fails (`diff.ts:81-91`).
+- History (`log`) never touches S3 — it reads `file_versions` ordered by `version DESC` (`log.ts:11-22`).
+
+**Implication**: with a backend that lacks version-id reads, `log` and forward history still work; `revert` and historical `diff` of binary content break unless emulated. `diff` degrades gracefully (diffSummary); `revert` does not (hard error).
+
+### 4. Configuration & credentials flow
+
+- **Schema**: `AgentFSConfig.s3` (`packages/core/src/config.ts:13-23`) = `{ provider, bucket, region, endpoint, publicEndpoint?, accessKeyId, secretAccessKey, versioningEnabled? }`. `forcePathStyle` is **not** configurable — hardcoded in the client.
+- **Defaults (local MinIO)**: `DEFAULT_CONFIG.s3` = provider `minio`, bucket `agentfs`, region `us-east-1`, endpoint `http://localhost:9000`, empty creds (`config.ts:53-61`).
+- **Resolution**: `getConfig()` (`config.ts:173-185`) reads `~/.agent-fs/config.json` (or `AGENT_FS_HOME`), deep-merges over defaults, then applies env overrides.
+- **Env overrides** (`applyEnvOverrides`, `config.ts:132-147`), `AWS_*` taking precedence over `S3_*` (for Tigris): `AWS_ENDPOINT_URL_S3`/`S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`/`S3_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`/`S3_SECRET_ACCESS_KEY`, `BUCKET_NAME`/`S3_BUCKET`, `AWS_REGION`/`S3_REGION`, `S3_PROVIDER`, `S3_PUBLIC_ENDPOINT`.
+- **Storage is a global singleton** — there are **no per-org/per-drive storage columns** anywhere in the schema (the `orgs` and `drives` tables carry only id/name/flags; `db/schema.ts:18-25`, `:45-55`). The only S3-related column in the whole DB is `file_versions.s3_version_id`. A backend is therefore a process-wide singleton, not a per-tenant object.
+- **Local vs hosted is config-only, one code path**: local = `onboard --local` spins up MinIO (`docker run --name agent-fs-minio …`, `onboard.ts:207-228`) and writes minioadmin creds (`onboard.ts:245-250`); hosted = external S3 via env or mounted `config.json` (`docker-compose.hosted.yml`, with a commented R2 example). Both funnel through the identical `getConfig().s3` → `new AgentS3Client(config.s3)` path.
+- **CLI is a thin HTTP client** to the daemon/hosted API (`api-client.ts:7-17`); it does not do object I/O itself except the `config validate` connectivity check.
+
+### 5. Database schema (storage-relevant columns)
+
+Authoritative DDL is `CREATE_TABLES_SQL` in `packages/core/src/db/raw.ts:4-123` (run on every init via `db/index.ts:39`); the Drizzle TS mirror is `db/schema.ts`.
+
+- **`files`** (`raw.ts:41-53`): `path, drive_id, size, content_type, author, current_version_id, created_at, modified_at, is_deleted, embedding_status`; PK `(path, drive_id)`. No blob column — content lives in the object store. Files are **soft-deleted** (`is_deleted`).
+- **`file_versions`** (`raw.ts:55-72`): `id, path, drive_id, version, s3_version_id, author, operation('write'|'edit'|'append'|'delete'|'revert'), message, diff_summary, size, etag, content_hash, created_at`; unique index `(path, drive_id, version)`. **The object key is NOT stored** — recomputed deterministically from `orgId/driveId/path`.
+- Search/embeddings: `content_chunks` (`raw.ts:114-122`), FTS5 `files_fts` + sqlite-vec `chunk_vectors` (`raw.ts:125-136`).
+
+### 6. files-sdk.dev capability report (verified against the official site + README)
+
+**Identity** — npm package `files-sdk` (unscoped), **v2.0.0**, by **Hayden Bleasel** (`github.com/haydenbleasel/files-sdk`), site `files-sdk.dev`. Self-described: "A unified storage SDK for object and blob backends. One small, honest API. Web-standards I/O. An escape hatch when you need the native client." **Distinct** from `@flystorage/*` (Frank de Jonge), `flydrive` (Adonis), and files.com's commercial SDK (naming collision only).
+
+**Core abstraction** — a `Files` instance constructed with an injected adapter:
+```ts
+import { Files } from "files-sdk";
+import { s3 } from "files-sdk/s3";
+const files = new Files({ adapter: s3({ bucket: "uploads", region: "us-east-1" }) });
+```
+Adapters are **subpath exports of the same package** (`files-sdk/s3`, `files-sdk/r2`, `files-sdk/gcs`, `files-sdk/azure`, `files-sdk/vercel-blob`, `files-sdk/netlify-blobs`, `files-sdk/local`, …). Each provider's native SDK is an **optional peer dependency** (S3 needs `@aws-sdk/client-s3 @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner`). "30+ adapters" advertised; S3-compatible explicitly covers **R2, MinIO, DigitalOcean Spaces, Backblaze B2, Wasabi**.
+
+**Unified API** (the complete method list): `upload`, `download`, `head`, `exists`, `delete`, `copy`, `move`, `list`/`listAll`, `url`, `signedUploadUrl`, plus `file(key)` for a key-scoped handle. Notable behaviors:
+- **`upload(key, body, { contentType, multipart? })`** — body is `Blob | File | ReadableStream | Uint8Array | ArrayBuffer | string`. Multipart via `{ multipart: true }` or `{ multipart: { partSize, concurrency } }`.
+- **`download(key, { range?, as? })`** — web-standard `Blob`/`ReadableStream`; **byte-range reads** map to HTTP 206 (`{ range: { start, end }, as: "stream" }`).
+- **`head(key)`** → `{ size, contentType, lastModified, etag }`.
+- **`exists(key)`** → `false` only on provider `NotFound`; auth/transport failures still throw.
+- **`url(key, { expiresIn })`** → presigned/temporary GET URL.
+- **`signedUploadUrl(key, { maxSize? })`** → presigned PUT (or presigned POST with a `content-length-range` policy when `maxSize` is set).
+- **`list`/`listAll({ prefix })`** → lazy async iterable of `{ key, size, … }`.
+- **`files.raw`** → the native underlying client (the configured `S3Client`) for anything provider-specific.
+- **Lifecycle hooks** at the constructor: `onAction`, `onRetry`, `onError`.
+- **Error model**: provider errors classified into canonical `NotFound`, `Unauthorized`, `Conflict`, `Provider`.
+
+**Runtime** — TypeScript-native, ESM, tree-shakeable (`sideEffects: false`); the test suite runs under `bun test` (strong Bun signal). S3 path is pure JS via `@aws-sdk/*`, which runs under Bun. (CJS presence unconfirmed — irrelevant for agent-fs's ESM/Bun runtime.)
+
+**Gaps relevant to a versioned filesystem** (deliberately pushed to `.raw`):
+1. **Object versioning** — no `listVersions`, no version-id-aware `download`/`delete` in the unified API. S3 versioning is explicitly a `.raw` concern.
+2. **Conditional/ETag writes** — no `upload(..., { ifMatch })` primitive. (agent-fs doesn't need this — concurrency is in SQLite.)
+3. **Arbitrary object metadata** (`x-amz-meta-*`) — not first-class (agent-fs already passes `metadata: undefined`, so no loss).
+4. **Delimiter/`CommonPrefixes` directory listing** — the unified `list({ prefix })` returns a flat key iterable; the `/`-delimiter "folders" semantic `ls` relies on is not obviously surfaced (needs verification / `.raw` / client-side prefix derivation).
+5. **Response-content-type override on presigned GET** — `url({ expiresIn })` shown without a `responseContentType` param (agent-fs currently sets it; may need `.raw` or may be unnecessary since content-type is stored on the object).
+6. **Single client per `Files` instance** — agent-fs's two-endpoint split (internal vs `publicEndpoint` presign) would need two `Files` instances or a `.raw` presigner.
+7. Young, single-maintainer project (weigh for production).
+
+### 7. Integration surface — mapping current ops onto a multi-adapter layer
+
+The change has three structural pieces and one semantic decision.
+
+**Structural piece A — extract an interface.** Promote `AgentS3Client`'s 10-method surface (§1 table) into a `StorageAdapter` interface in `packages/core/src/s3/` (or a renamed `packages/core/src/storage/`). `OpContext.s3` becomes `OpContext.storage: StorageAdapter` (or keep the name `s3` to minimize churn). `MockS3Client` already conforms (`test-utils.ts`).
+
+**Structural piece B — write adapters.** Each adapter implements the interface. Mapping current methods → `files-sdk`:
+
+| `AgentS3Client` method | `files-sdk` unified equivalent | Gap / `.raw` needed? |
+|---|---|---|
+| `putObject(key, body, _, contentType)` | `files.upload(key, body, { contentType })` | clean |
+| `getObject(key)` (no version) | `files.download(key)` → bytes | clean (consume Blob→Uint8Array) |
+| `getObject(key, versionId)` | — | **`.raw` `GetObjectCommand` with `VersionId`** (revert/diff) |
+| `deleteObject(key)` | `files.delete(key)` | clean |
+| `copyObject(from, to)` | `files.copy(from, to)` | clean (versionId return via `.raw` if needed) |
+| `listObjects(prefix, {delimiter})` | `files.list({ prefix })` | **delimiter/CommonPrefixes via `.raw` or client-side** |
+| `headObject(key)` | `files.head(key)` | clean |
+| `listObjectVersions(key)` | — | `.raw` (currently unused by ops) |
+| `checkVersioningEnabled`/`enableVersioning` | — | `.raw` bucket-versioning commands |
+| `getPresignedUrl(key, expiresIn, respCT?)` | `files.url(key, { expiresIn })` | response-content-type + public-endpoint split may need `.raw`/2nd instance |
+
+**Structural piece C — choose the adapter at startup.** Add a `provider`/`adapter` discriminator to `AgentFSConfig.s3` (the field `provider` already exists, currently informational). At `packages/server/src/index.ts:13`, switch on it to construct the right adapter. Config schema (`config.ts:13-23`) gains adapter-specific shapes (e.g. GCS keyfile, Azure connection string) — likely a tagged union. `forcePathStyle` would move from hardcoded into S3-adapter config.
+
+**Semantic decision (the part that needs a human call):** the version-critical paths (`revert`, historical `diff`) require version-id reads that no unified abstraction (`files-sdk` or flystorage) models. Two shapes:
+- **(i) `files-sdk` as the interface** — adapters wrap `Files`, drop to `files.raw` for versioned reads, delimiter listing, and bucket versioning. Pro: get 30+ backends, multipart, range reads, hooks "for free." Con: the version-critical S3 paths bypass the abstraction anyway, and non-S3 adapters (GCS/Azure/local) would need their *own* versioning emulation (e.g. copy-on-write version keys) since S3 object-versionId semantics don't port.
+- **(ii) agent-fs owns a thin `StorageAdapter` interface** — write adapters directly (S3 via `@aws-sdk` or `Bun.s3`; GCS; local FS), each free to implement versioned reads however its backend allows. `files-sdk` could be *one* adapter implementation. Pro: full control of the version contract; Con: more code, lose `files-sdk`'s breadth.
+- A hybrid is viable: keep the existing `AgentS3Client` as the S3 adapter (zero risk to the working S3 path), add a `files-sdk`-backed adapter for *new* backends where app-level versioning (copy-on-write to distinct keys, tracked in SQLite) replaces S3 object versioning.
+
+A genuinely portable versioning model would shift old-version retrieval off S3 object-versionId entirely — e.g. store each version under its own content-addressed key (`…/path/@v{n}` or `…/sha256/{hash}`) tracked by the existing `file_versions` table — making *every* backend (including plain local FS) capable of revert/diff without provider versioning. That is the largest design lever and the main thing a plan should decide.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `packages/core/src/s3/client.ts` | 51 | `AgentS3Client` — the single storage boundary; only AWS SDK importer |
+| `packages/core/src/s3/client.ts` | 63-74 | Dual client construction (internal `client` + `presignClient` on `publicEndpoint`), `forcePathStyle: true` |
+| `packages/core/src/s3/client.ts` | 78-238 | All 10 storage methods (put/get/delete/copy/list/head/listVersions/check+enable versioning/presign) |
+| `packages/core/src/s3/client.ts` | 99-120 | `getObject(key, versionId?)` — version-id read path |
+| `packages/core/src/ops/types.ts` | 5-13 | `OpContext` carrying `s3: AgentS3Client` — the injection seam |
+| `packages/core/src/ops/versioning.ts` | 11-14 | `getS3Key` key format `<orgId>/drives/<driveId>/<path>` |
+| `packages/core/src/ops/versioning.ts` | 152-258 | `createVersion` — SQLite version row + files upsert in one transaction |
+| `packages/core/src/ops/versioning.ts` | 92-109 | `assertExpectedVersion` — optimistic concurrency in SQLite (not S3) |
+| `packages/core/src/ops/write.ts` | 55-128 | `writeInternal` — hash, dedup short-circuit, `putObject`, `createVersion`, index |
+| `packages/core/src/ops/revert.ts` | 44-77 | Hard `VERSIONING_REQUIRED`; `getObject(key, s3VersionId)` → re-PUT |
+| `packages/core/src/ops/diff.ts` | 49-91 | Parallel version-id reads, `diffSummary` fallback |
+| `packages/core/src/ops/ls.ts` | 15 | `listObjects(prefix, { delimiter: "/" })` directory listing |
+| `packages/core/src/ops/signed-url.ts` | 19-52 | Presigned URL op (head-check + `getPresignedUrl`) |
+| `packages/core/src/config.ts` | 13-23 | `AgentFSConfig.s3` schema |
+| `packages/core/src/config.ts` | 132-147 | `applyEnvOverrides` — `AWS_*`/`S3_*` precedence |
+| `packages/core/src/db/raw.ts` | 41-72 | `files` + `file_versions` DDL (storage-relevant columns) |
+| `packages/server/src/index.ts` | 13 | `new AgentS3Client(config.s3)` — the single construction site to swap |
+| `packages/server/src/app.ts` | 18-77 | Threads `s3` into routes / IPC / MCP |
+| `packages/core/src/test-utils.ts` | — | `MockS3Client` already implements the interface shape |
+| `packages/cli/src/commands/onboard.ts` | 207-250 | MinIO container setup + S3 config write |
+| `docker-compose.hosted.yml` | 1-19 | Hosted/external-S3 wiring (R2 example) |
+
+## Decisions (ironed out 2026-06-25)
+
+Resolved with Taras via AskUserQuestion. These settle the central forks; the residual items move to *Verification for the plan* below.
+
+- **Goal & guiding value** — adopt a multi-adapter storage layer to get *automatic* support for a broad set of backends (S3/MinIO, local filesystem, and consumer providers like Dropbox / Google Drive) via `files-sdk`. Some backends will be feature-limited, and that is acceptable: the durable value — file **comments** and **search** — lives in SQLite and works on every backend regardless of object-store capabilities.
+- **Architecture — internal interface, keep `AgentS3Client`.** agent-fs owns a thin `StorageAdapter` interface (extracted from the current `AgentS3Client` surface, §1 table). The existing `AgentS3Client` stays as the full-featured **S3/MinIO** adapter (native versioning, dual internal-vs-public presign endpoint). A separate **`files-sdk`-backed adapter** supplies the breadth (local + consumer providers). This insulates agent-fs from churn in `files-sdk` (young, single-maintainer dep) and keeps **near-zero risk on the proven S3 path** (`AgentS3Client`'s behavior is unchanged; it only gains an `implements StorageAdapter` declaration). `files-sdk` is an *adapter implementation behind our interface*, not the interface itself.
+- **Versioning — per-backend, native where possible.** Three tiers:
+  1. **S3/MinIO (full):** keep native S3 object versioning for `revert` / historical `diff` (unchanged).
+  2. **Local filesystem (full):** implement an app-level version-key scheme — each version's bytes stored under its own key (tracked by the existing `file_versions` table) — so `revert` / `diff` work without object versioning. This uses the plain `upload`/`download` surface (distinct keys), **not** the `.raw` escape hatch.
+  3. **Other adapters (basic):** `revert` and historical-*content* `diff` are **unsupported**; `diff` still degrades to the stored `diffSummary`, and forward history (`log`) still works since it's SQLite-only.
+- **Limited-op behavior — typed `unsupported` error + capability metadata.** Ops a backend can't satisfy throw a typed `UnsupportedOperation`, surfaced cleanly in CLI/MCP. Each adapter advertises **capability metadata** (e.g. `{ versioning: false }`) so callers / the UI can check support up front instead of failing blindly.
+
+## Open Questions / Verification for the plan
+
+Technical items to confirm during planning/implementation (not blocking decisions):
+
+- **`StorageAdapter` interface shape** — finalize the method set extracted from `AgentS3Client` (§1 table) and where capability metadata lives. `revert` / `diff` / `ls` are the ops whose contracts must accommodate "unsupported" + non-S3 versioning. `file_versions.s3_version_id` becomes an **opaque per-adapter version handle**, not S3-specific.
+- **Local-FS versioning mechanism** — exact key scheme for per-version content on local (e.g. `<key>/.versions/v{n}` vs content-addressed `sha256/{hash}`) and how `revert`/`diff` resolve it.
+- **Delimiter directory listing** — confirm whether `files-sdk` `list({ prefix })` returns `/`-delimited common prefixes (folders) for `ls`, or whether the adapter derives them client-side / via `.raw`. (Not confirmed from the docs read.)
+- **Presigned GET nuances** — confirm `files-sdk` `url({ expiresIn })` can express a `responseContentType`-equivalent, and how to replicate the internal-vs-public presign endpoint split for non-S3 adapters (likely native to each provider's URL semantics).
+- **Per-backend config schema** — evolve `AgentFSConfig.s3` into a tagged union keyed by `provider`/adapter (S3 knobs incl. `forcePathStyle`/`publicEndpoint`, R2 `accountId`, GCS keyfile, Azure connection string, local path, OAuth tokens for Dropbox/GDrive). Adapter selection happens at `packages/server/src/index.ts:13`.
+- **FUSE/raw-write path** (`routes/files.ts`, `writeRaw`) — whether to adopt `files-sdk` multipart/streaming for large binary uploads (currently fully buffered, 50 MB cap) — an independent improvement.
+- **Bun + `files-sdk` live check** — verify a live `files-sdk` `s3()` / local adapter under Bun (against the MinIO container for S3) before committing.
+- **Presigned URLs are themselves a per-backend capability** — local FS and some consumer providers have no presigned-URL concept, so `signed-url` joins `revert`/`diff` as a capability-gated op (not just a "nuance"). agent-fs already has a byte-serving fallback: the daemon's `GET …/raw` route (`packages/server/src/routes/files.ts`) + the in-app viewer `buildAppUrl` (`packages/core/src/ops/urls.ts:1-9`). Decide whether limited backends return `UnsupportedOperation` for `signed-url` or transparently fall back to the daemon route.
+- **Cross-store consistency / atomicity** — the write path does `putObject` then `createVersion` (a SQLite transaction) as two non-atomic steps (`packages/core/src/ops/write.ts`). On remote/consumer backends (network failures, eventual consistency) the partial-failure window (object written but DB row not, or vice versa) is wider than on S3/local. Decide on ordering + a reconciliation/retry strategy (e.g. object-then-commit + orphan cleanup), or accept best-effort for limited backends.
+- **Auth for consumer providers** — Dropbox / Google Drive need OAuth token storage + refresh; likely out of scope for the first cut, but flag the surface (new config + per-drive credential storage).
+
+## Appendix
+
+- **Architecture notes**:
+  - The storage layer is already a clean single-boundary adapter (`AgentS3Client` + `ctx.s3`), with a conforming mock. This is the ideal precondition for multi-adapter support — the refactor is interface-extraction + a construction-site switch, not a scattered rewrite.
+  - agent-fs deliberately keeps almost all "filesystem" semantics in SQLite (version numbering, dedup, concurrency, metadata, search), treating the object store as a dumb keyed blob store. The one leak is S3 **object versioning** for old-content retrieval (revert/diff).
+  - Multi-tenancy is by key prefix in a single bucket; there is no per-org/per-drive backend concept today. Per-tenant backends would be a separate, larger feature (new DB columns + per-request adapter resolution).
+  - **Release-checklist reminder for any eventual plan** (from project `CLAUDE.md`): core/CLI/MCP changes require updating `skills/agent-fs/SKILL.md`, bumping `.claude-plugin/plugin.json` and root `package.json`, and extending `scripts/e2e.ts`. A storage-adapter change touches core ops semantics, so E2E coverage (incl. a non-S3 adapter and revert/diff under each backend) is in scope.
+- **files-sdk source**: site `https://files-sdk.dev/`, repo `https://github.com/haydenbleasel/files-sdk` (README at `packages/files-sdk/README.md`), npm `files-sdk` v2.0.0. Verified directly this session (the unified method list, MinIO/S3-compatible support, presigned GET/PUT, range reads, multipart, Bun test suite, and that versioning is a `.raw`-only concern).
+- **Permalink base** (this commit): `https://github.com/desplega-ai/agent-fs/blob/028667b60761aed5586b0bdca0407f69ae944ab2/<path>#L<line>`.
+- **Related research**: none found in `thoughts/taras/research/` on storage adapters prior to this document.
+
+## Review Errata
+
+_Reviewed: 2026-06-25 by Claude (structured review, auto-apply mode)_
+
+### Applied (auto-fixed)
+- [x] **File:line accuracy verified** — two mapping sub-agents had reported conflicting line numbers for `s3/client.ts` (`:48-65` vs `:78-97` for `putObject`, etc.). Read `client.ts` directly and confirmed the doc uses the **correct** set (`putObject:78-97` … `getPresignedUrl:226-238`, class `:51`, construction `:63-74`). Spot-checked `versioning.ts:11`, `write.ts:75`, `revert.ts:46/54`, `ops/types.ts:5-7`, `server/index.ts:13`, `config.ts:136-147`, `db/raw.ts:41/55/71`, `ops/ls.ts:15-16` — all accurate. No reference changes needed.
+- [x] **`MockS3Client` claim corrected (Important)** — it is a *duck-typed* second implementation wired in via an `as any` cast (`test-utils.ts:225`), not a typechecked interface implementation. Tempered the "already a conforming implementation" phrasing in §1 and the Summary's implication; the "ease" argument still holds (extracting the interface also removes the cast).
+- [x] **`signed-url` added as a capability-gated op (Important)** — presigned URLs are themselves backend-specific (no concept on local FS / some providers); added to the verification list with the existing `/raw` + `buildAppUrl` fallback noted.
+- [x] **Cross-store atomicity gap added (Important)** — `putObject` + `createVersion` are non-atomic; partial-failure window widens on remote/consumer backends. Added as a verification item.
+- [x] **"zero risk" → "near-zero risk" (Minor)** — `AgentS3Client` gains an `implements StorageAdapter` declaration, so the path isn't literally untouched.
+- [x] **Local-FS versioning wording (Minor)** — clarified it uses the plain `upload`/`download` surface with distinct keys, not the `.raw` escape hatch.
+
+### Notes (no change required)
+- **Genre**: at Taras's request (review comment), this document now carries a forward-looking *Decisions* section alongside the as-is research — a deliberate deviation from pure "document what IS." Captured here for transparency.
+- **Unverified-but-disclosed**: the `files-sdk` delimiter-listing and presigned-`responseContentType` behaviors remain flagged in the verification list (could not be confirmed from the docs read); these are plan-phase checks, not doc defects.
+
+### Remaining
+- None. No Critical findings.


### PR DESCRIPTION
## Summary

Introduces a thin internal `StorageAdapter` interface so agent-fs storage supports multiple backends, and adds a `files-sdk`-backed **local-filesystem** adapter alongside the existing S3/MinIO path. Backends are **feature-tiered**: S3/MinIO and local-FS both get full versioning (`revert` + historical `diff`); future basic-tier backends degrade cleanly. The durable value — version history, comments, and search — is SQLite-side and works identically on every backend.

Implemented as a 5-step DAG plan (`thoughts/taras/plans/2026-06-25-multi-adapter-storage/`). **S3/MinIO behavior is unchanged** — `AgentS3Client` only gains an `implements StorageAdapter` declaration.

## What changed

- **`StorageAdapter` interface + `StorageCapabilities` + `UnsupportedOperation`** (`packages/core/src/storage/adapter.ts`, `errors.ts`). `OpContext.s3` is typed to the interface; the `as any` mock cast is gone.
- **Capability gating, surfaced cleanly core → CLI → MCP.** A backend that can't satisfy an op throws the typed `UnsupportedOperation` → HTTP **422** → clean CLI message + MCP `isError` (no raw stack traces). `revert` hard-fails on a no-versioning backend; historical `diff` degrades to the stored `diffSummary`.
- **`LocalStorageAdapter`** (`packages/core/src/storage/local-adapter.ts`) — first non-S3 backend, backed by `files-sdk`'s `fs` adapter. Full versioning tier via **content-addressed blobs**: every version's bytes also live at a reserved `_afs-blobs/sha256/<hash>` key (outside drive listings); the version handle stored in `file_versions.s3_version_id` is the hash, so `revert`/`diff` work with no object-versioning primitive. Identical content dedups for free. `signed-url` falls back to the auth-gated daemon `/raw` app link (`kind: "app"`) instead of a presigned URL.
- **Tagged-union config + adapter selection + onboarding.** `AgentFSConfig.s3` is now discriminated by `provider`; `createStorageAdapter()` selects the adapter at the single construction site; `agent-fs onboard --filesystem` (alias `--storage local`, `--storage-root <dir>`) sets up a local-FS drive with no Docker/S3.
- **Cross-backend E2E + release checklist.** `scripts/e2e.ts` now runs its core-ops suite against **both** MinIO and local-FS (incl. revert/diff under each + an unsupported-op assertion + a signed-url backend matrix). SKILL.md documents the new backend/tiers; version bumped **0.9.0 → 0.10.0** in lockstep across all packages + `plugin.json` + `Cargo.toml` + `docs/openapi.json`.

## Testing

- ✅ `bun run typecheck` clean
- ✅ `bun test` — **898 pass / 114 skip / 0 fail** (1012 tests)
- ✅ `bun run scripts/e2e.ts` — **127/127** (MinIO ran against real Docker; local needs none; 10 FUSE skipped on Darwin), including revert/diff on both backends, the unsupported-op 422 assertion, and the signed-url presigned-vs-app matrix
- ✅ Post-implementation audit: `AUDIT: clean` — 0 blocking, 0 warnings, no scope creep
- All pre-push hooks pass (typecheck, build, test:coverage, OpenAPI freshness)

## Out of scope / follow-ups

- **No** consumer-provider adapter (Dropbox/GDrive) or OAuth — deferred to a follow-up plan.
- **No** multipart/streaming rewrite of the write path; **no** per-org/per-drive backend selection (storage stays a process-wide singleton, no new DB columns).
- Noted for later (non-blocking): local `_afs-blobs/` history has no GC (grows unbounded under churn); `--local` (MinIO Docker) vs `--filesystem` (real FS) naming is a latent footgun. See the Review Errata in the plan's `root.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
