### PR TITLE
fix: stop full search-index scans on every write (70 s event-loop stalls), migrate to Bun 1.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-fs",
   "description": "Agent-first filesystem CLI — store, search, and version files backed by S3",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "desplega-ai"
   },

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -35,6 +35,8 @@ jobs:
           fetch-depth: 0 # need full history + tags to test tag existence
 
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
 
       # Hard gate: a partial bump (root moved, sub-packages/Cargo.toml/plugin
       # left behind) fails here instead of shipping a broken version set.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
       - run: bun install --frozen-lockfile
       # Catches a partial version bump (root package.json moved but the
       # sub-packages, Cargo.toml, or plugin.json were left behind) on the PR
@@ -45,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.4.0"
       - run: bun install --frozen-lockfile
       - name: Run local-filesystem E2E suite
         run: bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --" --local-only

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,6 +31,8 @@ jobs:
           ref: ${{ inputs.tag || github.ref_name }}
 
       - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: "1.4.0"
 
       - name: Verify tag matches package.json version
         id: pkg
@@ -206,6 +208,8 @@ jobs:
           ref: ${{ needs.validate.outputs.release_tag }}
 
       - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: "1.4.0"
 
       - name: Download linux-x64 artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -253,6 +257,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
+        with:
+          bun-version: "1.4.0"
 
       - run: bun install --frozen-lockfile
       - run: bun run build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-fs-fuse"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,7 +16,7 @@ Full process, version-sync rules, and recovery steps: **[RELEASING.md](./RELEASI
 
 - **Name:** `@desplega.ai/agent-fs`
 - **Scope:** public
-- **Runtime:** Bun-only (`engines.bun >= 1.2.0`)
+- **Runtime:** Bun-only (`engines.bun >= 1.4.0`)
 - **Contents:** Bundled CLI (`dist/cli.js`) with external npm dependencies
 
 ### just-bash Adapter Package
@@ -124,6 +124,17 @@ curl -X POST https://your-app.fly.dev/auth/register \
 | `performance-1x` | 1 dedicated | 2 GB | Production, heavy embedding workloads |
 
 The default `fly.toml` uses `shared-cpu-1x` with 512 MB. Adjust in `fly.toml` under `[[vm]]` or pass the instance size when prompted by the deploy script.
+
+## Upgrading to 0.13.1: search index migration
+
+0.13.1 changes how the full-text index is stored. Before, every write (including binary uploads) scanned the whole index twice to find one row, which on a GB-scale index froze the daemon for tens of seconds per write. The new layout keys the index by `(drive, path)`, so writes are constant-time again.
+
+Existing databases migrate themselves on the first start of 0.13.1:
+
+1. **At startup, before listening:** one new index on `content_chunks` is built. This reads the table once. Budget roughly 10-20 s per GB of database on a laptop, several minutes on a `shared-cpu-1x` Fly machine. `/health` is not served during this step.
+2. **In the background, after listening:** the old index rows are copied into the new layout in small committed batches. Progress is logged as `search index migration: ...`. A restart resumes where it left off. Search stays complete during the copy: both layouts are queried until the copy finishes. Expect a few multi-second stalls on large indexes (FTS5 merges and the final drop of the old table), then nothing.
+
+Nothing to do by hand. If you prefer the startup cost outside a traffic window, start the new version once off-peak. If search results ever look incomplete after an upgrade, `agent-fs reindex` rebuilds the index from storage.
 
 ## Environment Variables Reference
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.4 AS builder
 
 WORKDIR /app
 COPY package.json bun.lock ./
@@ -18,7 +18,7 @@ RUN bun install --frozen-lockfile
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1-slim
+FROM oven/bun:1.4-slim
 
 WORKDIR /app
 COPY --from=builder /app/package.json /app/bun.lock ./

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ agent-fs was built to power the shared filesystem in [agent-swarm](https://githu
 
 ### Install
 
-Requires [Bun](https://bun.sh) >= 1.2.0.
+Requires [Bun](https://bun.sh) >= 1.4.0.
 
 ```bash
 bun add -g @desplega.ai/agent-fs

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "agent-fs",
       "devDependencies": {
         "@duckdb/node-api": "1.5.3-r.3",
-        "bun-types": "^1.2.0",
+        "bun-types": "^1.4.0",
         "typescript": "^5.7.0",
         "yaml": "^2.8.2",
         "zod-to-json-schema": "^3.25.1",
@@ -14,7 +14,7 @@
     },
     "packages/cli": {
       "name": "@desplega.ai/agent-fs",
-      "version": "0.9.0",
+      "version": "0.13.0",
       "bin": {
         "agent-fs": "dist/cli.js",
       },
@@ -46,7 +46,7 @@
     },
     "packages/core": {
       "name": "@desplega.ai/agent-fs-core",
-      "version": "0.9.0",
+      "version": "0.13.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.750.0",
         "@aws-sdk/s3-request-presigner": "^3.750.0",
@@ -62,22 +62,22 @@
         "zod": "^3.24.0",
       },
       "devDependencies": {
-        "bun-types": "^1.2.0",
+        "bun-types": "^1.4.0",
         "drizzle-kit": "^0.30.0",
         "typescript": "^5.7.0",
       },
     },
     "packages/fuse-helper-linux-arm64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-      "version": "0.9.0",
+      "version": "0.13.0",
     },
     "packages/fuse-helper-linux-x64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-      "version": "0.9.0",
+      "version": "0.13.0",
     },
     "packages/just-bash": {
       "name": "@desplega.ai/agent-fs-just-bash",
-      "version": "0.9.0",
+      "version": "0.13.0",
       "peerDependencies": {
         "just-bash": ">=3.0.1",
       },
@@ -87,7 +87,7 @@
     },
     "packages/mcp": {
       "name": "@desplega.ai/agent-fs-mcp",
-      "version": "0.9.0",
+      "version": "0.13.0",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -96,7 +96,7 @@
     },
     "packages/server": {
       "name": "@desplega.ai/agent-fs-server",
-      "version": "0.9.0",
+      "version": "0.13.0",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@desplega.ai/agent-fs-mcp": "workspace:*",
@@ -591,7 +591,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "agent-fs API",
-    "version": "0.13.0",
+    "version": "0.13.1",
     "description": "A persistent, searchable filesystem for AI agents. agent-fs is to files what agentmail is to email.",
     "license": {
       "name": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "agent-fs",
   "version": "0.13.0",
+  "packageManager": "bun@1.4.0",
   "private": true,
   "workspaces": [
     "packages/*"
@@ -16,7 +17,7 @@
   },
   "devDependencies": {
     "@duckdb/node-api": "1.5.3-r.3",
-    "bun-types": "^1.2.0",
+    "bun-types": "^1.4.0",
     "typescript": "^5.7.0",
     "yaml": "^2.8.2",
     "zod-to-json-schema": "^3.25.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-fs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "packageManager": "bun@1.4.0",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,7 +16,7 @@
     "cli"
   ],
   "engines": {
-    "bun": ">=1.2.0"
+    "bun": ">=1.4.0"
   },
   "bin": {
     "agent-fs": "dist/cli.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "Agent-first filesystem backed by S3",
   "license": "MIT",
@@ -35,8 +35,8 @@
     "sqlite-vec-linux-arm64": "^0.1.9",
     "sqlite-vec-linux-x64": "^0.1.9",
     "sqlite-vec-windows-x64": "^0.1.9",
-    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.13.0",
-    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.13.0"
+    "@desplega.ai/agent-fs-fuse-linux-x64": "^0.13.1",
+    "@desplega.ai/agent-fs-fuse-linux-arm64": "^0.13.1"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.750.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "drizzle-kit": "^0.30.0",
-    "bun-types": "^1.2.0",
+    "bun-types": "^1.4.0",
     "typescript": "^5.7.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-core",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/src/db/__tests__/db.test.ts
+++ b/packages/core/src/db/__tests__/db.test.ts
@@ -4,7 +4,7 @@ import * as sqliteVec from "sqlite-vec";
 import { unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { VIRTUAL_TABLE_SQL } from "../raw.js";
+import { VEC_TABLE_SQL } from "../raw.js";
 import { createDatabase } from "../index.js";
 
 // setup-sqlite.ts is auto-imported by db/index.ts, which runs setCustomSQLite once.
@@ -57,7 +57,7 @@ describe("Database initialization", () => {
   test("vec0 virtual table can be created and queried", () => {
     const sqlite = new Database(":memory:");
     sqliteVec.load(sqlite);
-    sqlite.exec(VIRTUAL_TABLE_SQL);
+    sqlite.exec(VEC_TABLE_SQL);
 
     // Insert a vector
     const embedding = new Float32Array(768);

--- a/packages/core/src/db/__tests__/fts-migration.test.ts
+++ b/packages/core/src/db/__tests__/fts-migration.test.ts
@@ -1,0 +1,273 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import * as sqliteVec from "sqlite-vec";
+import { unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import * as schema from "../schema.js";
+import { CREATE_TABLES_SQL, VEC_TABLE_SQL } from "../raw.js";
+import { createDatabase } from "../index.js";
+import {
+  isLegacyFtsTable,
+  hasLegacyFts,
+  prepareFtsMigration,
+  runFtsMigration,
+  LEGACY_FTS_TABLE,
+} from "../fts-migration.js";
+import { indexFile, removeFromIndex, ftsQuery } from "../../search/fts.js";
+import { grep } from "../../ops/grep.js";
+import { createTestContext } from "../../test-utils.js";
+
+const DRIVE = "drive-1";
+
+/**
+ * Build a database in the pre-0.13.1 layout: every table of today's schema
+ * except the full-text index, which is the old internal-content FTS5 table.
+ */
+function createLegacyDb(path = ":memory:"): Database {
+  const sqlite = new Database(path);
+  sqliteVec.load(sqlite);
+  sqlite.exec(CREATE_TABLES_SQL);
+  sqlite.exec(VEC_TABLE_SQL);
+  sqlite.exec(
+    "CREATE VIRTUAL TABLE files_fts USING fts5(path, content, drive_id UNINDEXED)"
+  );
+  return sqlite;
+}
+
+function addLegacyFile(
+  sqlite: Database,
+  path: string,
+  content: string,
+  opts: { deleted?: boolean } = {}
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO files(path, drive_id, size, author, created_at, modified_at, is_deleted)
+       VALUES (?, ?, ?, 'u1', 0, 0, ?)`
+    )
+    .run(path, DRIVE, content.length, opts.deleted ? 1 : 0);
+  sqlite
+    .prepare("INSERT INTO files_fts(path, content, drive_id) VALUES (?, ?, ?)")
+    .run(path, content, DRIVE);
+}
+
+function tableNames(sqlite: Database): string[] {
+  return (
+    sqlite
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+      .all() as Array<{ name: string }>
+  ).map((r) => r.name);
+}
+
+describe("FTS external-content migration", () => {
+  const tmpPaths: string[] = [];
+  afterEach(() => {
+    for (const p of tmpPaths) {
+      for (const suffix of ["", "-wal", "-shm"]) {
+        try {
+          unlinkSync(p + suffix);
+        } catch {}
+      }
+    }
+    tmpPaths.length = 0;
+  });
+
+  test("fresh database: nothing to migrate", async () => {
+    const { db } = createTestContext();
+    const sqlite = (db as any).$client as Database;
+
+    expect(isLegacyFtsTable(sqlite)).toBe(false);
+    expect(prepareFtsMigration(sqlite)).toBe(false);
+    expect(hasLegacyFts(sqlite)).toBe(false);
+    expect(await runFtsMigration(sqlite)).toEqual({ copied: 0, skipped: 0 });
+    expect(tableNames(sqlite)).not.toContain(LEGACY_FTS_TABLE);
+  });
+
+  test("createDatabase leaves a legacy index alone", () => {
+    const path = join(tmpdir(), `agent-fs-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    tmpPaths.push(path);
+    createLegacyDb(path).close();
+
+    const db = createDatabase(path);
+    const sqlite = (db as any).$client as Database;
+
+    // Still the old table under the old name, no triggers installed: an older
+    // daemon sharing this file keeps working until the new daemon takes over.
+    expect(isLegacyFtsTable(sqlite)).toBe(true);
+    expect(tableNames(sqlite)).not.toContain(LEGACY_FTS_TABLE);
+    const triggers = sqlite
+      .prepare("SELECT count(*) AS n FROM sqlite_master WHERE type = 'trigger'")
+      .get() as { n: number };
+    expect(triggers.n).toBe(0);
+
+    // The daemon's step 1 then works on the handle createDatabase returned.
+    expect(prepareFtsMigration(sqlite)).toBe(true);
+    expect(isLegacyFtsTable(sqlite)).toBe(false);
+    sqlite.close();
+  });
+
+  test("prepare renames the legacy index and routes writes to the new layout", () => {
+    const sqlite = createLegacyDb();
+    addLegacyFile(sqlite, "/old.md", "legacy content alpha");
+
+    expect(prepareFtsMigration(sqlite)).toBe(true);
+    expect(isLegacyFtsTable(sqlite)).toBe(false);
+    expect(hasLegacyFts(sqlite)).toBe(true);
+    expect(tableNames(sqlite)).toContain(LEGACY_FTS_TABLE);
+
+    const db = drizzle(sqlite, { schema });
+    indexFile(db, { path: "/new.md", driveId: DRIVE, content: "fresh content beta" });
+
+    // New write landed in the docs table and is indexed through the trigger.
+    const docs = sqlite.prepare("SELECT path FROM files_fts_docs").all() as Array<{ path: string }>;
+    expect(docs.map((d) => d.path)).toEqual(["/new.md"]);
+    expect(ftsQuery(db, { pattern: "beta", driveId: DRIVE }).map((m) => m.path)).toEqual(["/new.md"]);
+
+    // Legacy rows stay searchable while the copy is pending.
+    expect(ftsQuery(db, { pattern: "alpha", driveId: DRIVE }).map((m) => m.path)).toEqual(["/old.md"]);
+
+    // Idempotent.
+    expect(prepareFtsMigration(sqlite)).toBe(true);
+  });
+
+  test("search merges both layouts during the copy, new rows win", async () => {
+    const sqlite = createLegacyDb();
+    addLegacyFile(sqlite, "/a.md", "shared token stale");
+    addLegacyFile(sqlite, "/b.md", "shared token legacy only");
+    prepareFtsMigration(sqlite);
+    const db = drizzle(sqlite, { schema });
+
+    indexFile(db, { path: "/a.md", driveId: DRIVE, content: "shared token rewritten" });
+    indexFile(db, { path: "/c.md", driveId: DRIVE, content: "shared token new only" });
+
+    const hits = ftsQuery(db, { pattern: "shared", driveId: DRIVE });
+    expect(hits.map((h) => h.path).sort()).toEqual(["/a.md", "/b.md", "/c.md"]);
+    expect(hits.find((h) => h.path === "/a.md")!.snippet).toContain("rewritten");
+    expect(ftsQuery(db, { pattern: "stale", driveId: DRIVE })).toEqual([]);
+
+    const { ctx } = createTestContext();
+    const g = await grep({ ...ctx, db, driveId: DRIVE }, { pattern: "token", path: "/" });
+    expect(g.matches.map((m) => m.path).sort()).toEqual(["/a.md", "/b.md", "/c.md"]);
+    expect(g.matches.find((m) => m.path === "/a.md")!.content).toContain("rewritten");
+  });
+
+  test("run copies live rows in batches, skips deleted and rewritten, drops legacy", async () => {
+    const sqlite = createLegacyDb();
+    for (let i = 0; i < 7; i++) {
+      addLegacyFile(sqlite, `/doc-${i}.md`, `document number ${i} body`);
+    }
+    addLegacyFile(sqlite, "/gone.md", "deleted before migration", { deleted: true });
+    addLegacyFile(sqlite, "/orphan.md", "no files row at all");
+    sqlite.prepare("DELETE FROM files WHERE path = '/orphan.md'").run();
+
+    prepareFtsMigration(sqlite);
+    const db = drizzle(sqlite, { schema });
+    // Written after the rename: the new row must survive the copy.
+    indexFile(db, { path: "/doc-3.md", driveId: DRIVE, content: "document number 3 rewritten" });
+    // Deleted after the rename: must not come back.
+    removeFromIndex(db, { path: "/doc-5.md", driveId: DRIVE });
+    sqlite.prepare("UPDATE files SET is_deleted = 1 WHERE path = '/doc-5.md'").run();
+
+    const logs: string[] = [];
+    const result = await runFtsMigration(sqlite, { batchSize: 2, log: (m) => logs.push(m) });
+
+    expect(result).toEqual({ copied: 5, skipped: 4 });
+    expect(hasLegacyFts(sqlite)).toBe(false);
+    expect(tableNames(sqlite)).not.toContain(LEGACY_FTS_TABLE);
+    expect(sqlite.prepare("SELECT count(*) AS n FROM meta").get()).toEqual({ n: 0 });
+    expect(logs.at(-1)).toContain("done");
+
+    const paths = ftsQuery(db, { pattern: "document", driveId: DRIVE }).map((m) => m.path).sort();
+    expect(paths).toEqual(["/doc-0.md", "/doc-1.md", "/doc-2.md", "/doc-3.md", "/doc-4.md", "/doc-6.md"]);
+    expect(ftsQuery(db, { pattern: "rewritten", driveId: DRIVE }).map((m) => m.path)).toEqual(["/doc-3.md"]);
+    expect(ftsQuery(db, { pattern: "deleted", driveId: DRIVE })).toEqual([]);
+    expect(ftsQuery(db, { pattern: "orphan", driveId: DRIVE })).toEqual([]);
+
+    // Index and content table agree row for row.
+    const check = sqlite.prepare("INSERT INTO files_fts(files_fts) VALUES('integrity-check')");
+    expect(() => check.run()).not.toThrow();
+  });
+
+  test("run slices batches by content size, oversized rows go alone", async () => {
+    const sqlite = createLegacyDb();
+    addLegacyFile(sqlite, "/big.md", "x".repeat(5000));
+    for (let i = 0; i < 5; i++) addLegacyFile(sqlite, `/small-${i}.md`, `small row ${i}`);
+    prepareFtsMigration(sqlite);
+
+    const result = await runFtsMigration(sqlite, { batchSize: 50, batchBytes: 64 });
+    expect(result).toEqual({ copied: 6, skipped: 0 });
+    expect(hasLegacyFts(sqlite)).toBe(false);
+
+    const db = drizzle(sqlite, { schema });
+    expect(ftsQuery(db, { pattern: "small", driveId: DRIVE }).length).toBe(5);
+    expect(
+      (sqlite.prepare("SELECT length(content) AS n FROM files_fts_docs WHERE path = '/big.md'").get() as { n: number }).n
+    ).toBe(5000);
+  });
+
+  test("run raises crisismerge for the copy and restores it, even after a crash in between", async () => {
+    const sqlite = createLegacyDb();
+    addLegacyFile(sqlite, "/one.md", "one row");
+    prepareFtsMigration(sqlite);
+    const crisismerge = () =>
+      (sqlite.prepare("SELECT v FROM files_fts_config WHERE k = 'crisismerge'").get() as { v: number } | null)?.v ?? 16;
+
+    // Simulate a process that died after the copy + drop but before the restore.
+    await runFtsMigration(sqlite, { batchSize: 1 });
+    expect(crisismerge()).toBe(16);
+    sqlite.prepare("INSERT INTO files_fts(files_fts, rank) VALUES ('crisismerge', 1000)").run();
+    sqlite.prepare("INSERT INTO meta(key, value) VALUES ('fts_migration_tuning', '1')").run();
+
+    expect(prepareFtsMigration(sqlite)).toBe(true);
+    expect(await runFtsMigration(sqlite)).toEqual({ copied: 0, skipped: 0 });
+    expect(crisismerge()).toBe(16);
+    expect(sqlite.prepare("SELECT count(*) AS n FROM meta").get()).toEqual({ n: 0 });
+    expect(prepareFtsMigration(sqlite)).toBe(false);
+  });
+
+  test("run resumes from the persisted cursor", async () => {
+    const sqlite = createLegacyDb();
+    addLegacyFile(sqlite, "/first.md", "first row");
+    addLegacyFile(sqlite, "/second.md", "second row");
+    prepareFtsMigration(sqlite);
+
+    // Pretend an earlier run committed the first batch and then died.
+    const firstRowid = (
+      sqlite.prepare(`SELECT min(rowid) AS r FROM ${LEGACY_FTS_TABLE}`).get() as { r: number }
+    ).r;
+    sqlite
+      .prepare("INSERT INTO meta(key, value) VALUES ('fts_migration_cursor', ?)")
+      .run(String(firstRowid));
+
+    const result = await runFtsMigration(sqlite, { batchSize: 1 });
+    expect(result).toEqual({ copied: 1, skipped: 0 });
+
+    const db = drizzle(sqlite, { schema });
+    expect(ftsQuery(db, { pattern: "second", driveId: DRIVE }).map((m) => m.path)).toEqual(["/second.md"]);
+    // The first row was (by assumption) copied by the earlier run, so it is not re-copied here.
+    expect(ftsQuery(db, { pattern: "first", driveId: DRIVE })).toEqual([]);
+  });
+});
+
+describe("search index write path uses indexes", () => {
+  function plan(sqlite: Database, sql: string): string {
+    return (sqlite.prepare(`EXPLAIN QUERY PLAN ${sql}`).all() as Array<{ detail: string }>)
+      .map((r) => r.detail)
+      .join(" | ");
+  }
+
+  test("docs delete and chunk lookup are index searches, not scans", () => {
+    const { db } = createTestContext();
+    const sqlite = (db as any).$client as Database;
+
+    const docsPlan = plan(sqlite, "DELETE FROM files_fts_docs WHERE drive_id = 'd' AND path = '/p'");
+    expect(docsPlan).toContain("files_fts_docs_drive_path_uq");
+    expect(docsPlan).not.toContain("SCAN");
+
+    const chunksPlan = plan(sqlite, "SELECT id FROM content_chunks WHERE file_path = '/p' AND drive_id = 'd'");
+    expect(chunksPlan).toContain("idx_content_chunks_drive_path");
+    expect(chunksPlan).not.toContain("SCAN");
+  });
+});

--- a/packages/core/src/db/fts-migration.ts
+++ b/packages/core/src/db/fts-migration.ts
@@ -1,0 +1,250 @@
+import { Database } from "bun:sqlite";
+import { FTS_SCHEMA_SQL } from "./raw.js";
+
+/**
+ * One-time migration of the full-text index from the pre-0.13.1 layout
+ * (FTS5 table with internal content) to the external-content layout over
+ * `files_fts_docs` (see FTS_SCHEMA_SQL).
+ *
+ * Why this is not a plain startup migration: the old index holds a full copy
+ * of every indexed file. Re-tokenizing it takes about a minute per GB on a
+ * laptop and many minutes on a small cloud VM. Doing that inside
+ * `createDatabase()` would keep the daemon from answering `/health` for the
+ * whole time and, if the host kills the process meanwhile, the work would be
+ * lost and retried forever. So the migration is split:
+ *
+ *   1. `prepareFtsMigration()` (sync, instant): renames the old table to
+ *      `files_fts_legacy` and creates the new empty index plus triggers. From
+ *      this moment every write goes to the new layout.
+ *   2. `runFtsMigration()` (async, batched, resumable): copies the legacy rows
+ *      into `files_fts_docs` in small committed batches, yielding to the event
+ *      loop between them, then drops the legacy table. The cursor lives in the
+ *      `meta` table, so a restart resumes where it stopped.
+ *
+ * While `files_fts_legacy` exists, `ftsQuery` and `grep` read both tables
+ * (new rows win), so search stays whole during the copy.
+ *
+ * Only the daemon calls these. `createDatabase()` deliberately leaves a legacy
+ * table untouched so that a newer CLI binary cannot rename it under an older
+ * daemon that is still running against the same file.
+ */
+
+export const LEGACY_FTS_TABLE = "files_fts_legacy";
+const CURSOR_KEY = "fts_migration_cursor";
+/** Present in `meta` while the FTS5 crisismerge option is raised for the copy. */
+const TUNING_KEY = "fts_migration_tuning";
+const DEFAULT_BATCH_SIZE = 50;
+// Tokenizing is the expensive part of a batch, and it scales with bytes, not
+// rows. Cap each committed batch by content size so one batch stays short
+// (512 KB is roughly 100 ms on a laptop) even on a throttled VM.
+const DEFAULT_BATCH_BYTES = 512 * 1024;
+// FTS5 writes one b-tree segment per committed batch. With the default
+// crisismerge of 16, every 16th commit at a level merges that whole level at
+// once, which at GB scale blocks for many seconds. Raising it for the copy
+// leaves the merging to the incremental automerge (bounded work per commit);
+// it is restored afterwards. Well below FTS5's hard 2000-segment limit.
+const COPY_CRISISMERGE = 1000;
+const DEFAULT_CRISISMERGE = 16;
+
+/** `true` while `files_fts` is still the old internal-content table. */
+export function isLegacyFtsTable(sqlite: Database): boolean {
+  const row = sqlite
+    .prepare(
+      "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'files_fts'"
+    )
+    .get() as { sql: string } | null;
+  return !!row && !/content\s*=/i.test(row.sql);
+}
+
+// A legacy table only ever disappears, so once a connection has seen it gone
+// there is no need to ask sqlite_master again on every query.
+const legacyGone = new WeakSet<Database>();
+
+/** `true` while a renamed legacy table still awaits copying. */
+export function hasLegacyFts(sqlite: Database): boolean {
+  if (legacyGone.has(sqlite)) return false;
+  const row = sqlite
+    .prepare(
+      "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?"
+    )
+    .get(LEGACY_FTS_TABLE);
+  if (!row) legacyGone.add(sqlite);
+  return !!row;
+}
+
+function metaHas(sqlite: Database, key: string): boolean {
+  return !!sqlite.prepare("SELECT 1 FROM meta WHERE key = ?").get(key);
+}
+
+/** `true` while `runFtsMigration()` still has work to do (copy or cleanup). */
+export function ftsMigrationPending(sqlite: Database): boolean {
+  return hasLegacyFts(sqlite) || metaHas(sqlite, TUNING_KEY);
+}
+
+/**
+ * Step 1. Rename a legacy `files_fts` out of the way and install the new
+ * external-content index. Idempotent and instant (DDL only).
+ *
+ * Returns `true` when `runFtsMigration()` has work left to do.
+ */
+export function prepareFtsMigration(sqlite: Database): boolean {
+  sqlite.transaction(() => {
+    if (isLegacyFtsTable(sqlite)) {
+      sqlite.exec(`ALTER TABLE files_fts RENAME TO ${LEGACY_FTS_TABLE}`);
+      legacyGone.delete(sqlite);
+    }
+    sqlite.exec(FTS_SCHEMA_SQL);
+  })();
+  return ftsMigrationPending(sqlite);
+}
+
+export interface FtsMigrationResult {
+  /** Rows copied into the new index. */
+  copied: number;
+  /** Legacy rows skipped: file deleted, or already re-indexed since the rename. */
+  skipped: number;
+}
+
+export interface FtsMigrationOptions {
+  /** Rows fetched from the legacy table per round trip. */
+  batchSize?: number;
+  /** Content bytes committed per transaction (one oversized row is its own batch). */
+  batchBytes?: number;
+  log?: (msg: string) => void;
+}
+
+/**
+ * Step 2. Copy legacy rows into `files_fts_docs` in batches and drop the
+ * legacy table. Safe to call when there is nothing to migrate.
+ *
+ * Each batch is one short transaction that also advances the cursor, so the
+ * copy survives a crash or restart at any point. Rows whose file was deleted,
+ * or that were written again after the rename (already present in
+ * `files_fts_docs`), are skipped: the new layout is the source of truth.
+ */
+export async function runFtsMigration(
+  sqlite: Database,
+  opts: FtsMigrationOptions = {}
+): Promise<FtsMigrationResult> {
+  const result: FtsMigrationResult = { copied: 0, skipped: 0 };
+  if (!ftsMigrationPending(sqlite)) return result;
+  const log = opts.log ?? (() => {});
+
+  if (hasLegacyFts(sqlite)) {
+    await copyLegacyRows(sqlite, result, opts);
+  }
+
+  // Restore the merge setting. Also runs when this is all that is left over
+  // from a process that died between the copy and the restore.
+  sqlite.transaction(() => {
+    setCrisismerge(sqlite, DEFAULT_CRISISMERGE);
+    sqlite.prepare("DELETE FROM meta WHERE key = ?").run(TUNING_KEY);
+  })();
+
+  log(
+    `search index migration: done, ${result.copied} copied, ${result.skipped} skipped`
+  );
+  return result;
+}
+
+function setCrisismerge(sqlite: Database, value: number): void {
+  sqlite
+    .prepare("INSERT INTO files_fts(files_fts, rank) VALUES ('crisismerge', ?)")
+    .run(value);
+}
+
+type LegacyRow = { rowid: number; drive_id: string; path: string; content: string };
+
+async function copyLegacyRows(
+  sqlite: Database,
+  result: FtsMigrationResult,
+  opts: FtsMigrationOptions
+): Promise<void> {
+  const batchSize = opts.batchSize ?? DEFAULT_BATCH_SIZE;
+  const batchBytes = opts.batchBytes ?? DEFAULT_BATCH_BYTES;
+  const log = opts.log ?? (() => {});
+
+  sqlite.transaction(() => {
+    setCrisismerge(sqlite, COPY_CRISISMERGE);
+    sqlite
+      .prepare("INSERT OR IGNORE INTO meta(key, value) VALUES (?, '1')")
+      .run(TUNING_KEY);
+  })();
+
+  const readCursor = sqlite.prepare("SELECT value FROM meta WHERE key = ?");
+  const writeCursor = sqlite.prepare(
+    "INSERT INTO meta(key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+  );
+  const selectBatch = sqlite.prepare(
+    `SELECT rowid, drive_id, path, content FROM ${LEGACY_FTS_TABLE} WHERE rowid > ? ORDER BY rowid LIMIT ?`
+  );
+  const isLive = sqlite.prepare(
+    "SELECT 1 FROM files WHERE drive_id = ? AND path = ? AND is_deleted = 0"
+  );
+  const docExists = sqlite.prepare(
+    "SELECT 1 FROM files_fts_docs WHERE drive_id = ? AND path = ?"
+  );
+  const insertDoc = sqlite.prepare(
+    "INSERT INTO files_fts_docs(drive_id, path, content) VALUES (?, ?, ?)"
+  );
+
+  let cursor = Number(
+    (readCursor.get(CURSOR_KEY) as { value: string } | null)?.value ?? 0
+  );
+  log(`search index migration: starting at legacy rowid ${cursor}`);
+
+  const copyBatch = sqlite.transaction((rows: LegacyRow[]) => {
+    for (const row of rows) {
+      // Skip files deleted since, and files re-indexed since the rename
+      // (the docs row is newer than the legacy one).
+      if (
+        !isLive.get(row.drive_id, row.path) ||
+        docExists.get(row.drive_id, row.path)
+      ) {
+        result.skipped++;
+        continue;
+      }
+      insertDoc.run(row.drive_id, row.path, row.content);
+      result.copied++;
+    }
+    cursor = rows[rows.length - 1].rowid;
+    writeCursor.run(CURSOR_KEY, String(cursor));
+  });
+
+  let sinceLog = 0;
+  for (;;) {
+    const rows = selectBatch.all(cursor, batchSize) as LegacyRow[];
+    if (rows.length === 0) break;
+
+    // Commit in slices that stay under the byte budget (a single oversized
+    // row is its own slice), yielding to the event loop after each one.
+    let start = 0;
+    while (start < rows.length) {
+      let end = start;
+      let bytes = 0;
+      do {
+        bytes += rows[end].content.length;
+        end++;
+      } while (end < rows.length && bytes + rows[end].content.length <= batchBytes);
+      copyBatch(rows.slice(start, end));
+      start = end;
+      await Bun.sleep(0);
+    }
+
+    sinceLog += rows.length;
+    if (sinceLog >= 1000) {
+      sinceLog = 0;
+      log(
+        `search index migration: ${result.copied} copied, ${result.skipped} skipped (legacy rowid ${cursor})`
+      );
+    }
+  }
+
+  // Dropping the legacy table frees its pages in one synchronous step. That
+  // is a single scan of the old index, about what one write used to cost.
+  sqlite.transaction(() => {
+    sqlite.exec(`DROP TABLE ${LEGACY_FTS_TABLE}`);
+    sqlite.prepare("DELETE FROM meta WHERE key = ?").run(CURSOR_KEY);
+  })();
+  legacyGone.add(sqlite);
+}

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -8,8 +8,9 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { getDbPath } from "../config.js";
 import * as schema from "./schema.js";
-import { CREATE_TABLES_SQL, VIRTUAL_TABLE_SQL } from "./raw.js";
+import { CREATE_TABLES_SQL, VEC_TABLE_SQL, FTS_SCHEMA_SQL } from "./raw.js";
 import { runMigrations } from "./migrate.js";
+import { isLegacyFtsTable } from "./fts-migration.js";
 
 export type DB = ReturnType<typeof createDatabase>;
 
@@ -37,7 +38,15 @@ export function createDatabase(dbPath?: string): ReturnType<typeof drizzle> {
 
   // Create all tables (idempotent)
   sqlite.exec(CREATE_TABLES_SQL);
-  sqlite.exec(VIRTUAL_TABLE_SQL);
+  sqlite.exec(VEC_TABLE_SQL);
+
+  // The full-text index is only installed when the name is free. A database
+  // from before 0.13.1 still has the internal-content `files_fts`; the daemon
+  // migrates it (fts-migration.ts) and nothing else may touch it, so a newer
+  // CLI binary cannot rename it under an older daemon on the same file.
+  if (!isLegacyFtsTable(sqlite)) {
+    sqlite.exec(FTS_SCHEMA_SQL);
+  }
 
   // Run additive migrations for older DBs (idempotent)
   runMigrations(sqlite);

--- a/packages/core/src/db/raw.ts
+++ b/packages/core/src/db/raw.ts
@@ -122,17 +122,76 @@ CREATE TABLE IF NOT EXISTS content_chunks (
   char_offset INTEGER NOT NULL,
   token_count INTEGER NOT NULL
 );
-`;
 
-export const VIRTUAL_TABLE_SQL = `
--- FTS5 full-text index (internal content storage)
-CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
-  path, content, drive_id UNINDEXED
+-- Every write, rm, mv and the embedding job look chunks up by (drive, path).
+-- Without this index each of those is a full scan of a table that holds a
+-- copy of every indexed file.
+CREATE INDEX IF NOT EXISTS idx_content_chunks_drive_path
+  ON content_chunks(drive_id, file_path);
+
+-- Content table behind the files_fts external-content index. FTS5 cannot use
+-- an equality constraint on a column (only MATCH and rowid), so keying the
+-- text here with a unique (drive_id, path) index is what makes delete and
+-- upsert O(log n) instead of a scan of the whole index.
+CREATE TABLE IF NOT EXISTS files_fts_docs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  drive_id TEXT NOT NULL,
+  path TEXT NOT NULL,
+  content TEXT NOT NULL
 );
 
--- sqlite-vec vector index for semantic search (768 dimensions)
+CREATE UNIQUE INDEX IF NOT EXISTS files_fts_docs_drive_path_uq
+  ON files_fts_docs(drive_id, path);
+
+-- Small key/value store for internal bookkeeping (e.g. migration cursors).
+CREATE TABLE IF NOT EXISTS meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+`;
+
+/** sqlite-vec vector index for semantic search (768 dimensions). */
+export const VEC_TABLE_SQL = `
 CREATE VIRTUAL TABLE IF NOT EXISTS chunk_vectors USING vec0(
   chunk_id INTEGER PRIMARY KEY,
   embedding float[768]
 );
 `;
+
+/**
+ * FTS5 full-text index as an external-content table over files_fts_docs.
+ *
+ * The triggers keep the index in sync with the content table, so callers only
+ * ever touch files_fts_docs. The 'delete' command needs the old column values
+ * to remove the right tokens; the triggers are the one place that always has
+ * them.
+ *
+ * Not applied while a pre-0.13.1 internal-content files_fts table still holds
+ * the name: see fts-migration.ts.
+ */
+export const FTS_SCHEMA_SQL = `
+CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+  path, content, drive_id UNINDEXED,
+  content='files_fts_docs', content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS files_fts_docs_ai AFTER INSERT ON files_fts_docs BEGIN
+  INSERT INTO files_fts(rowid, path, content, drive_id)
+    VALUES (new.id, new.path, new.content, new.drive_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS files_fts_docs_ad AFTER DELETE ON files_fts_docs BEGIN
+  INSERT INTO files_fts(files_fts, rowid, path, content, drive_id)
+    VALUES ('delete', old.id, old.path, old.content, old.drive_id);
+END;
+
+CREATE TRIGGER IF NOT EXISTS files_fts_docs_au AFTER UPDATE ON files_fts_docs BEGIN
+  INSERT INTO files_fts(files_fts, rowid, path, content, drive_id)
+    VALUES ('delete', old.id, old.path, old.content, old.drive_id);
+  INSERT INTO files_fts(rowid, path, content, drive_id)
+    VALUES (new.id, new.path, new.content, new.drive_id);
+END;
+`;
+
+/** Every virtual-table object, for fresh databases and tests. */
+export const VIRTUAL_TABLE_SQL = VEC_TABLE_SQL + FTS_SCHEMA_SQL;

--- a/packages/core/src/db/schema.ts
+++ b/packages/core/src/db/schema.ts
@@ -187,12 +187,21 @@ export const events = sqliteTable(
 );
 
 // content_chunks (for embedding)
-export const contentChunks = sqliteTable("content_chunks", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  filePath: text("file_path").notNull(),
-  driveId: text("drive_id").notNull(),
-  chunkIndex: integer("chunk_index").notNull(),
-  content: text("content").notNull(),
-  charOffset: integer("char_offset").notNull(),
-  tokenCount: integer("token_count").notNull(),
-});
+export const contentChunks = sqliteTable(
+  "content_chunks",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    filePath: text("file_path").notNull(),
+    driveId: text("drive_id").notNull(),
+    chunkIndex: integer("chunk_index").notNull(),
+    content: text("content").notNull(),
+    charOffset: integer("char_offset").notNull(),
+    tokenCount: integer("token_count").notNull(),
+  },
+  (table) => ({
+    drivePathIdx: index("idx_content_chunks_drive_path").on(
+      table.driveId,
+      table.filePath
+    ),
+  })
+);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,12 @@
 export { createDatabase, schema } from "./db/index.js";
 export type { DB } from "./db/index.js";
 export {
+  prepareFtsMigration,
+  runFtsMigration,
+  hasLegacyFts,
+} from "./db/fts-migration.js";
+export type { FtsMigrationResult } from "./db/fts-migration.js";
+export {
   getConfig,
   setConfig,
   setConfigValue,

--- a/packages/core/src/ops/grep.ts
+++ b/packages/core/src/ops/grep.ts
@@ -1,6 +1,8 @@
 import { Database } from "bun:sqlite";
 import type { OpContext } from "./types.js";
 import { normalizePrefix } from "./paths.js";
+import { hasLegacyFts, LEGACY_FTS_TABLE } from "../db/fts-migration.js";
+import { legacyRowIsCurrent } from "../search/fts.js";
 
 export interface GrepParams {
   pattern: string;
@@ -25,13 +27,25 @@ export async function grep(
   const prefix = normalizePrefix(params.path);
   const raw = (ctx.db as any).$client as Database;
 
-  // Read content from FTS5 index (local SQLite) instead of fetching each file from S3.
-  // FTS5 stores the full content, so this avoids O(n) S3 GETs.
+  // Read content from the local search index instead of fetching each file
+  // from S3. files_fts_docs holds the full text and is indexed by (drive, path).
   const files = raw
     .prepare(
-      "SELECT path, content FROM files_fts WHERE drive_id = ? AND path LIKE ?"
+      "SELECT path, content FROM files_fts_docs WHERE drive_id = ? AND path LIKE ?"
     )
     .all(ctx.driveId, prefix + "%") as Array<{ path: string; content: string }>;
+
+  // During the one-time index migration, rows not yet copied still live in
+  // the legacy table, minus the ones the new layout has superseded.
+  if (hasLegacyFts(raw)) {
+    const legacy = raw
+      .prepare(
+        `SELECT path, content FROM ${LEGACY_FTS_TABLE}
+         WHERE drive_id = ? AND path LIKE ?${legacyRowIsCurrent(LEGACY_FTS_TABLE)}`
+      )
+      .all(ctx.driveId, prefix + "%") as Array<{ path: string; content: string }>;
+    files.push(...legacy);
+  }
 
   const matches: GrepMatch[] = [];
 

--- a/packages/core/src/search/fts.ts
+++ b/packages/core/src/search/fts.ts
@@ -1,25 +1,31 @@
 import type { DB } from "../db/index.js";
 import { Database } from "bun:sqlite";
+import { hasLegacyFts, LEGACY_FTS_TABLE } from "../db/fts-migration.js";
 
 function getRawDb(db: DB): Database {
   return (db as any).$client as Database;
 }
+
+// `files_fts` is an external-content FTS5 table over `files_fts_docs`, kept in
+// sync by triggers (see FTS_SCHEMA_SQL). Writers only touch the docs table,
+// where (drive_id, path) is a unique index. Writing through the FTS table by
+// `WHERE path = ?` would be a full scan: FTS5 can only use MATCH and rowid.
 
 export function indexFile(
   db: DB,
   params: { path: string; driveId: string; content: string }
 ): void {
   const raw = getRawDb(db);
-
-  // Remove existing entry first (upsert pattern for FTS5)
-  raw
-    .prepare("DELETE FROM files_fts WHERE path = ? AND drive_id = ?")
-    .run(params.path, params.driveId);
-
-  // Insert new entry
-  raw
-    .prepare("INSERT INTO files_fts(path, content, drive_id) VALUES (?, ?, ?)")
-    .run(params.path, params.content, params.driveId);
+  raw.transaction(() => {
+    raw
+      .prepare("DELETE FROM files_fts_docs WHERE drive_id = ? AND path = ?")
+      .run(params.driveId, params.path);
+    raw
+      .prepare(
+        "INSERT INTO files_fts_docs(drive_id, path, content) VALUES (?, ?, ?)"
+      )
+      .run(params.driveId, params.path, params.content);
+  })();
 }
 
 export function removeFromIndex(
@@ -28,8 +34,8 @@ export function removeFromIndex(
 ): void {
   const raw = getRawDb(db);
   raw
-    .prepare("DELETE FROM files_fts WHERE path = ? AND drive_id = ?")
-    .run(params.path, params.driveId);
+    .prepare("DELETE FROM files_fts_docs WHERE drive_id = ? AND path = ?")
+    .run(params.driveId, params.path);
 }
 
 export interface FtsMatch {
@@ -43,31 +49,45 @@ export function ftsQuery(
   params: { pattern: string; driveId: string; pathPrefix?: string }
 ): FtsMatch[] {
   const raw = getRawDb(db);
+  const results = ftsQueryTable(raw, "files_fts", params);
 
-  let sql: string;
-  let binds: any[];
+  // During the one-time index migration the not-yet-copied rows still live in
+  // the legacy table. Query it too, minus rows the new layout has superseded.
+  if (!hasLegacyFts(raw)) return results;
+  results.push(...ftsQueryTable(raw, LEGACY_FTS_TABLE, params));
+  return results.sort((a, b) => a.rank - b.rank).slice(0, 50);
+}
 
+/**
+ * Rows of the legacy table that the new layout has not superseded: the file
+ * still exists and has not been re-indexed into files_fts_docs since the
+ * rename. Both checks are index lookups on the (few) MATCH candidates.
+ */
+export function legacyRowIsCurrent(table: string): string {
+  return `
+    AND EXISTS (SELECT 1 FROM files f
+                WHERE f.drive_id = ${table}.drive_id AND f.path = ${table}.path AND f.is_deleted = 0)
+    AND NOT EXISTS (SELECT 1 FROM files_fts_docs d
+                    WHERE d.drive_id = ${table}.drive_id AND d.path = ${table}.path)`;
+}
+
+function ftsQueryTable(
+  raw: Database,
+  table: string,
+  params: { pattern: string; driveId: string; pathPrefix?: string }
+): FtsMatch[] {
   // FTS5 MATCH requires content columns only (not UNINDEXED ones).
   // Filter by drive_id and path prefix after the MATCH.
-  if (params.pathPrefix) {
-    sql = `
-      SELECT path, snippet(files_fts, 1, '<b>', '</b>', '...', 32) as snippet, rank
-      FROM files_fts
-      WHERE content MATCH ? AND drive_id = ? AND path LIKE ?
-      ORDER BY rank
-      LIMIT 50
-    `;
-    binds = [params.pattern, params.driveId, params.pathPrefix + "%"];
-  } else {
-    sql = `
-      SELECT path, snippet(files_fts, 1, '<b>', '</b>', '...', 32) as snippet, rank
-      FROM files_fts
-      WHERE content MATCH ? AND drive_id = ?
-      ORDER BY rank
-      LIMIT 50
-    `;
-    binds = [params.pattern, params.driveId];
-  }
-
-  return raw.prepare(sql).all(...binds) as FtsMatch[];
+  const pathFilter = params.pathPrefix ? " AND path LIKE ?" : "";
+  const legacyFilter = table === LEGACY_FTS_TABLE ? legacyRowIsCurrent(table) : "";
+  const sql = `
+    SELECT path, snippet(${table}, 1, '<b>', '</b>', '...', 32) as snippet, rank
+    FROM ${table}
+    WHERE content MATCH ? AND drive_id = ?${pathFilter}${legacyFilter}
+    ORDER BY rank
+    LIMIT 50
+  `;
+  const binds: unknown[] = [params.pattern, params.driveId];
+  if (params.pathPrefix) binds.push(params.pathPrefix + "%");
+  return raw.prepare(sql).all(...(binds as any[])) as FtsMatch[];
 }

--- a/packages/fuse-helper-linux-arm64/package.json
+++ b/packages/fuse-helper-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Linux aarch64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper-linux-x64/package.json
+++ b/packages/fuse-helper-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Linux x86_64 FUSE helper binary for @desplega.ai/agent-fs. Do not install directly.",
   "os": [
     "linux"

--- a/packages/fuse-helper/Cargo.toml
+++ b/packages/fuse-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-fs-fuse"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 description = "FUSE helper for agent-fs — mounts agent-fs drives as a Linux filesystem."
 license = "MIT"

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-just-bash",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "description": "just-bash-compatible filesystem adapter for agent-fs",
   "license": "MIT",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-mcp",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@desplega.ai/agent-fs-server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,13 @@
-import { createDatabase, getConfig, getHome, createStorageAdapter, createEmbeddingProviderFromEnv } from "@/core";
+import {
+  createDatabase,
+  getConfig,
+  getHome,
+  createStorageAdapter,
+  createEmbeddingProviderFromEnv,
+  prepareFtsMigration,
+  runFtsMigration,
+} from "@/core";
+import type { Database } from "bun:sqlite";
 import type { EmbeddingProvider } from "@/core";
 import { join } from "node:path";
 import { createApp } from "./app.js";
@@ -8,6 +17,13 @@ const config = getConfig();
 
 // Initialize database
 const db = createDatabase();
+const sqlite = (db as any).$client as Database;
+
+// Databases from before 0.13.1 carry the old full-text index layout. Swap the
+// name over now (instant DDL) so every write from here on lands in the new
+// layout; the row copy itself runs in the background once we are listening,
+// in small batches, so /health keeps answering and a restart resumes it.
+const ftsMigrationPending = prepareFtsMigration(sqlite);
 
 // Initialize the storage adapter for the configured backend (S3/MinIO or
 // local-FS). The factory also applies the test-only AGENT_FS_CAPABILITY_OVERRIDE
@@ -48,6 +64,12 @@ const server = Bun.serve({
 });
 
 console.log(`agent-fs daemon running on http://${server.hostname}:${server.port}`);
+
+if (ftsMigrationPending) {
+  runFtsMigration(sqlite, { log: (msg) => console.log(msg) }).catch((err) => {
+    console.error("search index migration failed (will resume on next start):", err);
+  });
+}
 
 // Event-loop lag watchdog. A synchronous operation that blocks the loop
 // (the prod wedge: /health dead for minutes while the process sits at


### PR DESCRIPTION
## Why

Prod restarted 23 times in 7 days. The watchdog showed single `PUT .../raw` requests blocking the event loop for ~70 s. None of it was the upload, the hash, or the S3 put. Every write (binary uploads included) ran two **synchronous full-table scans** to find one row:

1. `DELETE FROM files_fts WHERE path = ? AND drive_id = ?`. FTS5 only uses MATCH and rowid, so this scanned the whole index, including every row's `content`.
2. `SELECT id FROM content_chunks WHERE file_path = ? AND drive_id = ?` with no index on those columns. This table holds a second copy of every indexed file.

Both scale with the size of the whole search index, not the file being written. Synthetic index, same schema, laptop:

| Index size | FTS delete by path | content_chunks scan | Total per write |
|---|---|---|---|
| 147 MB (3k docs) | 14 ms | 19 ms | 33 ms |
| 1.48 GB (20k docs) | ~8.2 s | ~9.4 s | **~17 s** |

`bun:sqlite` is synchronous, so that is 17 s of frozen event loop per write on a fast laptop; on a `shared-cpu-1x` Fly machine with a network volume that is the 70 s stall. Concurrent PUTs serialize on the same loop, which is the 30 s task-creation halt with 3-4 attachments.

Read-only check on prod (both `count(*)` queries use the same plan as the writes):

```bash
fly ssh console -a agent-fs-taras -C "bun -e 'const {Database}=require(\"bun:sqlite\");const db=new Database(\"/data/agent-fs.db\",{readonly:true});const q=(l,s)=>{const t=performance.now();db.prepare(s).get(\"/nope\",\"x\");console.log(l,Math.round(performance.now()-t),\"ms\")};q(\"fts scan\",\"SELECT count(*) FROM files_fts WHERE path = ? AND drive_id = ?\");q(\"chunks scan\",\"SELECT count(*) FROM content_chunks WHERE file_path = ? AND drive_id = ?\")'"
```

## What

**Schema (`packages/core/src/db/raw.ts`)**
- `files_fts` becomes an FTS5 *external-content* table over a new `files_fts_docs(id, drive_id, path, content)` table with a unique `(drive_id, path)` index. Three triggers keep the index in sync; writers only touch `files_fts_docs`. Content is stored once instead of inside FTS.
- `idx_content_chunks_drive_path` on `content_chunks(drive_id, file_path)`.
- A small `meta(key, value)` table for migration bookkeeping.
- `grep` reads `files_fts_docs` directly (index range) instead of scanning the FTS table.

**Migration of existing databases (`packages/core/src/db/fts-migration.ts`)**
- At daemon startup: the old table is renamed to `files_fts_legacy` and the new index + triggers are created. DDL only, instant. From that moment every write lands in the new layout.
- After the daemon is listening: legacy rows are copied into `files_fts_docs` in small committed batches (512 KB of content per transaction), yielding to the event loop between batches. Progress is logged as `search index migration: ...`. The cursor lives in `meta`, so a restart resumes where it stopped. Rows whose file was deleted or re-indexed since the rename are skipped. The legacy table is dropped at the end.
- FTS5 `crisismerge` is raised from 16 to 1000 during the copy (with the default, every 16th commit at a level merges the whole level at once, which blocked for ~9 s at 20k docs) and restored afterwards. The restore is flagged in `meta` so it also happens if the process dies between copy and restore.
- While the legacy table exists, `ftsQuery` and `grep` query both layouts. Legacy rows that the new layout has superseded (file deleted, or re-indexed) are filtered out, so search stays whole during the copy.
- `createDatabase()` deliberately leaves a legacy table untouched. Only the daemon migrates, so a newer CLI binary (`auth`, `onboard`) cannot rename the table under an older daemon still running on the same file.

**Proposal 3 from the analysis** (skip `clearSearchData` for never-indexed binaries) is moot: every statement in it is now an index lookup.

**Bun 1.4** (separate commit): `packageManager`, CI `setup-bun`, Docker base images pinned to 1.4.0; `bun-types ^1.4.0`; `engines.bun >= 1.4.0` (README/DEPLOYMENT updated). The lockfile stays `lockfileVersion: 1`; Bun 1.4 keeps reading it and only writes v2 for new lockfiles.

## Measurements

Real migration code on a 1.48 GB legacy DB (20k docs, 600 MB of text), laptop, with a write + search every 200 ms during the copy:

- Startup `CREATE INDEX` on `content_chunks`: 13-20 s, before listening. One-time.
- Copy: 222 s total. Event-loop gaps: p50 220 ms; worst 6.5 s (the final `DROP TABLE`), then 3.3 s / 3.1 s / 2.3 s. Before tuning `crisismerge`: five gaps of 7.5-9.5 s.
- After: `indexFile` 1-2 ms, `removeFromIndex` < 1 ms, chunk lookup < 1 ms, `ftsQuery` 160 ms (BM25 over 20k matching docs).

End-to-end upgrade test: seeded a DB with the `main` server (40 docs + PNG via `PUT /raw`), stopped it, started this branch. Migration ran in the background (`42 copied, 0 skipped`), legacy table dropped, `fts`/`grep`/`search` correct, `rm` and rewrite during the new layout behave, `PUT /raw` of a 300 KB PNG: **6 ms**. `INSERT INTO files_fts(files_fts) VALUES('integrity-check')` passes.

## Residual risk, please read before deploying

- The startup index build and the final drop are unavoidable synchronous steps, each about the cost of one old write. On Fly they can take minutes. Expect `/health` to fail during the startup step once. If whatever restarts prod kills the process mid-copy, the copy resumes; the index build and the drop are transactional and retry on the next start.
- I could not measure on Fly (no `fly` auth on this machine). The prod DB size is the unknown; the one-liner above gives it.

## Checklist

- [x] Unit tests: `packages/core/src/db/__tests__/fts-migration.test.ts` (fresh DB no-op, legacy left alone by `createDatabase`, rename + dual-read, merge with new-wins, batched copy with skips, byte-sliced batches, cursor resume, crisismerge restore after crash, query plans use the indexes)
- [x] `bun run typecheck`, `bun run test`, `bun run build`, `bun run scripts/e2e.ts ... --local-only` (118/118) on Bun 1.4.0
- [x] Skill: no op/command change, nothing to update
- [x] E2E: no new op; migration covered by unit tests + the manual upgrade run above
- [x] `./scripts/release.sh 0.13.1`
- [x] DEPLOYMENT.md: upgrade note
