### PR TITLE
feat(server): first-class API key reset (self-service + org-admin)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.3-r.3",
         "bun-types": "^1.4.0",
+        "msgpackr": "^1",
         "typescript": "^5.7.0",
         "yaml": "^2.8.2",
         "zod-to-json-schema": "^3.25.1",
@@ -14,7 +15,7 @@
     },
     "packages/cli": {
       "name": "@desplega.ai/agent-fs",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "bin": {
         "agent-fs": "dist/cli.js",
       },
@@ -46,7 +47,7 @@
     },
     "packages/core": {
       "name": "@desplega.ai/agent-fs-core",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.750.0",
         "@aws-sdk/s3-request-presigner": "^3.750.0",
@@ -69,15 +70,15 @@
     },
     "packages/fuse-helper-linux-arm64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-arm64",
-      "version": "0.13.0",
+      "version": "0.13.2",
     },
     "packages/fuse-helper-linux-x64": {
       "name": "@desplega.ai/agent-fs-fuse-linux-x64",
-      "version": "0.13.0",
+      "version": "0.13.2",
     },
     "packages/just-bash": {
       "name": "@desplega.ai/agent-fs-just-bash",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "peerDependencies": {
         "just-bash": ">=3.0.1",
       },
@@ -87,7 +88,7 @@
     },
     "packages/mcp": {
       "name": "@desplega.ai/agent-fs-mcp",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -96,7 +97,7 @@
     },
     "packages/server": {
       "name": "@desplega.ai/agent-fs-server",
-      "version": "0.13.0",
+      "version": "0.13.2",
       "dependencies": {
         "@desplega.ai/agent-fs-core": "workspace:*",
         "@desplega.ai/agent-fs-mcp": "workspace:*",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -37,13 +37,15 @@ curl http://localhost:7433/health
 
 ### `POST /auth/register`
 
-Register a new user. Returns user ID, org ID, drive ID, and API key.
+Register a new user. Returns user ID, org ID, drive ID, and API key. The key is shown only once — it isn't stored anywhere but the user's own `config.json`.
 
 ```bash
 curl -X POST http://localhost:7433/auth/register \
   -H "Content-Type: application/json" \
   -d '{"email": "agent@example.com"}'
 ```
+
+A lost key is recoverable: the owner runs `agent-fs auth reset-key`, or an org admin runs `agent-fs member reset-key <email>` on their behalf. Either rotates the key and invalidates the old one immediately.
 
 ### `GET /auth/me`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -45,7 +45,7 @@ curl -X POST http://localhost:7433/auth/register \
   -d '{"email": "agent@example.com"}'
 ```
 
-A lost key is recoverable: the owner runs `agent-fs auth reset-key`, or an org admin runs `agent-fs member reset-key <email>` on their behalf. Either rotates the key and invalidates the old one immediately.
+`agent-fs auth reset-key` rotates your own key while you still hold the current one — it calls `/auth/reset-key`, which sits behind the same auth middleware as every other endpoint, so it cannot help if the key is genuinely lost. Recovering a lost key requires an org admin to run `agent-fs member reset-key <email>` on the locked-out user's behalf. Either path invalidates the old key immediately.
 
 ### `GET /auth/me`
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -150,6 +150,134 @@
         }
       }
     },
+    "/auth/reset-key": {
+      "post": {
+        "summary": "Reset your own API key",
+        "description": "Rotates the caller's API key. The old key stops working immediately. Records an api_key_reset audit event.",
+        "operationId": "resetApiKey",
+        "tags": [
+          "Auth"
+        ],
+        "responses": {
+          "200": {
+            "description": "API key reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "apiKey"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orgs/{orgId}/members/{userId}/reset-key": {
+      "post": {
+        "summary": "Reset a member's API key (org admin only)",
+        "description": "Org admins can rotate a member's API key on their behalf, e.g. to recover a locked-out user. The old key stops working immediately. Records an api_key_reset audit event with the admin as actor.",
+        "operationId": "resetMemberApiKey",
+        "tags": [
+          "Auth"
+        ],
+        "parameters": [
+          {
+            "name": "orgId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Organization ID"
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "ID of the member whose key to reset"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Member's API key reset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "apiKey": {
+                      "type": "string"
+                    },
+                    "userId": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "apiKey",
+                    "userId",
+                    "email"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an org admin",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Org not found, or userId is not a member of the org",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/orgs/{orgId}/ops": {
       "post": {
         "summary": "Dispatch a file operation",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.3-r.3",
     "bun-types": "^1.4.0",
+    "msgpackr": "^1",
     "typescript": "^5.7.0",
     "yaml": "^2.8.2",
     "zod-to-json-schema": "^3.25.1"

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -45,6 +45,22 @@ export function authCommands(client: ApiClient) {
     });
 
   cmd
+    .command("reset-key")
+    .description("Reset your own API key (the old key stops working)")
+    .action(async () => {
+      try {
+        const result = await client.post("/auth/reset-key", {});
+        console.log(`New API key: ${result.apiKey}`);
+        setConfigValue("auth.apiKey", result.apiKey);
+        client.setApiKey(result.apiKey);
+        console.log("API key saved to config. The old key is now invalid on the server.");
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  cmd
     .command("whoami")
     .description("Show current user info")
     .action(async () => {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -48,11 +48,21 @@ export function authCommands(client: ApiClient) {
     .command("reset-key")
     .description("Reset your own API key (the old key stops working)")
     .action(async () => {
+      const json = cmd.parent?.opts().json;
       try {
         const result = await client.post("/auth/reset-key", {});
-        console.log(`New API key: ${result.apiKey}`);
+        // api-client.ts reads `config.apiKey ?? config.auth.apiKey` — write
+        // both fields so whichever one it resolves holds the fresh key. A
+        // stale top-level `apiKey` (e.g. from the dashboard onboarding path)
+        // would otherwise keep winning over the freshly-rotated auth.apiKey.
         setConfigValue("auth.apiKey", result.apiKey);
+        setConfigValue("apiKey", result.apiKey);
         client.setApiKey(result.apiKey);
+        if (json) {
+          console.log(JSON.stringify({ apiKey: result.apiKey }, null, 2));
+          return;
+        }
+        console.log(`New API key: ${result.apiKey}`);
         console.log("API key saved to config. The old key is now invalid on the server.");
       } catch (err: any) {
         console.error(`Error: ${err.message}`);

--- a/packages/cli/src/commands/member.ts
+++ b/packages/cli/src/commands/member.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import type { ApiClient } from "../api-client.js";
+import { setConfigValue } from "@/core";
 
 export function memberCommands(
   client: ApiClient,
@@ -98,6 +99,19 @@ export function memberCommands(
           `/orgs/${orgId}/members/${userId}/reset-key`,
           {}
         );
+        // An admin can target their own email (e.g. lost their local key but
+        // still knows their old one, or is rotating on a schedule). The
+        // server-side reset invalidates the caller's own credential in that
+        // case, so persist the fresh key locally the same way `auth
+        // reset-key` does — otherwise the admin is locked out by their own
+        // successful reset.
+        const me = await client.getMe();
+        const isSelf = me.userId === result.userId;
+        if (isSelf) {
+          setConfigValue("auth.apiKey", result.apiKey);
+          setConfigValue("apiKey", result.apiKey);
+          client.setApiKey(result.apiKey);
+        }
         if (json) {
           console.log(
             JSON.stringify(
@@ -111,6 +125,9 @@ export function memberCommands(
         console.log(`New API key for ${email}: ${result.apiKey}`);
         console.log("Give this key to the user on a secure channel. The old key is now invalid.");
         console.log("This key is shown only once and grants full access to the user's account.");
+        if (isSelf) {
+          console.log("This is your own account — the new key has been saved to your local config.");
+        }
       } catch (err: any) {
         console.error(`Error: ${err.message}`);
         process.exit(1);

--- a/packages/cli/src/commands/member.ts
+++ b/packages/cli/src/commands/member.ts
@@ -86,6 +86,38 @@ export function memberCommands(
     });
 
   cmd
+    .command("reset-key")
+    .argument("<email>", "User email whose key to reset")
+    .description("Reset a member's API key (org admin only)")
+    .action(async (email: string) => {
+      const json = cmd.parent?.opts().json;
+      try {
+        const orgId = await getOrgId();
+        const userId = await resolveUserId(client, orgId, email);
+        const result = await client.post(
+          `/orgs/${orgId}/members/${userId}/reset-key`,
+          {}
+        );
+        if (json) {
+          console.log(
+            JSON.stringify(
+              { apiKey: result.apiKey, userId: result.userId, email: result.email },
+              null,
+              2
+            )
+          );
+          return;
+        }
+        console.log(`New API key for ${email}: ${result.apiKey}`);
+        console.log("Give this key to the user on a secure channel. The old key is now invalid.");
+        console.log("This key is shown only once and grants full access to the user's account.");
+      } catch (err: any) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+      }
+    });
+
+  cmd
     .command("remove")
     .argument("<email>", "User email to remove")
     .description("Remove a member from org (or drive only if --drive is set)")

--- a/packages/cli/src/commands/member.ts
+++ b/packages/cli/src/commands/member.ts
@@ -95,18 +95,21 @@ export function memberCommands(
       try {
         const orgId = await getOrgId();
         const userId = await resolveUserId(client, orgId, email);
+        // An admin can target their own email (e.g. lost their local key but
+        // still knows their old one, or is rotating on a schedule). Resolve
+        // self-target BEFORE the reset call: the reset invalidates the
+        // caller's own current key, so checking identity afterwards with the
+        // now-stale key would 401.
+        const me = await client.getMe();
+        const isSelf = me.userId === userId;
         const result = await client.post(
           `/orgs/${orgId}/members/${userId}/reset-key`,
           {}
         );
-        // An admin can target their own email (e.g. lost their local key but
-        // still knows their old one, or is rotating on a schedule). The
-        // server-side reset invalidates the caller's own credential in that
-        // case, so persist the fresh key locally the same way `auth
-        // reset-key` does — otherwise the admin is locked out by their own
-        // successful reset.
-        const me = await client.getMe();
-        const isSelf = me.userId === result.userId;
+        // The server-side reset invalidates the caller's own credential in
+        // the self-target case, so persist the fresh key locally the same
+        // way `auth reset-key` does — otherwise the admin is locked out by
+        // their own successful reset.
         if (isSelf) {
           setConfigValue("auth.apiKey", result.apiKey);
           setConfigValue("apiKey", result.apiKey);

--- a/packages/core/src/identity/__tests__/identity.test.ts
+++ b/packages/core/src/identity/__tests__/identity.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createDatabase, schema } from "../../db/index.js";
 import type { DB } from "../../db/index.js";
-import { createUser, getUserByApiKey, getUserByEmail, resetApiKey } from "../users.js";
+import {
+  createUser,
+  getUserByApiKey,
+  getUserByEmail,
+  resetApiKey,
+  resetApiKeyOrgless,
+} from "../users.js";
 import { createOrg, listUserOrgs, getOrg, inviteToOrg } from "../orgs.js";
 import {
   createDrive,
@@ -172,6 +178,43 @@ describe("resetApiKey", () => {
         orgId,
       })
     ).toThrow(NotFoundError);
+  });
+});
+
+describe("resetApiKeyOrgless", () => {
+  // No CLI/HTTP path can reach this state today (every registration
+  // auto-creates a personal org, and its last admin can never be removed —
+  // see `removeOrgMember`), so this simulates it directly at the DB layer by
+  // stripping the user's org membership after creation, matching the
+  // orgless fallback `POST /auth/reset-key` takes when `listUserOrgs`
+  // returns zero rows.
+  test("rotates the key with no orgId to attach an event to", () => {
+    const created = createUser(db, { email: "reset-orgless@example.com" });
+    const oldKey = created.apiKey;
+
+    db.delete(schema.orgMembers)
+      .where(require("drizzle-orm").eq(schema.orgMembers.userId, created.user.id))
+      .run();
+    expect(listUserOrgs(db, created.user.id).length).toBe(0);
+
+    const result = resetApiKeyOrgless(db, created.user.id);
+
+    expect(result.apiKey).toMatch(/^af_[0-9a-f]{64}$/);
+    expect(result.apiKey).not.toBe(oldKey);
+    expect(getUserByApiKey(db, oldKey)).toBeNull();
+    const byNewKey = getUserByApiKey(db, result.apiKey);
+    expect(byNewKey).not.toBeNull();
+    expect(byNewKey!.id).toBe(created.user.id);
+
+    // No orgId to attach an api_key_reset event to (events.orgId is a NOT
+    // NULL FK) — confirm none was written, matching the documented gap.
+    const eventRows = db
+      .select()
+      .from(schema.events)
+      .where(require("drizzle-orm").eq(schema.events.resourceId, created.user.id))
+      .all()
+      .filter((e) => e.type === "api_key_reset");
+    expect(eventRows.length).toBe(0);
   });
 });
 

--- a/packages/core/src/identity/__tests__/identity.test.ts
+++ b/packages/core/src/identity/__tests__/identity.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createDatabase, schema } from "../../db/index.js";
 import type { DB } from "../../db/index.js";
-import { createUser, getUserByApiKey, getUserByEmail } from "../users.js";
+import { createUser, getUserByApiKey, getUserByEmail, resetApiKey } from "../users.js";
 import { createOrg, listUserOrgs, getOrg, inviteToOrg } from "../orgs.js";
 import {
   createDrive,
@@ -93,6 +93,85 @@ describe("User management", () => {
 
     expect(raw!.apiKeyHash).not.toBe(apiKey);
     expect(raw!.apiKeyHash).toMatch(/^[0-9a-f]{64}$/); // SHA-256 hex
+  });
+});
+
+describe("resetApiKey", () => {
+  test("issues a fresh key, invalidates the old one, and records an event", () => {
+    const created = createUser(db, { email: "reset-self@example.com" });
+    const orgId = listUserOrgs(db, created.user.id).find((o) => o.isPersonal)!
+      .id;
+    const oldKey = created.apiKey;
+
+    const result = resetApiKey(db, {
+      userId: created.user.id,
+      actorId: created.user.id,
+      orgId,
+    });
+
+    expect(result.user.id).toBe(created.user.id);
+    expect(result.apiKey).toMatch(/^af_[0-9a-f]{64}$/);
+    expect(result.apiKey).not.toBe(oldKey);
+
+    expect(getUserByApiKey(db, oldKey)).toBeNull();
+    const byNewKey = getUserByApiKey(db, result.apiKey);
+    expect(byNewKey).not.toBeNull();
+    expect(byNewKey!.id).toBe(created.user.id);
+
+    const eventRows = db
+      .select()
+      .from(schema.events)
+      .where(require("drizzle-orm").eq(schema.events.resourceId, created.user.id))
+      .all()
+      .filter((e) => e.type === "api_key_reset");
+    expect(eventRows.length).toBe(1);
+    expect(eventRows[0].actor).toBe(created.user.id);
+    expect(JSON.parse(eventRows[0].metadata!)).toEqual({ method: "self" });
+  });
+
+  test("admin reset records actor distinct from target", () => {
+    const admin = createUser(db, { email: "reset-admin@example.com" });
+    const orgId = listUserOrgs(db, admin.user.id).find((o) => o.isPersonal)!
+      .id;
+    const target = createUser(db, { email: "reset-target@example.com" }).user;
+    inviteToOrg(db, {
+      orgId,
+      email: "reset-target@example.com",
+      role: "viewer",
+    });
+
+    const result = resetApiKey(db, {
+      userId: target.id,
+      actorId: admin.user.id,
+      orgId,
+    });
+
+    expect(result.user.email).toBe("reset-target@example.com");
+
+    const eventRows = db
+      .select()
+      .from(schema.events)
+      .where(require("drizzle-orm").eq(schema.events.resourceId, target.id))
+      .all()
+      .filter((e) => e.type === "api_key_reset");
+    expect(eventRows.length).toBe(1);
+    expect(eventRows[0].actor).toBe(admin.user.id);
+    expect(eventRows[0].target).toBe(target.id);
+    expect(JSON.parse(eventRows[0].metadata!)).toEqual({ method: "admin" });
+  });
+
+  test("throws NotFoundError for an unknown userId", () => {
+    const admin = createUser(db, { email: "reset-unknown@example.com" });
+    const orgId = listUserOrgs(db, admin.user.id).find((o) => o.isPersonal)!
+      .id;
+
+    expect(() =>
+      resetApiKey(db, {
+        userId: "00000000-0000-4000-8000-000000000000",
+        actorId: admin.user.id,
+        orgId,
+      })
+    ).toThrow(NotFoundError);
   });
 });
 

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -1,4 +1,10 @@
-export { createUser, getUserByApiKey, getUserByEmail, resetApiKey } from "./users.js";
+export {
+  createUser,
+  getUserByApiKey,
+  getUserByEmail,
+  resetApiKey,
+  resetApiKeyOrgless,
+} from "./users.js";
 export type { ResetApiKeyResult } from "./users.js";
 export { createOrg, listUserOrgs, getOrg, inviteToOrg, listOrgMembers, updateOrgMemberRole, removeOrgMember } from "./orgs.js";
 export { createDrive, listDrives, listDrivesForUser, getDrive, setDriveMember, listDriveMembers, updateDriveMemberRole, removeDriveMember } from "./drives.js";

--- a/packages/core/src/identity/index.ts
+++ b/packages/core/src/identity/index.ts
@@ -1,4 +1,5 @@
-export { createUser, getUserByApiKey, getUserByEmail } from "./users.js";
+export { createUser, getUserByApiKey, getUserByEmail, resetApiKey } from "./users.js";
+export type { ResetApiKeyResult } from "./users.js";
 export { createOrg, listUserOrgs, getOrg, inviteToOrg, listOrgMembers, updateOrgMemberRole, removeOrgMember } from "./orgs.js";
 export { createDrive, listDrives, listDrivesForUser, getDrive, setDriveMember, listDriveMembers, updateDriveMemberRole, removeDriveMember } from "./drives.js";
 export {

--- a/packages/core/src/identity/users.ts
+++ b/packages/core/src/identity/users.ts
@@ -101,13 +101,19 @@ export function resetApiKey(
 
 /**
  * Fallback for the impossible-in-practice case of a user with no orgs
- * (every user gets an auto-created personal org on registration): rotates
- * the key with no orgId to attach an audit event to, so it skips the event.
+ * (every user gets an auto-created personal org on registration, and the
+ * last admin can never be removed from a personal org — see
+ * `removeOrgMember`). Wrapped in a transaction to match `resetApiKey`'s
+ * atomicity guarantee. Cannot record an `api_key_reset` event like the
+ * org-scoped path does: `events.orgId` is a NOT NULL foreign key to `orgs`,
+ * and there is no orgId to attach an event to here.
  */
 export function resetApiKeyOrgless(db: DB, userId: string): { apiKey: string } {
   const apiKey = generateApiKey();
   const apiKeyHash = hashApiKey(apiKey);
-  db.update(schema.users).set({ apiKeyHash }).where(eq(schema.users.id, userId)).run();
+  db.transaction((tx) => {
+    tx.update(schema.users).set({ apiKeyHash }).where(eq(schema.users.id, userId)).run();
+  });
   return { apiKey };
 }
 

--- a/packages/core/src/identity/users.ts
+++ b/packages/core/src/identity/users.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { schema } from "../db/index.js";
 import type { DB } from "../db/index.js";
 import { createOrg } from "./orgs.js";
+import { NotFoundError } from "../errors.js";
 
 function hashApiKey(key: string): string {
   const hasher = new Bun.CryptoHasher("sha256");
@@ -46,6 +47,56 @@ export function createUser(
   });
 
   return { user: { id, email: params.email }, apiKey };
+}
+
+export interface ResetApiKeyResult {
+  user: { id: string; email: string };
+  apiKey: string; // Only returned on reset
+}
+
+export function resetApiKey(
+  db: DB,
+  params: { userId: string; actorId: string; orgId: string }
+): ResetApiKeyResult {
+  const existing = db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.id, params.userId))
+    .get();
+
+  if (!existing) {
+    throw new NotFoundError("User not found", { suggestion: "Check the user id" });
+  }
+
+  const apiKey = generateApiKey();
+  const apiKeyHash = hashApiKey(apiKey);
+  const now = new Date();
+
+  db.transaction((tx) => {
+    tx.update(schema.users)
+      .set({ apiKeyHash })
+      .where(eq(schema.users.id, params.userId))
+      .run();
+
+    tx.insert(schema.events)
+      .values({
+        id: crypto.randomUUID(),
+        orgId: params.orgId,
+        type: "api_key_reset",
+        resourceType: "user",
+        resourceId: params.userId,
+        actor: params.actorId,
+        target: params.userId,
+        status: "created",
+        metadata: JSON.stringify({
+          method: params.actorId === params.userId ? "self" : "admin",
+        }),
+        createdAt: now,
+      })
+      .run();
+  });
+
+  return { user: { id: existing.id, email: existing.email }, apiKey };
 }
 
 export function getUserByApiKey(

--- a/packages/core/src/identity/users.ts
+++ b/packages/core/src/identity/users.ts
@@ -99,6 +99,18 @@ export function resetApiKey(
   return { user: { id: existing.id, email: existing.email }, apiKey };
 }
 
+/**
+ * Fallback for the impossible-in-practice case of a user with no orgs
+ * (every user gets an auto-created personal org on registration): rotates
+ * the key with no orgId to attach an audit event to, so it skips the event.
+ */
+export function resetApiKeyOrgless(db: DB, userId: string): { apiKey: string } {
+  const apiKey = generateApiKey();
+  const apiKeyHash = hashApiKey(apiKey);
+  db.update(schema.users).set({ apiKeyHash }).where(eq(schema.users.id, userId)).run();
+  return { apiKey };
+}
+
 export function getUserByApiKey(
   db: DB,
   apiKey: string

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,8 @@ export {
   createUser,
   getUserByApiKey,
   getUserByEmail,
+  resetApiKey,
+  resetApiKeyOrgless,
   createOrg,
   listUserOrgs,
   getOrg,
@@ -115,7 +117,7 @@ export {
   resolveContext,
   ensureLocalUser,
 } from "./identity/index.js";
-export type { Role, ResolvedContext } from "./identity/index.js";
+export type { Role, ResolvedContext, ResetApiKeyResult } from "./identity/index.js";
 export { VERSION } from "./version.js";
 export { createEmbeddingProviderFromEnv } from "./search/embeddings/index.js";
 export type { EmbeddingProvider } from "./search/embeddings/index.js";

--- a/packages/core/src/openapi.ts
+++ b/packages/core/src/openapi.ts
@@ -141,6 +141,106 @@ export function generateOpenAPISpec() {
           },
         },
       },
+      "/auth/reset-key": {
+        post: {
+          summary: "Reset your own API key",
+          description:
+            "Rotates the caller's API key. The old key stops working immediately. Records an api_key_reset audit event.",
+          operationId: "resetApiKey",
+          tags: ["Auth"],
+          responses: {
+            "200": {
+              description: "API key reset",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      apiKey: { type: "string" },
+                    },
+                    required: ["apiKey"],
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/orgs/{orgId}/members/{userId}/reset-key": {
+        post: {
+          summary: "Reset a member's API key (org admin only)",
+          description:
+            "Org admins can rotate a member's API key on their behalf, e.g. to recover a locked-out user. The old key stops working immediately. Records an api_key_reset audit event with the admin as actor.",
+          operationId: "resetMemberApiKey",
+          tags: ["Auth"],
+          parameters: [
+            {
+              name: "orgId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "Organization ID",
+            },
+            {
+              name: "userId",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description: "ID of the member whose key to reset",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Member's API key reset",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      apiKey: { type: "string" },
+                      userId: { type: "string" },
+                      email: { type: "string" },
+                    },
+                    required: ["apiKey", "userId", "email"],
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+            "403": {
+              description: "Caller is not an org admin",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+            "404": {
+              description: "Org not found, or userId is not a member of the org",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/Error" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/orgs/{orgId}/ops": {
         post: {
           summary: "Dispatch a file operation",

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -561,3 +561,137 @@ describe("Multi-tenant RBAC", () => {
     expect(hiddenBody).toBe(missingBody);
   });
 });
+
+// --- API key reset routes ---
+
+describe("API key reset routes", () => {
+  function keyReq(key: string, path: string, opts?: RequestInit) {
+    const headers = new Headers(opts?.headers);
+    headers.set("Authorization", `Bearer ${key}`);
+    if (opts?.body) headers.set("Content-Type", "application/json");
+    return app.request(path, { ...opts, headers });
+  }
+
+  async function register(email: string) {
+    const res = await jsonPost("/auth/register", { email });
+    expect(res.status).toBe(200);
+    return res.json() as Promise<{ apiKey: string; userId: string; orgId: string }>;
+  }
+
+  test("self-reset returns a fresh key and invalidates the old one", async () => {
+    const user = await register("reset-self@example.com");
+
+    const resetRes = await keyReq(user.apiKey, "/auth/reset-key", { method: "POST" });
+    expect(resetRes.status).toBe(200);
+    const { apiKey: newKey } = await resetRes.json();
+    expect(newKey).toMatch(/^af_[0-9a-f]{64}$/);
+    expect(newKey).not.toBe(user.apiKey);
+
+    const oldKeyRes = await keyReq(user.apiKey, "/auth/me");
+    expect(oldKeyRes.status).toBe(401);
+
+    const newKeyRes = await keyReq(newKey, "/auth/me");
+    expect(newKeyRes.status).toBe(200);
+    expect((await newKeyRes.json()).email).toBe("reset-self@example.com");
+  });
+
+  test("admin reset by an org admin returns 200 and invalidates the member's old key", async () => {
+    const admin = await register("reset-admin@example.com");
+    const member = await register("reset-member@example.com");
+
+    const orgRes = await keyReq(admin.apiKey, "/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: "reset-org" }),
+    });
+    expect(orgRes.status).toBe(201);
+    const orgId = (await orgRes.json()).id;
+
+    const inviteRes = await keyReq(admin.apiKey, `/orgs/${orgId}/members/invite`, {
+      method: "POST",
+      body: JSON.stringify({ email: "reset-member@example.com", role: "viewer" }),
+    });
+    expect(inviteRes.status).toBe(200);
+
+    const resetRes = await keyReq(
+      admin.apiKey,
+      `/orgs/${orgId}/members/${member.userId}/reset-key`,
+      { method: "POST" }
+    );
+    expect(resetRes.status).toBe(200);
+    const body = await resetRes.json();
+    expect(body.apiKey).toMatch(/^af_[0-9a-f]{64}$/);
+    expect(body.userId).toBe(member.userId);
+    expect(body.email).toBe("reset-member@example.com");
+
+    expect((await keyReq(member.apiKey, "/auth/me")).status).toBe(401);
+    expect((await keyReq(body.apiKey, "/auth/me")).status).toBe(200);
+  });
+
+  test("a non-admin member gets 403 resetting another member's key", async () => {
+    const admin = await register("reset-nonadmin-admin@example.com");
+    const viewer = await register("reset-nonadmin-viewer@example.com");
+    const target = await register("reset-nonadmin-target@example.com");
+
+    const orgRes = await keyReq(admin.apiKey, "/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: "reset-nonadmin-org" }),
+    });
+    const orgId = (await orgRes.json()).id;
+
+    for (const email of ["reset-nonadmin-viewer@example.com", "reset-nonadmin-target@example.com"]) {
+      const res = await keyReq(admin.apiKey, `/orgs/${orgId}/members/invite`, {
+        method: "POST",
+        body: JSON.stringify({ email, role: "viewer" }),
+      });
+      expect(res.status).toBe(200);
+    }
+
+    const resetRes = await keyReq(
+      viewer.apiKey,
+      `/orgs/${orgId}/members/${target.userId}/reset-key`,
+      { method: "POST" }
+    );
+    expect(resetRes.status).toBe(403);
+  });
+
+  test("a caller outside the org gets 404", async () => {
+    const admin = await register("reset-outside-admin@example.com");
+    const target = await register("reset-outside-target@example.com");
+    const outsider = await register("reset-outside-outsider@example.com");
+
+    const orgRes = await keyReq(admin.apiKey, "/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: "reset-outside-org" }),
+    });
+    const orgId = (await orgRes.json()).id;
+    await keyReq(admin.apiKey, `/orgs/${orgId}/members/invite`, {
+      method: "POST",
+      body: JSON.stringify({ email: "reset-outside-target@example.com", role: "viewer" }),
+    });
+
+    const resetRes = await keyReq(
+      outsider.apiKey,
+      `/orgs/${orgId}/members/${target.userId}/reset-key`,
+      { method: "POST" }
+    );
+    expect(resetRes.status).toBe(404);
+  });
+
+  test("an admin reset for a non-member userId gets 404", async () => {
+    const admin = await register("reset-nonmember-admin@example.com");
+    const stranger = await register("reset-nonmember-stranger@example.com");
+
+    const orgRes = await keyReq(admin.apiKey, "/orgs", {
+      method: "POST",
+      body: JSON.stringify({ name: "reset-nonmember-org" }),
+    });
+    const orgId = (await orgRes.json()).id;
+
+    const resetRes = await keyReq(
+      admin.apiKey,
+      `/orgs/${orgId}/members/${stranger.userId}/reset-key`,
+      { method: "POST" }
+    );
+    expect(resetRes.status).toBe(404);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -102,7 +102,12 @@ try {
     s3,
     embeddingProvider,
     appUrl: config.appUrl,
-    resolveApiKey: () => config.auth?.apiKey ?? null,
+    // Reread the persisted config on every call rather than closing over the
+    // startup `config` const above: a self-reset (`auth reset-key`) rewrites
+    // config.json in place, and getConfig() has no cache, so this keeps
+    // in-flight and newly-mounted FUSE connections authenticated without a
+    // daemon restart.
+    resolveApiKey: () => getConfig().auth?.apiKey ?? null,
   });
   console.log(`agent-fs IPC listening on ${socketPath}`);
 } catch (err) {

--- a/packages/server/src/ipc/__tests__/server.test.ts
+++ b/packages/server/src/ipc/__tests__/server.test.ts
@@ -16,6 +16,9 @@ import {
   listUserOrgs,
   listDrives,
   setDriveMember,
+  resetApiKeyOrgless,
+  getConfig,
+  setConfigValue,
 } from "../../../../core/src/index.js";
 import { startIpcServer } from "../server.js";
 
@@ -341,6 +344,81 @@ describe("IPC server — round-trip", () => {
     });
     expect(editorWrite.open_write).toBeDefined();
     expect(editorWrite.open_write.version).toBe(2);
+  });
+});
+
+describe("IPC server — daemon credential after a self-reset (no restart)", () => {
+  // packages/server/src/index.ts:16 reads `const config = getConfig()` once
+  // at process startup. Before the fix, the IPC resolveApiKey closure
+  // returned that frozen snapshot forever, so a self-reset (which rewrites
+  // config.json but not that snapshot) locked out every FUSE mount until the
+  // daemon was restarted. The fix rereads getConfig() on every call, since
+  // getConfig() itself does a fresh disk read with no cache (packages/core/
+  // src/config.ts). This test runs both the frozen and the fresh resolver
+  // against ONE running daemon to prove the fix needs no restart.
+  let tmpHome: string;
+  let prevHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "agent-fs-home-test-"));
+    prevHome = process.env.AGENT_FS_HOME;
+    process.env.AGENT_FS_HOME = tmpHome;
+  });
+
+  afterEach(() => {
+    if (prevHome === undefined) delete process.env.AGENT_FS_HOME;
+    else process.env.AGENT_FS_HOME = prevHome;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("frozen-at-startup resolver 401s after reset; getConfig()-per-call resolver keeps working", async () => {
+    const db = createTestDb();
+    const s3 = new MockS3Client();
+    const { user, apiKey } = createUser(db, { email: "reset-ipc@example.com" });
+    setConfigValue("auth.apiKey", apiKey);
+
+    // Mirrors the buggy packages/server/src/index.ts:16 — read once, before
+    // the daemon has ever seen a reset.
+    const configAtStartup = getConfig();
+    let useFrozenSnapshot = false;
+
+    const socketPath = join(tmpHome, "ipc.sock");
+    const server = startIpcServer(socketPath, {
+      db,
+      s3: s3 as any,
+      embeddingProvider: null,
+      resolveApiKey: () =>
+        (useFrozenSnapshot ? configAtStartup : getConfig()).auth?.apiKey ?? null,
+    });
+
+    try {
+      // Sanity check: both patterns authenticate before any reset happens.
+      const before: any = await roundTrip(socketPath, { op: "list_drives" });
+      expect(before.drives).toBeInstanceOf(Array);
+
+      // Simulate `agent-fs auth reset-key`: rotate the DB-side key hash (the
+      // server-side half of /auth/reset-key) and persist the new key to
+      // config.json (the CLI-side half in auth.ts) — no daemon restart.
+      const { apiKey: newApiKey } = resetApiKeyOrgless(db, user.id);
+      setConfigValue("auth.apiKey", newApiKey);
+
+      // Pre-fix behavior: the resolver frozen at startup keeps offering the
+      // now-revoked key, so the FUSE-mount auth path fails without a restart.
+      useFrozenSnapshot = true;
+      const stale: any = await roundTrip(socketPath, { op: "list_drives" });
+      expect(stale.error).toBeDefined();
+      expect(stale.error.http_status).toBe(401);
+      expect(stale.error.code).toBe("AUTH_MISSING");
+
+      // Fixed behavior: rereading getConfig() picks up the rotated key on
+      // the very next call, on the same running daemon.
+      useFrozenSnapshot = false;
+      const fresh: any = await roundTrip(socketPath, { op: "list_drives" });
+      expect(fresh.drives).toBeInstanceOf(Array);
+      expect(fresh.drives[0].slug).toBe(listDrives(db, listUserOrgs(db, user.id)[0].id)[0].name);
+    } finally {
+      server.stop();
+    }
   });
 });
 

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -1,5 +1,11 @@
 import { Hono } from "hono";
-import { createUser, listUserOrgs, resolveContext } from "@/core";
+import {
+  createUser,
+  listUserOrgs,
+  resolveContext,
+  resetApiKey,
+  resetApiKeyOrgless,
+} from "@/core";
 import type { DB } from "@/core";
 import type { AppEnv } from "../types.js";
 
@@ -56,6 +62,28 @@ export function authRoutes(db: DB) {
         defaultDriveId: null,
       });
     }
+  });
+
+  router.post("/reset-key", (c) => {
+    const user = c.get("user");
+    const orgs = listUserOrgs(db, user.id);
+
+    if (orgs.length === 0) {
+      // Defensive fallback: every user gets an auto-created personal org on
+      // registration, so this should not happen in practice. Without an
+      // orgId there is nowhere to attach the audit event, so skip it.
+      console.warn(`api key reset for user ${user.id} with no orgs; no audit event recorded`);
+      const { apiKey } = resetApiKeyOrgless(db, user.id);
+      return c.json({ apiKey });
+    }
+
+    const org = orgs.find((o) => o.isPersonal) ?? orgs[0];
+    const result = resetApiKey(db, {
+      userId: user.id,
+      actorId: user.id,
+      orgId: org.id,
+    });
+    return c.json({ apiKey: result.apiKey });
   });
 
   return router;

--- a/packages/server/src/routes/orgs.ts
+++ b/packages/server/src/routes/orgs.ts
@@ -16,6 +16,7 @@ import {
   roleAtLeast,
   requireDriveAdmin,
   assertDriveInOrg,
+  resetApiKey,
   NotFoundError,
   PermissionDeniedError,
 } from "@/core";
@@ -131,6 +132,24 @@ export function orgRoutes(db: DB) {
     } catch (err: any) {
       return c.json({ error: "BAD_REQUEST", message: err.message }, 400);
     }
+  });
+
+  router.post("/:orgId/members/:userId/reset-key", (c) => {
+    const user = c.get("user");
+    const orgId = c.req.param("orgId");
+    const targetUserId = c.req.param("userId");
+    requireOrgAdmin(db, user.id, orgId);
+    requireOrgMember(db, targetUserId, orgId);
+    const result = resetApiKey(db, {
+      userId: targetUserId,
+      actorId: user.id,
+      orgId,
+    });
+    return c.json({
+      apiKey: result.apiKey,
+      userId: result.user.id,
+      email: result.user.email,
+    });
   });
 
   router.delete("/:orgId/members/:userId", (c) => {

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -2235,6 +2235,107 @@ async function runStandardTests(daemonUrl: string) {
     }
   });
 
+  await test(
+    "IPC daemon credential survives a self-reset without a restart (FUSE-mount lockout regression)",
+    async () => {
+      // The HTTP-level reset-key tests above don't exercise this bug: HTTP
+      // auth is validated per-request straight against the DB. The daemon's
+      // IPC listener — what a mounted FUSE drive actually talks to — used to
+      // resolve the bearer key from a `config` object read once at process
+      // startup (packages/server/src/index.ts:105), so an existing or
+      // freshly-mounted drive kept authenticating with the revoked key until
+      // the daemon was restarted. This connects to the real running daemon's
+      // Unix socket, the same one the Rust FUSE helper speaks to, and proves
+      // the fix (rereading getConfig() per call) needs no restart.
+      const { Packr, Unpackr } = await import("msgpackr");
+      const packr = new Packr({ useRecords: false });
+      const unpackr = new Unpackr({ useRecords: false });
+
+      function ipcRoundTrip(socketPath: string, body: unknown): Promise<any> {
+        const buf = packr.pack({ id: 1, body });
+        const lenBuf = Buffer.alloc(4);
+        lenBuf.writeUInt32BE(buf.length, 0);
+        const frame = Buffer.concat([lenBuf, buf as unknown as Buffer]);
+        return new Promise((resolve, reject) => {
+          let recvBuf = Buffer.alloc(0);
+          let timeout: ReturnType<typeof setTimeout>;
+          Bun.connect({
+            unix: socketPath,
+            socket: {
+              open(socket) {
+                socket.write(frame);
+                timeout = setTimeout(() => {
+                  reject(new Error("ipc roundTrip timed out"));
+                  socket.end();
+                }, 5000);
+              },
+              data(socket, chunk) {
+                recvBuf = Buffer.concat([recvBuf, chunk]);
+                if (recvBuf.length < 4) return;
+                const len = recvBuf.readUInt32BE(0);
+                if (recvBuf.length < 4 + len) return;
+                const env = unpackr.unpack(recvBuf.subarray(4, 4 + len)) as {
+                  id: number;
+                  body: unknown;
+                };
+                clearTimeout(timeout);
+                socket.end();
+                resolve(env.body);
+              },
+              error(_socket, err) {
+                clearTimeout(timeout);
+                reject(err);
+              },
+            },
+          }).catch(reject);
+        });
+      }
+
+      const socketPath = join(testDir, "agent-fs.sock");
+
+      const regRes = await fetch(`${daemonUrl}/auth/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: "reset-ipc-mount@e2e.local" }),
+      });
+      assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+      const regData = (await regRes.json()) as any;
+      const oldKey = regData.apiKey;
+
+      const configPath = join(testDir, "config.json");
+      const original = readFileSync(configPath, "utf-8");
+      const config = JSON.parse(original);
+      config.auth.apiKey = oldKey;
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+      try {
+        // Sanity check: the daemon's IPC listener authenticates the freshly
+        // registered key before any reset happens.
+        const before: any = await ipcRoundTrip(socketPath, { op: "list_drives" });
+        assert(
+          Array.isArray(before.drives),
+          true,
+          `Expected drives array before reset, got: ${JSON.stringify(before)}`
+        );
+
+        // Reset via the real CLI path, against the real running daemon —
+        // no restart between this call and the next IPC round trip.
+        const out = runWithEnv("auth reset-key", { AGENT_FS_API_KEY: oldKey });
+        const match = out.match(/New API key: (af_[0-9a-f]{64})/);
+        assert(!!match, true, `Expected printed key to match af_[0-9a-f]{64}, got: ${out}`);
+
+        const after: any = await ipcRoundTrip(socketPath, { op: "list_drives" });
+        assert(
+          Array.isArray(after.drives),
+          true,
+          `Expected the IPC listener to accept the rotated key without a daemon restart, got: ${JSON.stringify(after)}`
+        );
+      } finally {
+        writeFileSync(configPath, original);
+      }
+    }
+  );
+
   // Switch back and clean up config
   run(`org switch ${personalOrgId}`);
 

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -2052,6 +2052,74 @@ async function runStandardTests(daemonUrl: string) {
     }
   });
 
+  // -- API key reset --
+
+  await test("self reset: auth reset-key issues a fresh key and invalidates the old one", async () => {
+    const regRes = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "reset-self@e2e.local" }),
+    });
+    assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+    const regData = (await regRes.json()) as any;
+    const oldKey = regData.apiKey;
+
+    const out = runWithEnv("auth reset-key", { AGENT_FS_API_KEY: oldKey });
+    assertIncludes(out, "New API key:");
+    const match = out.match(/New API key: (af_[0-9a-f]{64})/);
+    assert(!!match, true, `Expected printed key to match af_[0-9a-f]{64}, got: ${out}`);
+    const newKey = match![1];
+    assert(newKey !== oldKey, true, "Expected the new key to differ from the old key");
+
+    const oldRes = await fetch(`${daemonUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${oldKey}` },
+    });
+    assert(oldRes.status, 401, `Expected old key to be invalidated (401), got ${oldRes.status}`);
+
+    const newRes = await fetch(`${daemonUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${newKey}` },
+    });
+    assert(newRes.status, 200, `Expected new key to work (200), got ${newRes.status}`);
+  });
+
+  await test("admin reset: member reset-key rotates an invited member's key", async () => {
+    // Personal orgs disallow member removal entirely, so this runs against
+    // the second (shared) org used by the invite/remove tests above.
+    run(`org switch ${secondOrgId}`);
+
+    const regRes = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "reset-member@e2e.local" }),
+    });
+    assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+    const memberData = (await regRes.json()) as any;
+    const oldMemberKey = memberData.apiKey;
+
+    run("member invite reset-member@e2e.local --role viewer");
+
+    const out = run("member reset-key reset-member@e2e.local");
+    assertIncludes(out, "New API key for reset-member@e2e.local:");
+    assertIncludes(out, "old key is now invalid");
+    const match = out.match(/New API key for reset-member@e2e\.local: (af_[0-9a-f]{64})/);
+    assert(!!match, true, `Expected printed key to match af_[0-9a-f]{64}, got: ${out}`);
+    const newMemberKey = match![1];
+
+    const oldRes = await fetch(`${daemonUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${oldMemberKey}` },
+    });
+    assert(oldRes.status, 401, `Expected old member key to be invalidated (401), got ${oldRes.status}`);
+
+    const newRes = await fetch(`${daemonUrl}/auth/me`, {
+      headers: { Authorization: `Bearer ${newMemberKey}` },
+    });
+    assert(newRes.status, 200, `Expected new member key to work (200), got ${newRes.status}`);
+
+    // Clean up, then switch back to the personal org for the tests that follow.
+    run("member remove reset-member@e2e.local");
+    run(`org switch ${personalOrgId}`);
+  });
+
   // Switch back and clean up config
   run(`org switch ${personalOrgId}`);
 
@@ -2880,8 +2948,10 @@ async function runFuseTests() {
   });
 
   // 8. Auth-expired: kill the daemon's auth and assert EACCES (or auth error in .agent-fs/status).
-  //    Implementation note: a real revocation API doesn't exist yet in v1; we approximate
-  //    by truncating the API key in the config so the next op gets 401 → EACCES.
+  //    Implementation note: a real revocation API exists now (POST /auth/reset-key,
+  //    see "self reset" / "admin reset" in the CLI suite above); this FUSE test still
+  //    corrupts the local config's key directly because it's exercising the mount's
+  //    read path for an already-invalid key, not the reset op itself.
   await fuseTest("auth-expired: corrupted api-key surfaces auth error", async () => {
     runFuseCmd(`mkdir -p /mnt/agent-fs`);
     inFs(`mount /mnt/agent-fs`);

--- a/scripts/e2e.ts
+++ b/scripts/e2e.ts
@@ -112,6 +112,16 @@ const testEnv = (): NodeJS.ProcessEnv => {
     AGENT_FS_DEFAULT_DRIVE_ID: "",
     AGENT_FS_SHARED_ORG_ID: "",
     BUCKET_NAME: "",
+    // Same story for API credentials: `run`/`runWithEnv` override these
+    // explicitly per-call, but `runRaw` (used by tests that deliberately
+    // exercise config-file-only auth resolution) does not — a stray
+    // AGENT_FS_API_KEY/AGENT_FS_API_URL from an agent-swarm worker's own
+    // real agent-fs account would otherwise leak through and point the CLI
+    // at production instead of this ephemeral test daemon. `undefined` (not
+    // "") so api-client.ts's `??` fallback to config still applies — an
+    // empty string is not nullish and would short-circuit it.
+    AGENT_FS_API_KEY: undefined,
+    AGENT_FS_API_URL: undefined,
   };
 
   if (localOnly) {
@@ -2118,6 +2128,111 @@ async function runStandardTests(daemonUrl: string) {
     // Clean up, then switch back to the personal org for the tests that follow.
     run("member remove reset-member@e2e.local");
     run(`org switch ${personalOrgId}`);
+  });
+
+  await test("self reset: auth reset-key --json returns structured output", async () => {
+    const regRes = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "reset-json@e2e.local" }),
+    });
+    assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+    const regData = (await regRes.json()) as any;
+
+    const out = runWithEnv("--json auth reset-key", { AGENT_FS_API_KEY: regData.apiKey });
+    const parsed = JSON.parse(out);
+    assert(typeof parsed.apiKey, "string", "Expected --json output to include an apiKey string");
+    assert(!out.includes("New API key:"), true, "Expected --json output to skip the plain-text banner");
+  });
+
+  await test("persisted-key path: auth reset-key updates the config field api-client reads", async () => {
+    // api-client.ts resolves `config.apiKey ?? config.auth.apiKey`. Simulate
+    // the dashboard-onboarding shape (only the top-level field populated) to
+    // reproduce the bug where a reset only updated auth.apiKey and left the
+    // client reading a stale, now-invalid top-level key.
+    const regRes = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "reset-persisted@e2e.local" }),
+    });
+    assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+    const regData = (await regRes.json()) as any;
+    const oldKey = regData.apiKey;
+
+    const configPath = join(testDir, "config.json");
+    const original = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(original);
+    config.apiKey = oldKey;
+    config.auth.apiKey = "";
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    try {
+      // No AGENT_FS_API_KEY override — relies entirely on persisted config,
+      // same as a real interactive session would.
+      const out = runRaw("auth reset-key");
+      assertIncludes(out, "New API key:");
+      const match = out.match(/New API key: (af_[0-9a-f]{64})/);
+      assert(!!match, true, `Expected printed key to match af_[0-9a-f]{64}, got: ${out}`);
+      const newKey = match![1];
+      assert(newKey !== oldKey, true, "Expected the new key to differ from the old key");
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      assert(updated.apiKey, newKey, "Expected top-level config.apiKey to hold the fresh key");
+      assert(updated.auth.apiKey, newKey, "Expected config.auth.apiKey to hold the fresh key");
+
+      // A follow-up command relying purely on the persisted config (no env
+      // override) must authenticate with the new key, not 401 on the stale one.
+      const whoamiOut = runRaw("auth whoami");
+      assertIncludes(whoamiOut, "reset-persisted@e2e.local");
+    } finally {
+      writeFileSync(configPath, original);
+    }
+  });
+
+  await test("admin self-target reset: member reset-key <own email> persists the new key locally", async () => {
+    const regRes = await fetch(`${daemonUrl}/auth/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "reset-admin-self@e2e.local" }),
+    });
+    assert(regRes.ok, true, `Expected 200, got ${regRes.status}`);
+    const regData = (await regRes.json()) as any;
+    const oldKey = regData.apiKey;
+
+    const configPath = join(testDir, "config.json");
+    const original = readFileSync(configPath, "utf-8");
+    const config = JSON.parse(original);
+    config.auth.apiKey = oldKey;
+    delete config.apiKey;
+    writeFileSync(configPath, JSON.stringify(config, null, 2));
+
+    try {
+      // The freshly-registered user is admin of their own personal org, so
+      // targeting their own email exercises the admin self-reset path.
+      // --org pins the context explicitly: config.defaultOrg may still hold
+      // the primary test user's org from an earlier `org switch` test, which
+      // would misresolve getOrgId() for this different user/session.
+      const out = runRaw(`--org ${regData.orgId} member reset-key reset-admin-self@e2e.local`);
+      assertIncludes(out, "New API key for reset-admin-self@e2e.local:");
+      const match = out.match(/New API key for reset-admin-self@e2e\.local: (af_[0-9a-f]{64})/);
+      assert(!!match, true, `Expected printed key to match af_[0-9a-f]{64}, got: ${out}`);
+      const newKey = match![1];
+      assert(newKey !== oldKey, true, "Expected the new key to differ from the old key");
+
+      const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+      assert(
+        updated.auth.apiKey,
+        newKey,
+        "Expected the admin's own reset to persist the fresh key to local config"
+      );
+
+      // A follow-up command relying purely on the persisted config must
+      // authenticate with the fresh key, not the invalidated old one.
+      const whoamiOut = runRaw("auth whoami");
+      assertIncludes(whoamiOut, "reset-admin-self@e2e.local");
+    } finally {
+      writeFileSync(configPath, original);
+    }
   });
 
   // Switch back and clean up config

--- a/skills/agent-fs/SKILL.md
+++ b/skills/agent-fs/SKILL.md
@@ -6,7 +6,8 @@ description: >-
   "find that file", "store this document", "search agent-fs", "list my files",
   "show version history", "revert file", "set up agent-fs", "get a signed url",
   "share this file", "manage members", "invite user", "list members", "remove member",
-  "update role", file persistence for agents, shared agent filesystem, or any
+  "update role", "reset api key", "rotate api key", "lost my api key", file
+  persistence for agents, shared agent filesystem, or any
   mention of the agent-fs CLI. Also use when the user needs to manage drives,
   manage org/drive members, generate presigned URLs, check recent activity, or use
   semantic search across stored files. Also use when the user wants to run SQL
@@ -197,6 +198,7 @@ Supported formats: csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also `.gz` 
 | `init` | `agent-fs init [--local] [-y]` | Alias for `onboard` |
 | `auth register` | `agent-fs auth register <email>` | Register a new user |
 | `auth whoami` | `agent-fs auth whoami` | Show current user info |
+| `auth reset-key` | `agent-fs auth reset-key` | Reset your own API key. The old key stops working immediately. |
 
 ### Member Management
 
@@ -206,6 +208,7 @@ Supported formats: csv, tsv, parquet, xlsx, json, ndjson/jsonl (each also `.gz` 
 | `member invite` | `agent-fs member invite <email> --role <role>` | Invite user to org (viewer/editor/admin) |
 | `member update-role` | `agent-fs member update-role <email> --role <role>` | Update org role (use `--drive <id>` for drive role) |
 | `member remove` | `agent-fs member remove <email>` | Remove from org (use `--drive <id>` for drive only) |
+| `member reset-key` | `agent-fs member reset-key <email>` | Reset a member's API key (org admin only). The old key stops working immediately. |
 
 The `--drive` flag is a global option — place it before the subcommand: `agent-fs --drive <id> member list`.
 


### PR DESCRIPTION
## Summary
This adds a first-class way to reset an agent-fs API key, replacing the current "re-register" workaround — keys are shown exactly once at registration today and there is no way to rotate a lost or leaked key without creating a brand-new user.
Two new endpoints: `POST /auth/reset-key` lets an authenticated user rotate their own key, and `POST /orgs/{orgId}/members/{userId}/reset-key` lets an org admin rotate a member's key (403 for non-admins acting on the route, 404 when the target is not a member of that org).
Two new CLI commands: `agent-fs auth reset-key` and `agent-fs member reset-key <email>`, both with `--json` support; the admin command never writes the target member's new key into the admin's own local config.
Every reset inserts an `api_key_reset` audit event (`method: "self"` or `"admin"`) in the same transaction as the key-hash update, via the new `resetApiKey` core op in `packages/core/src/identity/users.ts` (plus a small `resetApiKeyOrgless` fallback for the defensive case of a self-reset by a user with zero orgs).

## Test plan

Run from the repo root on this branch:

```bash
bun install --frozen-lockfile
bun run typecheck
```
Expected: `tsc --build` exits 0, no errors.

```bash
bun run build
bun run test
```
Expected: `522 pass / 0 fail / 57 skip`.

```bash
bun run scripts/e2e.ts "bun run packages/cli/src/index.ts --" --local-only
```
Expected: `124/124` passing (15 skipped, all Docker/MinIO-gated) — this is the exact CI `e2e` job.

```bash
bun run scripts/sync-openapi.ts
git diff --exit-code docs/openapi.json
```
Expected: clean, no diff (OpenAPI spec already committed up to date).

```bash
find packages/*/src -maxdepth 1 -name "*.js"
```
Expected: no output (stale-`.js` guard).

## Redeploy surfaces

- **Sandbox backend** `agent-fs.sandbox.capchase.com` — needs a redeploy to pick up the two new routes (`/auth/reset-key`, `/orgs/{orgId}/members/{userId}/reset-key`) and the new `resetApiKey` core op. See DEPLOYMENT.md.
- **`live/` and `landing/` (Vercel)** — no functional change in this PR (CLI/server-only), so no redeploy is required for these, but they auto-deploy previews on this PR regardless per the standard Vercel Git integration.

## Plan
Implements the plan Daniel approved in `thoughts/6557a439-15b8-4c55-a639-638626f4983e/research/2026-09-01-agent-fs-api-key-reset.md`.

## Note
This PR replaces #35, which was opened by mistake against the upstream `desplega-ai/agent-fs` instead of `Capchase/agent-fs`. Same branch, same commits, correct base repo.
