### PR TITLE
Add Live recents and comment notifications

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "author": {
     "name": "desplega-ai"
   },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.10.1",
+    "version": "0.11.0",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",
@@ -1033,6 +1033,70 @@
                       },
                       "resolved": {
                         "type": "boolean"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "title": "comment-notification-list",
+                    "description": "List comment notifications for the current user in the active drive. Returns { notifications, unreadCount }.",
+                    "required": [
+                      "op"
+                    ],
+                    "properties": {
+                      "op": {
+                        "type": "string",
+                        "const": "comment-notification-list"
+                      },
+                      "driveId": {
+                        "type": "string",
+                        "description": "Target drive ID (optional, uses default drive)"
+                      },
+                      "unreadOnly": {
+                        "type": "boolean"
+                      },
+                      "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100
+                      },
+                      "offset": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "title": "comment-notification-read",
+                    "description": "Mark selected comment notification IDs, or all comment notifications in the active drive, as read. Returns { markedRead }.",
+                    "required": [
+                      "op"
+                    ],
+                    "properties": {
+                      "op": {
+                        "type": "string",
+                        "const": "comment-notification-read"
+                      },
+                      "driveId": {
+                        "type": "string",
+                        "description": "Target drive ID (optional, uses default drive)"
+                      },
+                      "ids": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "minItems": 1,
+                        "maxItems": 100
+                      },
+                      "all": {
+                        "type": "boolean",
+                        "enum": [
+                          true
+                        ]
                       }
                     },
                     "additionalProperties": false

--- a/live/src/api/errors.ts
+++ b/live/src/api/errors.ts
@@ -1,0 +1,4 @@
+export function isUnknownOperationError(error: unknown, op: string): boolean {
+  if (!(error instanceof Error)) return false
+  return error.message === `Unknown operation: ${op}`
+}

--- a/live/src/api/types.ts
+++ b/live/src/api/types.ts
@@ -147,6 +147,26 @@ export interface CommentResolveResult {
   resolvedAt?: string
 }
 
+export interface CommentNotificationEntry {
+  id: string
+  commentId: string
+  parentId?: string
+  path: string
+  body: string
+  actor: string
+  createdAt: string
+  read: boolean
+}
+
+export interface CommentNotificationListResult {
+  notifications: CommentNotificationEntry[]
+  unreadCount: number
+}
+
+export interface CommentNotificationReadResult {
+  markedRead: number
+}
+
 // FTS types (from core/ops/fts.ts)
 
 export interface FtsOpMatch {

--- a/live/src/components/comments/CommentNotifications.tsx
+++ b/live/src/components/comments/CommentNotifications.tsx
@@ -1,0 +1,184 @@
+import { useState } from "react"
+import { Bell, CheckCheck, MessageSquare } from "lucide-react"
+import { useBrowser } from "@/contexts/browser"
+import {
+  useCommentNotifications,
+  useMarkCommentNotificationsRead,
+} from "@/hooks/use-comment-notifications"
+import { useDisplayName } from "@/components/UserName"
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import { sidePanelStore } from "@/stores/side-panel"
+import { uiChromeStore } from "@/stores/ui-chrome"
+import type { CommentNotificationEntry } from "@/api/types"
+
+/**
+ * Top-bar comment inbox. It deliberately stays absent until the server
+ * returns data, which keeps the live UI backward-compatible with older API
+ * deployments where the notification ops do not exist yet.
+ */
+export function CommentNotifications() {
+  const [open, setOpen] = useState(false)
+  const { selectFile } = useBrowser()
+  const { data } = useCommentNotifications()
+  const markRead = useMarkCommentNotificationsRead()
+
+  if (!data) return null
+
+  const openNotification = (notification: CommentNotificationEntry) => {
+    if (!notification.read) {
+      markRead.mutate({ ids: [notification.id] })
+    }
+
+    selectFile(notification.path.replace(/^\/+/, ""))
+    setOpen(false)
+
+    // The file route updates on this click; wait until the comments rail has
+    // committed before asking the shared chrome store to reveal it.
+    requestAnimationFrame(() => {
+      sidePanelStore.setTab("comments")
+      uiChromeStore.setRight(true)
+    })
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="relative"
+            aria-label={
+              data.unreadCount > 0
+                ? `${data.unreadCount} unread comment notification${data.unreadCount === 1 ? "" : "s"}`
+                : "Comment notifications"
+            }
+          >
+            <Bell />
+            {data.unreadCount > 0 && (
+              <span className="absolute -right-1 -top-1 flex min-w-3.5 h-3.5 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-none text-primary-foreground">
+                {data.unreadCount > 99 ? "99+" : data.unreadCount}
+              </span>
+            )}
+          </Button>
+        }
+      />
+      <PopoverContent
+        align="end"
+        className="w-[min(22rem,calc(100vw-1rem))] gap-0 overflow-hidden p-0"
+      >
+        <div className="flex h-10 items-center justify-between border-b border-border px-3">
+          <div className="min-w-0">
+            <span className="text-sm font-medium">Comments</span>
+            {data.unreadCount > 0 && (
+              <span className="ml-1.5 text-xs text-muted-foreground">
+                {data.unreadCount} unread
+              </span>
+            )}
+          </div>
+          {data.unreadCount > 0 && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="gap-1 text-muted-foreground"
+              onClick={() => markRead.mutate({ all: true })}
+              disabled={markRead.isPending}
+            >
+              <CheckCheck />
+              Mark all read
+            </Button>
+          )}
+        </div>
+
+        <div className="max-h-96 overflow-y-auto p-1.5">
+          {data.notifications.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 px-4 py-8 text-center">
+              <MessageSquare
+                className="size-7 text-muted-foreground/60"
+                strokeWidth={1.5}
+              />
+              <div>
+                <p className="text-sm font-medium">No comment activity</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  New comments and replies will appear here.
+                </p>
+              </div>
+            </div>
+          ) : (
+            data.notifications.map((notification) => (
+              <NotificationRow
+                key={notification.id}
+                notification={notification}
+                onOpen={openNotification}
+              />
+            ))
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+function NotificationRow({
+  notification,
+  onOpen,
+}: {
+  notification: CommentNotificationEntry
+  onOpen: (notification: CommentNotificationEntry) => void
+}) {
+  const { display } = useDisplayName(notification.actor)
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen(notification)}
+      className={cn(
+        "flex w-full gap-2.5 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        notification.read && "opacity-65",
+      )}
+    >
+      <span
+        className={cn(
+          "mt-1.5 size-1.5 shrink-0 rounded-full",
+          notification.read ? "bg-transparent" : "bg-primary",
+        )}
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-baseline gap-1.5">
+          <span className="min-w-0 truncate text-xs font-medium">{display}</span>
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {timeAgo(notification.createdAt)}
+          </span>
+        </span>
+        <span className="mt-0.5 block line-clamp-2 text-xs leading-relaxed">
+          {notification.body}
+        </span>
+        <span className="mt-1 block truncate text-[10px] text-muted-foreground">
+          {notification.path.replace(/^\/+/, "")}
+        </span>
+      </span>
+    </button>
+  )
+}
+
+function timeAgo(dateString: string): string {
+  const timestamp = new Date(dateString).getTime()
+  if (!Number.isFinite(timestamp)) return ""
+
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000))
+  if (seconds < 60) return "now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d`
+  return new Date(timestamp).toLocaleDateString()
+}

--- a/live/src/components/file-tree/FileTree.tsx
+++ b/live/src/components/file-tree/FileTree.tsx
@@ -1,15 +1,25 @@
-import { useCallback, useRef } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useCallback, useEffect, useRef } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { FolderOpen, SearchX } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
+import { useBrowser } from "@/contexts/browser"
 import { FileTreeNode } from "./FileTreeNode"
 import { treeExpansionStore, useFocusedPath } from "@/stores/tree-expansion"
 import { useFileSearch } from "@/stores/file-search"
 import { useSearchInput } from "@/contexts/search-input"
 import type { LsResult } from "@/api/types"
 
+const REVEAL_TIMEOUT_MS = 15_000
+
+function ancestorPaths(path: string): string[] {
+  const parts = path.split("/").filter(Boolean)
+  return parts.slice(0, -1).map((_, index) => parts.slice(0, index + 1).join("/"))
+}
+
 export function FileTree() {
   const { client, orgId, driveId } = useAuth()
+  const { selectedFile } = useBrowser()
+  const queryClient = useQueryClient()
   const containerRef = useRef<HTMLDivElement>(null)
   const focusedPath = useFocusedPath()
   const filter = useFileSearch()
@@ -20,6 +30,60 @@ export function FileTree() {
     queryFn: () => client.callOp<LsResult>(orgId!, "ls", {}, driveId),
     enabled: !!orgId && !!driveId,
   })
+  const treeReady = !!data
+
+  useEffect(() => {
+    const path = selectedFile?.replace(/^\/+/, "")
+    if (!path || path.endsWith("/") || !treeReady) return
+
+    const ancestors = ancestorPaths(path)
+    treeExpansionStore.expandMany(ancestors)
+
+    // The file may have been created by another client after an ls result was
+    // cached. Refresh only the listings needed to reveal this path; invalidating
+    // every expanded tree node would turn one selection into an unbounded fanout.
+    for (const listingPath of ["", ...ancestors]) {
+      void queryClient.invalidateQueries({
+        queryKey: ["ls", orgId, driveId, listingPath],
+        exact: true,
+      })
+    }
+
+    const container = containerRef.current
+    if (!container) return
+
+    const revealSelectedRow = () => {
+      const row = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("[data-tree-path]"),
+      ).find((candidate) => candidate.dataset.treePath === path)
+
+      if (!row) return false
+
+      // Update the roving tab stop without moving DOM focus away from the
+      // viewer, editor, or search input that the user is currently using.
+      treeExpansionStore.setFocusedPath(path)
+      row.scrollIntoView({ block: "center", inline: "nearest" })
+      return true
+    }
+
+    if (revealSelectedRow()) return
+
+    // Child directories load lazily. Watch this tree until the selected row
+    // materializes, then disconnect immediately.
+    const observer = new MutationObserver(() => {
+      if (!revealSelectedRow()) return
+      observer.disconnect()
+      window.clearTimeout(timeoutId)
+    })
+    observer.observe(container, { childList: true, subtree: true })
+
+    const timeoutId = window.setTimeout(() => observer.disconnect(), REVEAL_TIMEOUT_MS)
+
+    return () => {
+      observer.disconnect()
+      window.clearTimeout(timeoutId)
+    }
+  }, [driveId, orgId, queryClient, selectedFile, treeReady])
 
   /** Collect all visible row paths in DOM order. */
   const collectVisible = useCallback((): {
@@ -170,7 +234,10 @@ export function FileTree() {
   })
 
   const noFilterMatches =
-    filter.status === "loaded" && filter.query.length > 0 && filter.matchedPaths.length === 0
+    filter.status === "loaded" &&
+    filter.query.length > 0 &&
+    filter.matchedPaths.length === 0 &&
+    !selectedFile
 
   return (
     <div

--- a/live/src/components/file-tree/FileTreeNode.tsx
+++ b/live/src/components/file-tree/FileTreeNode.tsx
@@ -59,7 +59,13 @@ export function FileTreeNode({ entry, path, depth, isDefaultFocus = false }: Fil
   // to the store so re-renders fire on every keystroke.
   const filter = useFileSearch()
   const filterActive = filter.query.length > 0
-  const visible = isPathVisible(fullPath)
+  // Keep the selected file and its ancestor chain visible even when an old
+  // in-tree search is still active (for example after opening a notification).
+  // This preserves the promise that every file open reveals itself in Tree.
+  const selectedPath = selectedFile?.replace(/^\/+|\/+$/g, "") ?? null
+  const isOnSelectedPath =
+    selectedPath === fullPath || selectedPath?.startsWith(`${fullPath}/`) === true
+  const visible = isPathVisible(fullPath) || isOnSelectedPath
   const expandedByFilter = filterActive && isDir && hasMatchingDescendant(fullPath)
   const expanded = userExpanded || expandedByFilter
   const focusedPath = useFocusedPath()

--- a/live/src/components/file-tree/RecentFiles.tsx
+++ b/live/src/components/file-tree/RecentFiles.tsx
@@ -1,0 +1,62 @@
+import { History } from "lucide-react"
+import { useBrowser } from "@/contexts/browser"
+import { glyphFor } from "@/lib/file-glyphs"
+import { cn } from "@/lib/utils"
+
+interface RecentFilesProps {
+  onOpenFile: (path: string) => void
+}
+
+export function RecentFiles({ onOpenFile }: RecentFilesProps) {
+  const { recentFiles, selectedFile } = useBrowser()
+
+  if (recentFiles.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 px-4 py-12 text-center">
+        <History className="size-8 text-muted-foreground/60" strokeWidth={1.5} />
+        <div className="space-y-1">
+          <p className="text-sm font-medium">No recent files</p>
+          <p className="text-xs text-muted-foreground">
+            Files you open will appear here.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <ul className="py-1" aria-label="Recently viewed files">
+      {recentFiles.map((path) => {
+        const lastSlash = path.lastIndexOf("/")
+        const filename = lastSlash === -1 ? path : path.slice(lastSlash + 1)
+        const parentPath = lastSlash === -1 ? "Drive root" : path.slice(0, lastSlash)
+        const glyph = glyphFor(path)
+        const isSelected = selectedFile === path
+
+        return (
+          <li key={path}>
+            <button
+              type="button"
+              title={path}
+              aria-current={isSelected ? "page" : undefined}
+              onClick={() => onOpenFile(path)}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+                isSelected &&
+                  "bg-sidebar-accent text-sidebar-accent-foreground",
+              )}
+            >
+              <glyph.Icon className={cn("size-4 shrink-0", glyph.className)} />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">{filename}</span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  {parentPath}
+                </span>
+              </span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/live/src/components/folder-view/FolderView.tsx
+++ b/live/src/components/folder-view/FolderView.tsx
@@ -8,6 +8,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { ListView } from "./ListView"
 import { GridView } from "./GridView"
 import { ViewModeToggle, useFolderViewMode } from "./ViewModeToggle"
+import { RecentActivity } from "./RecentActivity"
 import type { LsEntry, LsResult } from "@/api/types"
 
 interface FolderViewProps {
@@ -89,6 +90,8 @@ export function FolderView({ path }: FolderViewProps) {
 
       {/* Body */}
       <div className="flex-1 overflow-y-auto p-3">
+        {currentPath === "" && <RecentActivity />}
+
         {isLoading ? (
           <div className="flex h-full items-center justify-center">
             <Spinner />
@@ -110,19 +113,33 @@ export function FolderView({ path }: FolderViewProps) {
             </div>
           </div>
         ) : mode === "grid" ? (
-          <GridView
-            entries={sorted}
-            currentPath={currentPath}
-            onEntryClick={handleEntryClick}
-          />
+          <>
+            {currentPath === "" && <AllFilesHeading />}
+            <GridView
+              entries={sorted}
+              currentPath={currentPath}
+              onEntryClick={handleEntryClick}
+            />
+          </>
         ) : (
-          <ListView
-            entries={sorted}
-            currentPath={currentPath}
-            onEntryClick={handleEntryClick}
-          />
+          <>
+            {currentPath === "" && <AllFilesHeading />}
+            <ListView
+              entries={sorted}
+              currentPath={currentPath}
+              onEntryClick={handleEntryClick}
+            />
+          </>
         )}
       </div>
     </div>
+  )
+}
+
+function AllFilesHeading() {
+  return (
+    <h2 className="px-3 py-1 text-xs font-medium text-muted-foreground">
+      All files
+    </h2>
   )
 }

--- a/live/src/components/folder-view/RecentActivity.tsx
+++ b/live/src/components/folder-view/RecentActivity.tsx
@@ -1,0 +1,177 @@
+import { useMemo } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { ChevronDown, History } from "lucide-react"
+import { isUnknownOperationError } from "@/api/errors"
+import { useAuth } from "@/contexts/auth"
+import { useBrowser } from "@/contexts/browser"
+import { useLocalStorage } from "@/hooks/use-local-storage"
+import { cn } from "@/lib/utils"
+import { glyphFor } from "@/lib/file-glyphs"
+import { MiddleEllipsis } from "@/lib/middle-ellipsis"
+import type { RecentEntry, RecentResult } from "@/api/types"
+
+const MAX_VISIBLE = 8
+
+interface RecentFile extends RecentEntry {
+  path: string
+}
+
+/** A compact, drive-wide activity list for the drive root. */
+export function RecentActivity() {
+  const { client, orgId, driveId } = useAuth()
+  const { selectFile } = useBrowser()
+  const [collapsed, setCollapsed] = useLocalStorage(
+    "liveui:recent-activity:collapsed",
+    false,
+  )
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["recent", orgId, driveId],
+    queryFn: () =>
+      client.callOp<RecentResult>(orgId!, "recent", { limit: 50 }, driveId),
+    enabled: !!orgId && !!driveId,
+    retry: false,
+    refetchInterval: (query) =>
+      isUnknownOperationError(query.state.error, "recent") ? false : 60_000,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: false,
+  })
+
+  const files = useMemo(() => newestCurrentFiles(data?.entries ?? []), [data])
+
+  // This section is optional enhancement. Older servers may not expose the
+  // recent op, so a failure must never displace the ordinary folder listing.
+  if (isError) return null
+
+  if (isLoading) {
+    return (
+      <section
+        aria-label="Recently changed"
+        className="mb-2 border-b border-border/70 pb-3"
+      >
+        <SectionHeading
+          collapsed={collapsed}
+          onToggle={() => setCollapsed(!collapsed)}
+        />
+        {!collapsed && (
+          <div className="mx-3 mt-2 h-px overflow-hidden bg-border">
+            <div className="h-full w-1/3 animate-pulse bg-muted-foreground/40" />
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  if (files.length === 0) return null
+
+  return (
+    <section
+      aria-labelledby="recently-changed-heading"
+      className="mb-2 border-b border-border/70 pb-2"
+    >
+      <SectionHeading
+        id="recently-changed-heading"
+        collapsed={collapsed}
+        onToggle={() => setCollapsed(!collapsed)}
+      />
+      {!collapsed && (
+        <div className="flex flex-col">
+          {files.map((entry) => {
+            const glyph = glyphFor(entry.path)
+            const label = entry.version === 1 ? "Created" : "Updated"
+
+            return (
+              <button
+                key={entry.path}
+                type="button"
+                onClick={() => selectFile(entry.path)}
+                className={cn(
+                  "flex w-full items-center gap-2.5 rounded-md px-3 py-1.5 text-left text-sm",
+                  "hover:bg-muted transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1",
+                )}
+              >
+                <glyph.Icon className={cn("size-4 shrink-0", glyph.className)} />
+                <span className="min-w-0 flex-1">
+                  <MiddleEllipsis text={entry.path} />
+                </span>
+                <span className="shrink-0 text-[11px] text-muted-foreground">
+                  {label} · {formatRelativeTime(entry.createdAt)}
+                </span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function SectionHeading({
+  id,
+  collapsed,
+  onToggle,
+}: {
+  id?: string
+  collapsed: boolean
+  onToggle: () => void
+}) {
+  return (
+    <h2 id={id}>
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        onClick={onToggle}
+        className="flex w-full items-center gap-1.5 rounded-md px-3 py-1 text-left text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+      >
+        <ChevronDown
+          className={cn(
+            "size-3.5 transition-transform motion-reduce:transition-none",
+            collapsed && "-rotate-90",
+          )}
+        />
+        <History className="size-3.5" />
+        <span>Recently changed</span>
+      </button>
+    </h2>
+  )
+}
+
+function newestCurrentFiles(entries: RecentEntry[]): RecentFile[] {
+  const seen = new Set<string>()
+  const files: RecentFile[] = []
+
+  for (const entry of entries) {
+    const path = entry.path.replace(/^\/+|\/+$/g, "")
+    if (!path || seen.has(path)) continue
+
+    // Mark the newest event as consumed before filtering deletes. Otherwise an
+    // older write for a now-deleted file could surface later in the response.
+    seen.add(path)
+    if (entry.operation === "delete") continue
+
+    files.push({ ...entry, path })
+    if (files.length === MAX_VISIBLE) break
+  }
+
+  return files
+}
+
+function formatRelativeTime(iso: string): string {
+  const timestamp = new Date(iso).getTime()
+  if (!Number.isFinite(timestamp)) return "recently"
+
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor((Date.now() - timestamp) / 1_000),
+  )
+  if (elapsedSeconds < 60) return "now"
+  if (elapsedSeconds < 3_600) return `${Math.floor(elapsedSeconds / 60)}m ago`
+  if (elapsedSeconds < 86_400) return `${Math.floor(elapsedSeconds / 3_600)}h ago`
+  if (elapsedSeconds < 604_800) return `${Math.floor(elapsedSeconds / 86_400)}d ago`
+
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  })
+}

--- a/live/src/components/layout/Sidebar.tsx
+++ b/live/src/components/layout/Sidebar.tsx
@@ -1,13 +1,121 @@
+import { useEffect, useId, useState, type KeyboardEvent } from "react"
 import { FileTree } from "@/components/file-tree/FileTree"
+import { RecentFiles } from "@/components/file-tree/RecentFiles"
 import { SearchBar } from "@/components/search/SearchBar"
+import { Button } from "@/components/ui/button"
+import { useBrowser } from "@/contexts/browser"
+import { useFileSearch } from "@/stores/file-search"
+
+type SidebarView = "tree" | "recent"
 
 export function Sidebar({ children }: { children?: React.ReactNode }) {
+  const [view, setView] = useState<SidebarView>("tree")
+  const { selectedFile, selectFile } = useBrowser()
+  const search = useFileSearch()
+  const tabsId = useId()
+  const searchActive = search.query.length > 0
+  const activeView: SidebarView = searchActive ? "tree" : view
+  const treeTabId = `${tabsId}-tree-tab`
+  const recentTabId = `${tabsId}-recent-tab`
+  const treePanelId = `${tabsId}-tree-panel`
+  const recentPanelId = `${tabsId}-recent-panel`
+
+  // URL-driven file opens should always reveal the selected row in the tree.
+  // A user may still switch back to Recent afterward without changing files.
+  useEffect(() => {
+    if (selectedFile && !selectedFile.endsWith("/")) setView("tree")
+  }, [selectedFile])
+
+  const selectTab = (next: SidebarView) => {
+    if (next === "recent" && searchActive) return
+    setView(next)
+  }
+
+  const handleTabKeyDown = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    current: SidebarView,
+  ) => {
+    let next: SidebarView | null = null
+    if (event.key === "ArrowLeft" || event.key === "Home") next = "tree"
+    if (event.key === "ArrowRight" || event.key === "End") {
+      next = searchActive ? "tree" : "recent"
+    }
+    if (!next || next === current) return
+
+    event.preventDefault()
+    selectTab(next)
+    const nextId = next === "tree" ? treeTabId : recentTabId
+    requestAnimationFrame(() => document.getElementById(nextId)?.focus())
+  }
+
+  const handleOpenRecent = (path: string) => {
+    setView("tree")
+    selectFile(path)
+  }
+
   return (
     <aside className="flex h-full w-full shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
       <SearchBar />
       {children}
-      <div className="flex-1 overflow-y-auto">
-        <FileTree />
+      <div className="shrink-0 border-b border-sidebar-border px-3 py-2">
+        <div
+          role="tablist"
+          aria-label="File navigation"
+          className="flex rounded-md border border-sidebar-border bg-sidebar-accent/30 p-0.5"
+        >
+          <Button
+            id={treeTabId}
+            type="button"
+            role="tab"
+            aria-selected={activeView === "tree"}
+            aria-controls={treePanelId}
+            tabIndex={activeView === "tree" ? 0 : -1}
+            variant={activeView === "tree" ? "default" : "ghost"}
+            size="xs"
+            className={
+              activeView === "tree"
+                ? "flex-1 bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
+                : "flex-1 text-muted-foreground"
+            }
+            onClick={() => selectTab("tree")}
+            onKeyDown={(event) => handleTabKeyDown(event, "tree")}
+          >
+            Tree
+          </Button>
+          <Button
+            id={recentTabId}
+            type="button"
+            role="tab"
+            aria-selected={activeView === "recent"}
+            aria-controls={recentPanelId}
+            tabIndex={activeView === "recent" ? 0 : -1}
+            variant={activeView === "recent" ? "default" : "ghost"}
+            size="xs"
+            className={
+              activeView === "recent"
+                ? "flex-1 bg-sidebar-primary text-sidebar-primary-foreground shadow-sm"
+                : "flex-1 text-muted-foreground"
+            }
+            disabled={searchActive}
+            title={searchActive ? "Clear search to view recent files" : undefined}
+            onClick={() => selectTab("recent")}
+            onKeyDown={(event) => handleTabKeyDown(event, "recent")}
+          >
+            Recent
+          </Button>
+        </div>
+      </div>
+      <div
+        id={activeView === "tree" ? treePanelId : recentPanelId}
+        role="tabpanel"
+        aria-labelledby={activeView === "tree" ? treeTabId : recentTabId}
+        className="flex-1 overflow-y-auto"
+      >
+        {activeView === "tree" ? (
+          <FileTree />
+        ) : (
+          <RecentFiles onOpenFile={handleOpenRecent} />
+        )}
       </div>
     </aside>
   )

--- a/live/src/components/layout/TopBar.tsx
+++ b/live/src/components/layout/TopBar.tsx
@@ -4,6 +4,7 @@ import { DriveSwitcher } from "./DriveSwitcher"
 import { HealthIndicator } from "./HealthIndicator"
 import { ThemeToggle } from "./ThemeToggle"
 import { AccountSwitcher } from "@/components/AccountSwitcher"
+import { CommentNotifications } from "@/components/comments/CommentNotifications"
 import { Button } from "@/components/ui/button"
 import { Kbd } from "@/components/ui/kbd"
 import {
@@ -24,6 +25,7 @@ export function TopBar({ leading }: { leading?: React.ReactNode }) {
       </div>
       <div className="flex-1" />
       <div className="flex items-center gap-1 shrink-0">
+        <CommentNotifications />
         <HealthIndicator />
         <HelpButton />
         <ThemeToggle />

--- a/live/src/contexts/browser.tsx
+++ b/live/src/contexts/browser.tsx
@@ -1,11 +1,17 @@
-import { createContext, useContext, useState, useCallback, type ReactNode } from "react"
-import { useNavigate } from "react-router"
+import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react"
+import { useLocation, useNavigate } from "react-router"
 import { useAuth } from "./auth"
+import {
+  recentFilesScope,
+  recordRecentFile,
+  useRecentFiles,
+} from "@/stores/recent-files"
 
 interface BrowserContextValue {
   activeDriveId: string
   currentPath: string
   selectedFile: string | null
+  recentFiles: readonly string[]
   navigateToFolder: (path: string) => void
   selectFile: (path: string | null) => void
   setSelectedFile: (path: string | null) => void
@@ -14,10 +20,32 @@ interface BrowserContextValue {
 const BrowserContext = createContext<BrowserContextValue | null>(null)
 
 export function BrowserProvider({ children }: { children: ReactNode }) {
-  const { orgId, driveId } = useAuth()
+  const { credential, orgId, driveId } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
   const [currentPath, setCurrentPath] = useState("")
   const [selectedFile, setSelectedFile] = useState<string | null>(null)
+  const recentScope = orgId && driveId
+    ? recentFilesScope(credential.id, orgId, driveId)
+    : null
+  const recentFiles = useRecentFiles(recentScope)
+
+  // Observe selection rather than only selectFile() so cold deep links and
+  // detail routes are recorded too. The store ignores folder paths.
+  useEffect(() => {
+    if (!recentScope || !selectedFile) return
+
+    // Auth scope updates can briefly precede RouteParamsSync when switching
+    // accounts or drives. Only record when the URL belongs to this scope so a
+    // selection from the previous drive cannot leak into the new history.
+    const routePrefixes = [
+      `/file/~/${orgId}/${driveId}/`,
+      `/detail/~/${orgId}/${driveId}/`,
+    ]
+    if (!routePrefixes.some((prefix) => location.pathname.startsWith(prefix))) return
+
+    recordRecentFile(recentScope, selectedFile)
+  }, [driveId, location.pathname, orgId, recentScope, selectedFile])
 
   const navigateToFolder = useCallback((path: string) => {
     setCurrentPath(path)
@@ -48,6 +76,7 @@ export function BrowserProvider({ children }: { children: ReactNode }) {
         activeDriveId: driveId,
         currentPath,
         selectedFile,
+        recentFiles,
         navigateToFolder,
         selectFile,
         setSelectedFile,

--- a/live/src/hooks/use-comment-notifications.ts
+++ b/live/src/hooks/use-comment-notifications.ts
@@ -1,0 +1,101 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { isUnknownOperationError } from "@/api/errors"
+import { useAuth } from "@/contexts/auth"
+import type {
+  CommentNotificationListResult,
+  CommentNotificationReadResult,
+} from "@/api/types"
+
+type MarkReadParams = Record<string, unknown> & {
+  ids?: string[]
+  all?: boolean
+}
+
+function notificationQueryKey(orgId: string | null, driveId: string) {
+  return ["comment-notifications", orgId, driveId] as const
+}
+
+/**
+ * Poll the per-user comment inbox. Older servers do not expose this op; the
+ * consumer intentionally renders nothing when this query errors so mixed
+ * UI/API deployments remain usable during rollout.
+ */
+export function useCommentNotifications() {
+  const { client, orgId, driveId } = useAuth()
+
+  return useQuery({
+    queryKey: notificationQueryKey(orgId, driveId),
+    queryFn: () =>
+      client.callOp<CommentNotificationListResult>(
+        orgId!,
+        "comment-notification-list",
+        { limit: 30 },
+        driveId,
+      ),
+    enabled: !!orgId && !!driveId,
+    retry: false,
+    refetchInterval: (query) => {
+      if (
+        isUnknownOperationError(
+          query.state.error,
+          "comment-notification-list",
+        )
+      ) {
+        return false
+      }
+      return query.state.status === "error" ? 30_000 : 10_000
+    },
+    refetchOnWindowFocus: false,
+  })
+}
+
+export function useMarkCommentNotificationsRead() {
+  const { client, orgId, driveId } = useAuth()
+  const queryClient = useQueryClient()
+  const queryKey = notificationQueryKey(orgId, driveId)
+
+  return useMutation({
+    mutationFn: (params: MarkReadParams) =>
+      client.callOp<CommentNotificationReadResult>(
+        orgId!,
+        "comment-notification-read",
+        params,
+        driveId,
+      ),
+    onMutate: async (params) => {
+      await queryClient.cancelQueries({ queryKey })
+      const previous = queryClient.getQueryData<CommentNotificationListResult>(queryKey)
+
+      queryClient.setQueryData<CommentNotificationListResult>(queryKey, (current) => {
+        if (!current) return current
+
+        const requested = new Set(params.ids ?? [])
+        let newlyRead = 0
+        const notifications = current.notifications.map((notification) => {
+          const shouldRead = params.all === true || requested.has(notification.id)
+          if (!shouldRead || notification.read) return notification
+          newlyRead += 1
+          return { ...notification, read: true }
+        })
+
+        return {
+          notifications,
+          unreadCount:
+            params.all === true
+              ? 0
+              : Math.max(0, current.unreadCount - newlyRead),
+        }
+      })
+
+      return { previous }
+    },
+    onError: (_error, _params, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous)
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey })
+    },
+  })
+}

--- a/live/src/stores/recent-files.ts
+++ b/live/src/stores/recent-files.ts
@@ -1,0 +1,104 @@
+import { useSyncExternalStore } from "react"
+
+const STORAGE_KEY = "liveui:recent-files:v1"
+const MAX_RECENT_FILES = 25
+const EMPTY_FILES: readonly string[] = []
+
+type Listener = () => void
+type RecentFilesSnapshot = Record<string, readonly string[]>
+
+function normalizeFilePath(path: string): string | null {
+  const normalized = path.replace(/^\/+/, "")
+  if (!normalized || normalized.endsWith("/")) return null
+  return normalized
+}
+
+function sanitizePaths(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return EMPTY_FILES
+
+  const seen = new Set<string>()
+  const paths: string[] = []
+
+  for (const candidate of value) {
+    if (typeof candidate !== "string") continue
+    const path = normalizeFilePath(candidate)
+    if (!path || seen.has(path)) continue
+    seen.add(path)
+    paths.push(path)
+    if (paths.length === MAX_RECENT_FILES) break
+  }
+
+  return paths
+}
+
+function readSnapshot(): RecentFilesSnapshot {
+  try {
+    if (typeof localStorage === "undefined") return {}
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return {}
+
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+
+    return Object.fromEntries(
+      Object.entries(parsed).map(([scope, paths]) => [scope, sanitizePaths(paths)]),
+    )
+  } catch {
+    return {}
+  }
+}
+
+let snapshot = readSnapshot()
+const listeners = new Set<Listener>()
+
+function emit() {
+  listeners.forEach((listener) => listener())
+}
+
+function persist() {
+  try {
+    if (typeof localStorage === "undefined") return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot))
+  } catch {
+    // Ignore quota and privacy-mode errors. Recents are an enhancement only.
+  }
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => listeners.delete(listener)
+}
+
+export function recentFilesScope(
+  credentialId: string,
+  orgId: string,
+  driveId: string,
+): string {
+  return JSON.stringify([credentialId, orgId, driveId])
+}
+
+export function recordRecentFile(scope: string, rawPath: string) {
+  const path = normalizeFilePath(rawPath)
+  if (!scope || !path) return
+
+  const current = snapshot[scope] ?? EMPTY_FILES
+  if (current[0] === path) return
+
+  snapshot = {
+    ...snapshot,
+    [scope]: [path, ...current.filter((candidate) => candidate !== path)].slice(
+      0,
+      MAX_RECENT_FILES,
+    ),
+  }
+  persist()
+  emit()
+}
+
+export function useRecentFiles(scope: string | null): readonly string[] {
+  return useSyncExternalStore(
+    subscribe,
+    () => (scope ? (snapshot[scope] ?? EMPTY_FILES) : EMPTY_FILES),
+    () => EMPTY_FILES,
+  )
+}

--- a/live/src/stores/tree-expansion.ts
+++ b/live/src/stores/tree-expansion.ts
@@ -59,6 +59,26 @@ class TreeExpansionStore {
     this.emit()
   }
 
+  expandMany(paths: Iterable<string>) {
+    let changed = false
+
+    for (const path of paths) {
+      if (!path || this.paths.has(path)) continue
+      this.paths.add(path)
+      this.order.push(path)
+      changed = true
+    }
+
+    if (!changed) return
+
+    while (this.order.length > MAX_PATHS) {
+      const evict = this.order.shift()!
+      this.paths.delete(evict)
+    }
+    this.persist()
+    this.emit()
+  }
+
   collapse(path: string) {
     if (!this.paths.has(path)) return
     this.paths.delete(path)
@@ -143,6 +163,7 @@ export const treeExpansionStore = {
   isExpanded: (path: string) => store.isExpanded(path),
   toggle: (path: string) => store.toggle(path),
   expand: (path: string) => store.expand(path),
+  expandMany: (paths: Iterable<string>) => store.expandMany(paths),
   collapse: (path: string) => store.collapse(path),
   getFocusedPath: () => store.getFocusedPath(),
   setFocusedPath: (path: string | null) => store.setFocusedPath(path),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.10.1",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.10.1"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.11.0",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.11.0"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",

--- a/packages/cli/src/__tests__/comment-command.test.ts
+++ b/packages/cli/src/__tests__/comment-command.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { commentCommands } from "../commands/comment.js";
+import type { ApiClient } from "../api-client.js";
+
+describe("comment commands", () => {
+  test("includes the resolved drive in notification operations", async () => {
+    const calls: Array<{
+      orgId: string;
+      op: string;
+      params: Record<string, unknown>;
+    }> = [];
+    const client = {
+      callOp: async (
+        orgId: string,
+        op: string,
+        params: Record<string, unknown>
+      ) => {
+        calls.push({ orgId, op, params });
+        return { notifications: [], unreadCount: 0 };
+      },
+    } as Pick<ApiClient, "callOp"> as ApiClient;
+
+    const command = commentCommands(
+      client,
+      () => "org-1",
+      (orgId) => {
+        expect(orgId).toBe("org-1");
+        return "drive-2";
+      }
+    );
+
+    await command.parseAsync(["notifications", "--unread"], { from: "user" });
+
+    expect(calls).toEqual([
+      {
+        orgId: "org-1",
+        op: "comment-notification-list",
+        params: { unreadOnly: true, driveId: "drive-2" },
+      },
+    ]);
+  });
+});

--- a/packages/cli/src/commands/comment.ts
+++ b/packages/cli/src/commands/comment.ts
@@ -1,12 +1,18 @@
 import { Command } from "commander";
 import type { ApiClient } from "../api-client.js";
 
-export function commentCommands(client: ApiClient, getOrgId: () => string | Promise<string>) {
+export function commentCommands(
+  client: ApiClient,
+  getOrgId: () => string | Promise<string>,
+  getDriveId: (orgId?: string) => string | Promise<string>
+) {
   const cmd = new Command("comment").description("Document comments");
 
   async function callOp(opName: string, params: Record<string, any>) {
     try {
-      return await client.callOp(await getOrgId(), opName, params);
+      const orgId = await getOrgId();
+      const driveId = await getDriveId(orgId);
+      return await client.callOp(orgId, opName, { ...params, driveId });
     } catch (err: any) {
       if (err?.cause?.code === "ECONNREFUSED" || err?.message?.includes("fetch failed")) {
         console.error(
@@ -151,6 +157,59 @@ export function commentCommands(client: ApiClient, getOrgId: () => string | Prom
     .action(async (id: string) => {
       try {
         const result = await callOp("comment-resolve", { id, resolved: false });
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command("notifications")
+    .option("--unread", "Show unread notifications only")
+    .option("--limit <n>", "Max results (1-100)")
+    .description("List comment notifications for the current user")
+    .action(async (opts: any) => {
+      try {
+        const params: Record<string, any> = {};
+        if (opts.unread) params.unreadOnly = true;
+        if (opts.limit !== undefined) {
+          const limit = Number(opts.limit);
+          if (!Number.isInteger(limit) || limit < 1 || limit > 100) {
+            throw new Error("--limit must be an integer between 1 and 100");
+          }
+          params.limit = limit;
+        }
+        const result = await callOp("comment-notification-list", params);
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  cmd
+    .command("read")
+    .argument("[ids...]", "Notification event IDs")
+    .option("--all", "Mark all notifications in the active drive as read")
+    .description("Mark comment notifications as read")
+    .action(async (ids: string[] | undefined, opts: any) => {
+      try {
+        const notificationIds = ids ?? [];
+        if (opts.all && notificationIds.length > 0) {
+          throw new Error("Provide notification IDs or --all, not both");
+        }
+        if (!opts.all && notificationIds.length === 0) {
+          throw new Error("Provide one or more notification IDs or --all");
+        }
+        if (notificationIds.length > 100) {
+          throw new Error("At most 100 notification IDs can be marked read at once");
+        }
+
+        const params = opts.all
+          ? { all: true }
+          : { ids: notificationIds };
+        const result = await callOp("comment-notification-read", params);
         console.log(JSON.stringify(result, null, 2));
       } catch (err: any) {
         console.error(`Error: ${err.message}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,7 +86,7 @@ program.addCommand(driveCommands(client, getOrgId));
 program.addCommand(orgCommands(client));
 program.addCommand(initCommand());
 program.addCommand(onboardCommand());
-program.addCommand(commentCommands(client, getOrgId));
+program.addCommand(commentCommands(client, getOrgId, getDriveId));
 program.addCommand(memberCommands(client, getOrgId));
 program.addCommand(mountCommand());
 program.addCommand(umountCommand());

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/src/__tests__/rbac-mapping.test.ts
+++ b/packages/core/src/__tests__/rbac-mapping.test.ts
@@ -2,7 +2,10 @@ import { describe, test, expect } from "bun:test";
 import { getRequiredRole } from "../identity/rbac.js";
 
 describe("getRequiredRole", () => {
-  const viewerOps = ["ls", "cat", "tail", "stat", "grep", "fts", "search", "log", "diff", "recent", "signed-url"];
+  const viewerOps = [
+    "ls", "cat", "tail", "stat", "grep", "fts", "search", "log", "diff", "recent", "signed-url",
+    "comment-notification-list", "comment-notification-read",
+  ];
   const editorOps = ["write", "edit", "append", "rm", "mv", "cp", "revert"];
   const adminOps = ["reindex"];
 

--- a/packages/core/src/db/raw.ts
+++ b/packages/core/src/db/raw.ts
@@ -110,6 +110,8 @@ CREATE TABLE IF NOT EXISTS events (
 
 CREATE INDEX IF NOT EXISTS idx_events_resource ON events(resource_type, resource_id);
 CREATE INDEX IF NOT EXISTS idx_events_actor ON events(actor);
+CREATE INDEX IF NOT EXISTS idx_events_notification_inbox
+  ON events(org_id, type, target, status, created_at DESC);
 
 CREATE TABLE IF NOT EXISTS content_chunks (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -2,6 +2,7 @@ import {
   sqliteTable,
   text,
   integer,
+  index,
   primaryKey,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
@@ -154,24 +155,36 @@ export const comments = sqliteTable("comments", {
 });
 
 // events (generic event/notification table)
-export const events = sqliteTable("events", {
-  id: text("id").primaryKey(),
-  orgId: text("org_id")
-    .notNull()
-    .references(() => orgs.id),
-  type: text("type").notNull(),
-  resourceType: text("resource_type").notNull(),
-  resourceId: text("resource_id").notNull(),
-  actor: text("actor")
-    .notNull()
-    .references(() => users.id),
-  target: text("target"),
-  status: text("status", { enum: ["created", "ack", "deleted"] })
-    .notNull()
-    .default("created"),
-  metadata: text("metadata"),
-  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
-});
+export const events = sqliteTable(
+  "events",
+  {
+    id: text("id").primaryKey(),
+    orgId: text("org_id")
+      .notNull()
+      .references(() => orgs.id),
+    type: text("type").notNull(),
+    resourceType: text("resource_type").notNull(),
+    resourceId: text("resource_id").notNull(),
+    actor: text("actor")
+      .notNull()
+      .references(() => users.id),
+    target: text("target"),
+    status: text("status", { enum: ["created", "ack", "deleted"] })
+      .notNull()
+      .default("created"),
+    metadata: text("metadata"),
+    createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  },
+  (table) => ({
+    notificationInboxIdx: index("idx_events_notification_inbox").on(
+      table.orgId,
+      table.type,
+      table.target,
+      table.status,
+      table.createdAt
+    ),
+  })
+);
 
 // content_chunks (for embedding)
 export const contentChunks = sqliteTable("content_chunks", {

--- a/packages/core/src/identity/rbac.ts
+++ b/packages/core/src/identity/rbac.ts
@@ -39,6 +39,8 @@ const OP_ROLES: Record<string, Role> = {
   "comment-add": "editor",
   "comment-list": "viewer",
   "comment-get": "viewer",
+  "comment-notification-list": "viewer",
+  "comment-notification-read": "viewer",
   "comment-update": "editor",
   "comment-delete": "editor",
   "comment-resolve": "editor",

--- a/packages/core/src/ops/__tests__/comment-notification.test.ts
+++ b/packages/core/src/ops/__tests__/comment-notification.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { schema } from "../../db/index.js";
+import { createTestDb } from "../../test-utils.js";
+import { ValidationError } from "../../errors.js";
+import { commentAdd, commentDelete } from "../comment.js";
+import {
+  commentNotificationList,
+  commentNotificationRead,
+} from "../comment-notification.js";
+import type { OpContext } from "../types.js";
+
+const ORG_1 = "notification-org-1";
+const ORG_2 = "notification-org-2";
+const DRIVE_1 = "notification-drive-1";
+const DRIVE_2 = "notification-drive-2";
+const DRIVE_3 = "notification-drive-3";
+const USER_A = "notification-user-a";
+const USER_B = "notification-user-b";
+const USER_C = "notification-user-c";
+const USER_D = "notification-user-d";
+
+function createFixture() {
+  const db = createTestDb();
+  const now = new Date();
+
+  for (const [id, email] of [
+    [USER_A, "notification-a@test.com"],
+    [USER_B, "notification-b@test.com"],
+    [USER_C, "notification-c@test.com"],
+    [USER_D, "notification-d@test.com"],
+  ] as const) {
+    db.insert(schema.users)
+      .values({ id, email, apiKeyHash: id, createdAt: now })
+      .run();
+  }
+
+  db.insert(schema.orgs)
+    .values([
+      { id: ORG_1, name: "Notification Org 1", createdAt: now },
+      { id: ORG_2, name: "Notification Org 2", createdAt: now },
+    ])
+    .run();
+  db.insert(schema.drives)
+    .values([
+      { id: DRIVE_1, orgId: ORG_1, name: "Drive 1", createdAt: now },
+      { id: DRIVE_2, orgId: ORG_1, name: "Drive 2", createdAt: now },
+      { id: DRIVE_3, orgId: ORG_2, name: "Drive 3", createdAt: now },
+    ])
+    .run();
+  db.insert(schema.orgMembers)
+    .values([
+      { orgId: ORG_1, userId: USER_A, role: "editor" },
+      { orgId: ORG_1, userId: USER_B, role: "viewer" },
+      { orgId: ORG_1, userId: USER_C, role: "editor" },
+      { orgId: ORG_2, userId: USER_B, role: "viewer" },
+      { orgId: ORG_2, userId: USER_D, role: "editor" },
+    ])
+    .run();
+  db.insert(schema.driveMembers)
+    .values([
+      { driveId: DRIVE_1, userId: USER_A, role: "editor" },
+      { driveId: DRIVE_1, userId: USER_B, role: "viewer" },
+      { driveId: DRIVE_2, userId: USER_C, role: "editor" },
+      { driveId: DRIVE_2, userId: USER_B, role: "viewer" },
+      { driveId: DRIVE_3, userId: USER_D, role: "editor" },
+      { driveId: DRIVE_3, userId: USER_B, role: "viewer" },
+    ])
+    .run();
+
+  const ctx = (orgId: string, driveId: string, userId: string): OpContext => ({
+    db,
+    s3: null as any,
+    orgId,
+    driveId,
+    userId,
+  });
+
+  return {
+    db,
+    ctxA1: ctx(ORG_1, DRIVE_1, USER_A),
+    ctxB1: ctx(ORG_1, DRIVE_1, USER_B),
+    ctxB2: ctx(ORG_1, DRIVE_2, USER_B),
+    ctxB3: ctx(ORG_2, DRIVE_3, USER_B),
+    ctxC2: ctx(ORG_1, DRIVE_2, USER_C),
+    ctxD3: ctx(ORG_2, DRIVE_3, USER_D),
+  };
+}
+
+describe("comment notifications", () => {
+  test("requires notification IDs or all=true when marking read", async () => {
+    const { ctxB1 } = createFixture();
+
+    await expect(commentNotificationRead(ctxB1, {})).rejects.toThrow(
+      ValidationError
+    );
+    await expect(
+      commentNotificationRead(ctxB1, { ids: ["notification-id"], all: true })
+    ).rejects.toThrow(ValidationError);
+  });
+
+  test("emits one targeted notification per other current drive member", async () => {
+    const { db, ctxA1, ctxB1, ctxB2 } = createFixture();
+    const comment = await commentAdd(ctxA1, {
+      path: "/docs/notification.md",
+      body: "Please review this",
+    });
+
+    const events = db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.type, "comment_notification"))
+      .all();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      resourceType: "comment",
+      resourceId: comment.id,
+      actor: USER_A,
+      target: USER_B,
+      status: "created",
+    });
+
+    const recipient = await commentNotificationList(ctxB1, {});
+    expect(recipient.unreadCount).toBe(1);
+    expect(recipient.notifications).toEqual([
+      expect.objectContaining({
+        id: events[0].id,
+        commentId: comment.id,
+        path: "/docs/notification.md",
+        body: "Please review this",
+        actor: USER_A,
+        read: false,
+      }),
+    ]);
+
+    expect((await commentNotificationList(ctxA1, {})).notifications).toEqual([]);
+    expect((await commentNotificationList(ctxB2, {})).notifications).toEqual([]);
+
+    // The existing target-less lifecycle event remains audit-only and is not
+    // interpreted as an unread notification by the new API.
+    const auditEvent = db
+      .select()
+      .from(schema.events)
+      .where(
+        and(
+          eq(schema.events.type, "comment_created"),
+          eq(schema.events.resourceId, comment.id)
+        )
+      )
+      .get();
+    expect(auditEvent?.target).toBeNull();
+  });
+
+  test("notifies for replies and includes the parent ID", async () => {
+    const { ctxA1, ctxB1 } = createFixture();
+    const root = await commentAdd(ctxA1, {
+      path: "/docs/thread.md",
+      body: "Root",
+    });
+    const reply = await commentAdd(ctxA1, {
+      parentId: root.id,
+      body: "Reply",
+    });
+
+    const result = await commentNotificationList(ctxB1, {});
+    const replyNotification = result.notifications.find(
+      (notification) => notification.commentId === reply.id
+    );
+    expect(replyNotification).toMatchObject({
+      parentId: root.id,
+      path: "/docs/thread.md",
+      body: "Reply",
+    });
+  });
+
+  test("marks selected or all active-drive notifications as read", async () => {
+    const { db, ctxA1, ctxB1 } = createFixture();
+    await commentAdd(ctxA1, { path: "/docs/one.md", body: "One" });
+    await commentAdd(ctxA1, { path: "/docs/two.md", body: "Two" });
+
+    const initial = await commentNotificationList(ctxB1, {});
+    expect(initial.unreadCount).toBe(2);
+
+    expect(
+      await commentNotificationRead(ctxB1, { ids: [initial.notifications[0].id] })
+    ).toEqual({ markedRead: 1 });
+    expect(
+      await commentNotificationRead(ctxB1, { ids: [initial.notifications[0].id] })
+    ).toEqual({ markedRead: 0 });
+
+    const partiallyRead = await commentNotificationList(ctxB1, {});
+    expect(partiallyRead.unreadCount).toBe(1);
+    expect(partiallyRead.notifications.filter((item) => item.read)).toHaveLength(1);
+    const readNotification = partiallyRead.notifications.find((item) => item.read)!;
+    const unreadNotification = partiallyRead.notifications.find((item) => !item.read)!;
+    db.update(schema.events)
+      .set({ createdAt: new Date(Date.now() + 60_000) })
+      .where(eq(schema.events.id, readNotification.id))
+      .run();
+    expect(
+      (await commentNotificationList(ctxB1, { limit: 1 })).notifications[0].id
+    ).toBe(unreadNotification.id);
+    expect(
+      (await commentNotificationList(ctxB1, { unreadOnly: true })).notifications
+    ).toHaveLength(1);
+
+    expect(await commentNotificationRead(ctxB1, { all: true })).toEqual({
+      markedRead: 1,
+    });
+    expect((await commentNotificationList(ctxB1, {})).unreadCount).toBe(0);
+  });
+
+  test("read operations cannot cross user, drive, or org boundaries", async () => {
+    const { db, ctxA1, ctxB1, ctxB2, ctxB3, ctxC2, ctxD3 } = createFixture();
+    await commentAdd(ctxA1, { path: "/drive-1.md", body: "Drive 1" });
+    await commentAdd(ctxC2, { path: "/drive-2.md", body: "Drive 2" });
+    await commentAdd(ctxD3, { path: "/drive-3.md", body: "Drive 3" });
+
+    const drive1Notification = (await commentNotificationList(ctxB1, {}))
+      .notifications[0];
+    expect(drive1Notification).toBeDefined();
+    expect((await commentNotificationList(ctxB2, {})).notifications).toHaveLength(1);
+    expect((await commentNotificationList(ctxB3, {})).notifications).toHaveLength(1);
+
+    expect(
+      await commentNotificationRead(ctxA1, { ids: [drive1Notification.id] })
+    ).toEqual({ markedRead: 0 });
+    expect(
+      await commentNotificationRead(ctxB2, { ids: [drive1Notification.id] })
+    ).toEqual({ markedRead: 0 });
+    expect(
+      await commentNotificationRead(ctxB3, { ids: [drive1Notification.id] })
+    ).toEqual({ markedRead: 0 });
+
+    expect(
+      db
+        .select({ status: schema.events.status })
+        .from(schema.events)
+        .where(eq(schema.events.id, drive1Notification.id))
+        .get()?.status
+    ).toBe("created");
+    expect(
+      await commentNotificationRead(ctxB1, { ids: [drive1Notification.id] })
+    ).toEqual({ markedRead: 1 });
+  });
+
+  test("does not return notifications whose comments were deleted", async () => {
+    const { ctxA1, ctxB1 } = createFixture();
+    const comment = await commentAdd(ctxA1, {
+      path: "/docs/deleted.md",
+      body: "Delete me",
+    });
+    await commentDelete(ctxA1, { id: comment.id });
+
+    expect(await commentNotificationList(ctxB1, {})).toEqual({
+      notifications: [],
+      unreadCount: 0,
+    });
+  });
+});

--- a/packages/core/src/ops/__tests__/ops.test.ts
+++ b/packages/core/src/ops/__tests__/ops.test.ts
@@ -328,7 +328,7 @@ describe.skipIf(SKIP)("recent", () => {
 describe.skipIf(SKIP)("op registry", () => {
   test("all ops are registered", () => {
     const ops = getRegisteredOps();
-    expect(ops.length).toBe(29);
+    expect(ops.length).toBe(31);
     expect(ops).toContain("write");
     expect(ops).toContain("cat");
     expect(ops).toContain("edit");
@@ -338,6 +338,8 @@ describe.skipIf(SKIP)("op registry", () => {
     expect(ops).toContain("search");
     expect(ops).toContain("reindex");
     expect(ops).toContain("tree");
+    expect(ops).toContain("comment-notification-list");
+    expect(ops).toContain("comment-notification-read");
     expect(ops).toContain("glob");
     expect(ops).toContain("sql");
   });

--- a/packages/core/src/ops/__tests__/registry.test.ts
+++ b/packages/core/src/ops/__tests__/registry.test.ts
@@ -7,11 +7,12 @@ describe("Op Registry", () => {
     "tail", "log", "diff", "revert", "recent",
     "grep", "fts", "search", "vec-search", "reindex", "tree", "glob", "sql", "signed-url",
     "comment-add", "comment-list", "comment-get", "comment-update", "comment-delete", "comment-resolve",
+    "comment-notification-list", "comment-notification-read",
   ];
 
-  test("getRegisteredOps returns all 29 ops", () => {
+  test("getRegisteredOps returns all 31 ops", () => {
     const ops = getRegisteredOps();
-    expect(ops.length).toBe(29);
+    expect(ops.length).toBe(31);
     for (const op of expectedOps) {
       expect(ops).toContain(op);
     }

--- a/packages/core/src/ops/comment-notification.ts
+++ b/packages/core/src/ops/comment-notification.ts
@@ -1,0 +1,174 @@
+import { and, count, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import { schema } from "../db/index.js";
+import { ValidationError } from "../errors.js";
+import type {
+  CommentNotificationEntry,
+  CommentNotificationListParams,
+  CommentNotificationListResult,
+  CommentNotificationReadParams,
+  CommentNotificationReadResult,
+  OpContext,
+} from "./types.js";
+
+const NOTIFICATION_TYPE = "comment_notification";
+const DEFAULT_LIMIT = 50;
+const READ_BATCH_SIZE = 500;
+
+function notificationScope(ctx: OpContext) {
+  return [
+    eq(schema.events.orgId, ctx.orgId),
+    eq(schema.events.type, NOTIFICATION_TYPE),
+    eq(schema.events.resourceType, "comment"),
+    eq(schema.events.target, ctx.userId),
+    eq(schema.comments.orgId, ctx.orgId),
+    eq(schema.comments.driveId, ctx.driveId),
+    eq(schema.comments.isDeleted, false),
+  ];
+}
+
+export async function commentNotificationList(
+  ctx: OpContext,
+  params: CommentNotificationListParams
+): Promise<CommentNotificationListResult> {
+  const conditions = [
+    ...notificationScope(ctx),
+    ne(schema.events.status, "deleted"),
+  ];
+
+  if (params.unreadOnly) {
+    conditions.push(eq(schema.events.status, "created"));
+  }
+
+  const rows = ctx.db
+    .select({
+      id: schema.events.id,
+      commentId: schema.comments.id,
+      parentId: schema.comments.parentId,
+      path: schema.comments.path,
+      body: schema.comments.body,
+      actor: schema.events.actor,
+      createdAt: schema.events.createdAt,
+      status: schema.events.status,
+    })
+    .from(schema.events)
+    .innerJoin(
+      schema.comments,
+      and(
+        eq(schema.events.resourceId, schema.comments.id),
+        eq(schema.events.resourceType, "comment")
+      )
+    )
+    .where(and(...conditions))
+    // Keep every unread item reachable even when the inbox contains more than
+    // one page of already-read history. Within each state, show newest first.
+    .orderBy(
+      sql`CASE WHEN ${schema.events.status} = 'created' THEN 0 ELSE 1 END`,
+      desc(schema.events.createdAt)
+    )
+    .limit(params.limit ?? DEFAULT_LIMIT)
+    .offset(params.offset ?? 0)
+    .all();
+
+  const unread = ctx.db
+    .select({ value: count() })
+    .from(schema.events)
+    .innerJoin(
+      schema.comments,
+      and(
+        eq(schema.events.resourceId, schema.comments.id),
+        eq(schema.events.resourceType, "comment")
+      )
+    )
+    .where(
+      and(
+        ...notificationScope(ctx),
+        eq(schema.events.status, "created")
+      )
+    )
+    .get();
+
+  const notifications: CommentNotificationEntry[] = rows.map((row) => ({
+    id: row.id,
+    commentId: row.commentId,
+    parentId: row.parentId ?? undefined,
+    path: row.path,
+    body: row.body,
+    actor: row.actor,
+    createdAt: row.createdAt,
+    read: row.status === "ack",
+  }));
+
+  return {
+    notifications,
+    unreadCount: Number(unread?.value ?? 0),
+  };
+}
+
+export async function commentNotificationRead(
+  ctx: OpContext,
+  params: CommentNotificationReadParams
+): Promise<CommentNotificationReadResult> {
+  if (params.all === true && params.ids && params.ids.length > 0) {
+    throw new ValidationError("Provide notification IDs or set all=true, not both", {
+      suggestion: "Remove ids to mark all notifications, or omit all to mark selected IDs",
+    });
+  }
+
+  if (params.all !== true && (!params.ids || params.ids.length === 0)) {
+    throw new ValidationError("Provide notification IDs or set all=true", {
+      suggestion: "Pass ids: [...] to mark selected notifications, or all: true",
+    });
+  }
+
+  const conditions = [
+    ...notificationScope(ctx),
+    eq(schema.events.status, "created"),
+  ];
+
+  if (!params.all) {
+    const ids = params.ids ?? [];
+    if (ids.length === 0) {
+      return { markedRead: 0 };
+    }
+    conditions.push(inArray(schema.events.id, ids));
+  }
+
+  // Resolve IDs through the comments join first. Events do not carry drive_id,
+  // so updating only by event ID/target would allow a known ID from another
+  // drive to cross the active drive boundary.
+  const scopedIds = ctx.db
+    .select({ id: schema.events.id })
+    .from(schema.events)
+    .innerJoin(
+      schema.comments,
+      and(
+        eq(schema.events.resourceId, schema.comments.id),
+        eq(schema.events.resourceType, "comment")
+      )
+    )
+    .where(and(...conditions))
+    .all()
+    .map((row) => row.id);
+
+  let markedRead = 0;
+  for (let offset = 0; offset < scopedIds.length; offset += READ_BATCH_SIZE) {
+    const batch = scopedIds.slice(offset, offset + READ_BATCH_SIZE);
+    const updated = ctx.db
+      .update(schema.events)
+      .set({ status: "ack" })
+      .where(
+        and(
+          inArray(schema.events.id, batch),
+          eq(schema.events.orgId, ctx.orgId),
+          eq(schema.events.target, ctx.userId),
+          eq(schema.events.type, NOTIFICATION_TYPE),
+          eq(schema.events.status, "created")
+        )
+      )
+      .returning({ id: schema.events.id })
+      .all();
+    markedRead += updated.length;
+  }
+
+  return { markedRead };
+}

--- a/packages/core/src/ops/comment.ts
+++ b/packages/core/src/ops/comment.ts
@@ -1,4 +1,4 @@
-import { eq, and, sql, desc } from "drizzle-orm";
+import { eq, and, sql, desc, ne } from "drizzle-orm";
 import { schema } from "../db/index.js";
 import type {
   OpContext,
@@ -45,6 +45,45 @@ function emitEvent(
       metadata: params.metadata ? JSON.stringify(params.metadata) : null,
       createdAt: new Date(),
     })
+    .run();
+}
+
+function emitCommentNotifications(
+  ctx: OpContext,
+  params: { commentId: string; path: string; parentId?: string; createdAt: Date }
+) {
+  const recipients = ctx.db
+    .select({ userId: schema.driveMembers.userId })
+    .from(schema.driveMembers)
+    .where(
+      and(
+        eq(schema.driveMembers.driveId, ctx.driveId),
+        ne(schema.driveMembers.userId, ctx.userId)
+      )
+    )
+    .all();
+
+  if (recipients.length === 0) return;
+
+  ctx.db
+    .insert(schema.events)
+    .values(
+      recipients.map(({ userId }) => ({
+        id: crypto.randomUUID(),
+        orgId: ctx.orgId,
+        type: "comment_notification",
+        resourceType: "comment",
+        resourceId: params.commentId,
+        actor: ctx.userId,
+        target: userId,
+        status: "created" as const,
+        metadata: JSON.stringify({
+          path: params.path,
+          parentId: params.parentId,
+        }),
+        createdAt: params.createdAt,
+      }))
+    )
     .run();
 }
 
@@ -170,6 +209,12 @@ export async function commentAdd(
     resourceType: "comment",
     resourceId: id,
     metadata: { path, parentId: params.parentId },
+  });
+  emitCommentNotifications(ctx, {
+    commentId: id,
+    path,
+    parentId: params.parentId,
+    createdAt: now,
   });
 
   return {

--- a/packages/core/src/ops/index.ts
+++ b/packages/core/src/ops/index.ts
@@ -33,6 +33,10 @@ import {
   commentDelete,
   commentResolve,
 } from "./comment.js";
+import {
+  commentNotificationList,
+  commentNotificationRead,
+} from "./comment-notification.js";
 
 export interface OpDefinition {
   description: string;
@@ -299,6 +303,23 @@ const opRegistry: Record<string, OpDefinition> = {
       resolved: z.boolean(),
     }),
   },
+  "comment-notification-list": {
+    description: "List comment notifications for the current user in the active drive. Returns { notifications, unreadCount }.",
+    handler: commentNotificationList,
+    schema: z.object({
+      unreadOnly: z.boolean().optional(),
+      limit: z.number().int().min(1).max(100).optional(),
+      offset: z.number().int().min(0).optional(),
+    }),
+  },
+  "comment-notification-read": {
+    description: "Mark selected comment notification IDs, or all comment notifications in the active drive, as read. Returns { markedRead }.",
+    handler: commentNotificationRead,
+    schema: z.object({
+      ids: z.array(z.string()).min(1).max(100).optional(),
+      all: z.literal(true).optional(),
+    }),
+  },
 };
 
 export async function dispatchOp(
@@ -346,5 +367,5 @@ export function getOpDefinition(name: string): OpDefinition | undefined {
 }
 
 // Re-export individual ops for direct use
-export { write, writeRaw, cat, edit, append, ls, stat, rm, mv, cp, tail, log, diff, revert, recent, grep, fts, search, vecSearch, reindex, tree, glob, sql, signedUrl, commentAdd, commentList, commentGet, commentUpdate, commentDelete, commentResolve };
+export { write, writeRaw, cat, edit, append, ls, stat, rm, mv, cp, tail, log, diff, revert, recent, grep, fts, search, vecSearch, reindex, tree, glob, sql, signedUrl, commentAdd, commentList, commentGet, commentUpdate, commentDelete, commentResolve, commentNotificationList, commentNotificationRead };
 export type * from "./types.js";

--- a/packages/core/src/ops/types.ts
+++ b/packages/core/src/ops/types.ts
@@ -310,6 +310,40 @@ export interface CommentResolveResult {
   resolvedAt?: Date;
 }
 
+export interface CommentNotificationListParams {
+  unreadOnly?: boolean;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CommentNotificationEntry {
+  /** Notification event ID. */
+  id: string;
+  commentId: string;
+  parentId?: string;
+  path: string;
+  body: string;
+  actor: string;
+  createdAt: Date;
+  read: boolean;
+}
+
+export interface CommentNotificationListResult {
+  notifications: CommentNotificationEntry[];
+  unreadCount: number;
+}
+
+export interface CommentNotificationReadParams {
+  /** Mark only these notification event IDs as read. */
+  ids?: string[];
+  /** Mark every unread comment notification in the active drive as read. */
+  all?: boolean;
+}
+
+export interface CommentNotificationReadResult {
+  markedRead: number;
+}
+
 // --- Tree types ---
 
 export interface TreeParams {

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -1783,6 +1783,8 @@ async function runStandardTests(daemonUrl: string) {
   });
 
   let user3ApiKey = "";
+  let user3PersonalOrgId = "";
+  let user3PersonalDriveId = "";
   await test("rbac: register third user", async () => {
     const res = await fetch(`${daemonUrl}/auth/register`, {
       method: "POST",
@@ -1792,7 +1794,17 @@ async function runStandardTests(daemonUrl: string) {
     assert(res.ok, true, `Expected 200, got ${res.status}`);
     const data = await res.json() as any;
     user3ApiKey = data.apiKey;
+    user3PersonalOrgId = data.orgId;
     assert(!!user3ApiKey, true, "Expected API key for user3");
+    assert(!!user3PersonalOrgId, true, "Expected personal org ID for user3");
+
+    const drivesRes = await fetch(`${daemonUrl}/orgs/${user3PersonalOrgId}/drives`, {
+      headers: authed(user3ApiKey),
+    });
+    assert(drivesRes.ok, true, `Expected 200, got ${drivesRes.status}`);
+    const drives = ((await drivesRes.json()) as any).drives;
+    user3PersonalDriveId = drives[0]?.id;
+    assert(!!user3PersonalDriveId, true, "Expected personal drive ID for user3");
   });
 
   await test("rbac: invite user3 to second org as viewer", async () => {
@@ -1937,6 +1949,122 @@ async function runStandardTests(daemonUrl: string) {
     });
     assert(res.status, 403, `Expected 403, got ${res.status}`);
     assert(((await res.json()) as any).error, "PERMISSION_DENIED");
+  });
+
+  await test("rbac: comment notifications are target and drive scoped", async () => {
+    const addRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({
+        op: "comment-add",
+        driveId: secondDriveId,
+        path: "/rbac-probe.txt",
+        body: "notification scope probe",
+      }),
+    });
+    assert(addRes.ok, true, `comment-add failed: ${addRes.status}`);
+    const commentId = ((await addRes.json()) as any).id;
+    assert(!!commentId, true, "Expected comment ID");
+
+    const user3ListRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({
+        op: "comment-notification-list",
+        driveId: secondDriveId,
+        unreadOnly: true,
+      }),
+    });
+    assert(user3ListRes.ok, true, `notification list failed: ${user3ListRes.status}`);
+    const user3List = await user3ListRes.json() as any;
+    const notification = user3List.notifications.find((entry: any) => entry.commentId === commentId);
+    assert(!!notification, true, "Expected user3 to receive the comment notification");
+    assert(notification.read, false, "Expected notification to be unread");
+    assert(user3List.unreadCount >= 1, true, "Expected a positive unread count");
+
+    const actorListRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({
+        op: "comment-notification-list",
+        driveId: secondDriveId,
+        unreadOnly: true,
+      }),
+    });
+    assert(actorListRes.ok, true, `actor notification list failed: ${actorListRes.status}`);
+    const actorList = await actorListRes.json() as any;
+    assert(
+      actorList.notifications.some((entry: any) => entry.commentId === commentId),
+      false,
+      "Expected comment author to receive no self-notification",
+    );
+
+    const crossUserReadRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(apiKey),
+      body: JSON.stringify({
+        op: "comment-notification-read",
+        driveId: secondDriveId,
+        ids: [notification.id],
+      }),
+    });
+    assert(crossUserReadRes.ok, true, `cross-user read failed: ${crossUserReadRes.status}`);
+    assert(((await crossUserReadRes.json()) as any).markedRead, 0);
+
+    const crossDriveReadRes = await fetch(`${daemonUrl}/orgs/${user3PersonalOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({
+        op: "comment-notification-read",
+        driveId: user3PersonalDriveId,
+        ids: [notification.id],
+      }),
+    });
+    assert(crossDriveReadRes.ok, true, `cross-drive read failed: ${crossDriveReadRes.status}`);
+    assert(((await crossDriveReadRes.json()) as any).markedRead, 0);
+
+    const stillUnreadRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({
+        op: "comment-notification-list",
+        driveId: secondDriveId,
+        unreadOnly: true,
+      }),
+    });
+    assert(stillUnreadRes.ok, true, `notification list failed: ${stillUnreadRes.status}`);
+    const stillUnread = await stillUnreadRes.json() as any;
+    assert(
+      stillUnread.notifications.some((entry: any) => entry.id === notification.id),
+      true,
+      "Expected scoped-out reads to leave the notification unread",
+    );
+
+    const readRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({
+        op: "comment-notification-read",
+        driveId: secondDriveId,
+        ids: [notification.id],
+      }),
+    });
+    assert(readRes.ok, true, `notification read failed: ${readRes.status}`);
+    assert(((await readRes.json()) as any).markedRead, 1);
+
+    const afterReadRes = await fetch(`${daemonUrl}/orgs/${secondOrgId}/ops`, {
+      method: "POST",
+      headers: authed(user3ApiKey),
+      body: JSON.stringify({
+        op: "comment-notification-list",
+        driveId: secondDriveId,
+      }),
+    });
+    assert(afterReadRes.ok, true, `notification list failed: ${afterReadRes.status}`);
+    const afterRead = await afterReadRes.json() as any;
+    const readNotification = afterRead.notifications.find((entry: any) => entry.id === notification.id);
+    assert(!!readNotification, true, "Expected acknowledged notification in the full list");
+    assert(readNotification.read, true, "Expected notification to be marked read");
   });
 
   await test("rbac: comment IDs are org/drive scoped (cross-tenant 404)", async () => {

--- a/skills/agent-fs/SKILL.md
+++ b/skills/agent-fs/SKILL.md
@@ -182,6 +182,8 @@ Supported formats: csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also `.gz` 
 | `comment update` | `agent-fs comment update <id> --body <text>` | Update a comment (author only) |
 | `comment delete` | `agent-fs comment delete <id>` | Soft-delete a comment (author only) |
 | `comment resolve` | `agent-fs comment resolve <id>` | Resolve a comment |
+| `comment notifications` | `agent-fs comment notifications [--unread] [--limit <n>]` | List comment notifications for the current user in the active drive |
+| `comment read` | `agent-fs comment read [ids...] [--all]` | Mark selected notification event IDs, or all active-drive notifications, as read |
 
 ### Setup & Auth
 
@@ -320,6 +322,15 @@ agent-fs comment reply <comment-id> --body "Added in v3"
 
 # List comments
 agent-fs comment list docs/spec.md
+
+# Check unread notifications (the returned IDs are notification event IDs)
+agent-fs comment notifications --unread --limit 20
+
+# Mark selected notifications as read
+agent-fs comment read <notification-id> [<notification-id>...]
+
+# Or acknowledge every notification in the active drive
+agent-fs comment read --all
 
 # Resolve a comment
 agent-fs comment resolve <comment-id>


### PR DESCRIPTION
## Summary

- add a clear `Tree | Recent` sidebar switcher with drive-scoped, localStorage-backed recently viewed files
- reveal opened files by expanding and refreshing their ancestor listings, then centering the selected tree row
- add a collapsible, persisted `Recently changed` section to the drive root for newly created and updated files
- add per-user comment notifications with unread/read state, mark-selected and mark-all operations, tenant/drive isolation, and backward-compatible Live polling
- expose comment notification list/read commands through the CLI and agent-fs skill, add inbox indexing, and bump coordinated package/plugin versions to `0.11.0`

## Why

The Live file browser did not preserve recent navigation, deep-linked files could remain hidden in collapsed or stale tree branches, drive-level file activity was not visible on the root page, and comment activity had no per-user notification/read state.

## Impact

Users can return to recently viewed files, reliably locate the active file in the tree, see recent drive changes, and manage comment notifications from both Live and the CLI. New Live clients remain usable against older servers: unsupported notification operations stay hidden, while transient polling errors continue retrying.

## Validation

- `bun --env-file=/dev/null run typecheck`
- `bun --env-file=/dev/null test packages/*/src/` — 466 passed, 57 skipped, 0 failed
- `pnpm --dir live build`
- `bun --env-file=/dev/null run build:npm` in `packages/cli`
- sandbox-safe full E2E — 126/128 passed; the new comment notification target/drive-scoping scenario passed, 10 FUSE tests skipped on Darwin
  - remaining failures were local embedding `vec-search` and hybrid `search`, both `Error: Failed to create context`
