### PR TITLE
feat(live): create, upload, rename and delete files in the web UI

### DIFF
--- a/live/package.json
+++ b/live/package.json
@@ -27,6 +27,7 @@
     "monaco-editor": "^0.55.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-dropzone": "^20.1.1",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.10.0",
     "react-router": "^7.6.0",

--- a/live/pnpm-lock.yaml
+++ b/live/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      react-dropzone:
+        specifier: ^20.1.1
+        version: 20.1.1(@types/react@19.2.14)(react@19.2.4)
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
@@ -953,6 +956,10 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  attr-accept@4.0.0:
+    resolution: {integrity: sha512-hmCnJClmeKNKlsBHgbM8yLZRiQZ4/20UXbLJb6OUT16eWcM5/xNZerr80a/zCYob768KIGq++aLrQNTuwPsIOQ==}
+    engines: {node: '>= 22'}
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1517,6 +1524,10 @@ packages:
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
+
+  file-selector@5.0.1:
+    resolution: {integrity: sha512-v0g/PTeuQgvKCBrVRsfVudvwXlRHSWHEQkVgKawgCGHkEpKA1clp3Om5jvEVhz8G9W/mOYjJH9FhkH4C888PgQ==}
+    engines: {node: '>= 22'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2442,6 +2453,16 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-dropzone@20.1.1:
+    resolution: {integrity: sha512-2cilRFP8bsjDOHpV0sJ6XY8pzJhmz4/cQ6s9yeckOACWYDR+n4MGGtnJh3Rycq/9SLhDWugqDx1z5mtfmOOZhw==}
+    engines: {node: '>= 22'}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>= 18'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -3865,6 +3886,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  attr-accept@4.0.0: {}
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4443,6 +4466,8 @@ snapshots:
   figures@6.1.0:
     dependencies:
       is-unicode-supported: 2.1.0
+
+  file-selector@5.0.1: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -5520,6 +5545,14 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-dropzone@20.1.1(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      attr-accept: 4.0.0
+      file-selector: 5.0.1
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/live/src/App.tsx
+++ b/live/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, useNavigate, useParams } from "react-router"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { TooltipProvider } from "@/components/ui/tooltip"
@@ -81,17 +81,29 @@ function RouteParamsSync({ syncFile = true }: { syncFile?: boolean } = {}) {
   const paramDriveId = params.driveId
   const paramFile = params["*"] ?? null
 
+  // URL -> context is one-way and must fire only when the URL changes. The
+  // router applies navigations inside a transition, so an in-app org or drive
+  // switch commits its context update first, while this route (and its stale
+  // params) is still mounted. With `orgId`/`driveId` in the deps that commit
+  // re-ran the sync and the old URL overwrote the switch, which is why a
+  // switch from a file view used to need two clicks. Read the current context
+  // through a ref instead so only a param change triggers a sync.
+  const ctxRef = useRef({ orgId, driveId })
   useEffect(() => {
-    if (paramOrgId && paramOrgId !== orgId) {
-      setOrgId(paramOrgId)
-    }
-  }, [paramOrgId, orgId, setOrgId])
+    ctxRef.current = { orgId, driveId }
+  })
 
   useEffect(() => {
-    if (paramDriveId && paramDriveId !== driveId) {
+    if (paramOrgId && paramOrgId !== ctxRef.current.orgId) {
+      setOrgId(paramOrgId)
+    }
+  }, [paramOrgId, setOrgId])
+
+  useEffect(() => {
+    if (paramDriveId && paramDriveId !== ctxRef.current.driveId) {
       setDriveId(paramDriveId)
     }
-  }, [paramDriveId, driveId, setDriveId])
+  }, [paramDriveId, setDriveId])
 
   useEffect(() => {
     if (!syncFile) return

--- a/live/src/api/client.ts
+++ b/live/src/api/client.ts
@@ -1,4 +1,15 @@
-import type { MeResponse, Drive, OrgMembersResult, RegisterResponse, SqlResult, SqlTableBinding, WriteParams, WriteResult } from "./types"
+import type {
+  MeResponse,
+  Drive,
+  MvResult,
+  OrgMembersResult,
+  RegisterResponse,
+  RmResult,
+  SqlResult,
+  SqlTableBinding,
+  WriteParams,
+  WriteResult,
+} from "./types"
 
 export interface ApiError {
   error: string
@@ -6,6 +17,29 @@ export interface ApiError {
   suggestion?: string
   field?: string
   path?: string
+  /** HTTP status when the error came from a response (absent for network errors). */
+  status?: number
+}
+
+/**
+ * True when a write was rejected because the path is at a different version
+ * than the caller asserted. For create-only writes (`expectedVersion: 0` or
+ * `If-None-Match: *`) this means "the file already exists".
+ */
+export function isConflictError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false
+  const e = err as Partial<ApiError>
+  return e.error === "EDIT_CONFLICT" || e.status === 409
+}
+
+export interface PutRawOptions {
+  /** Create-only: sends `If-None-Match: *`. A 409 means the path already exists. */
+  ifNoneMatch?: boolean
+  /** Version message, stored on the new version row. */
+  message?: string
+  /** Upload progress in bytes. */
+  onProgress?: (loaded: number, total: number) => void
+  signal?: AbortSignal
 }
 
 export class AgentFsClient {
@@ -62,7 +96,7 @@ export class AgentFsClient {
       } catch {
         body = { error: "UNKNOWN", message: res.statusText }
       }
-      throw Object.assign(new Error(body.message), body)
+      throw Object.assign(new Error(body.message), body, { status: res.status })
     }
 
     return res.json()
@@ -124,6 +158,94 @@ export class AgentFsClient {
 
   async write(orgId: string, driveId: string, params: WriteParams): Promise<WriteResult> {
     return this.callOp<WriteResult>(orgId, "write", { ...params }, driveId)
+  }
+
+  /** Move or rename a single file. The server overwrites `to` if it exists. */
+  async mv(orgId: string, driveId: string, params: { from: string; to: string }): Promise<MvResult> {
+    return this.callOp<MvResult>(orgId, "mv", { ...params }, driveId)
+  }
+
+  /** Soft-delete a single file (writes a delete-marker version). */
+  async rm(orgId: string, driveId: string, params: { path: string }): Promise<RmResult> {
+    return this.callOp<RmResult>(orgId, "rm", { ...params }, driveId)
+  }
+
+  /**
+   * Binary upload to `PUT /orgs/:orgId/drives/:driveId/files/<path>/raw`.
+   *
+   * Same wire format as the CLI's `putRaw`: Bearer auth, an octet-stream body
+   * (the server detects MIME from the extension), `If-None-Match: *` for
+   * create-only writes, and a percent-encoded version message. Uses
+   * `XMLHttpRequest` because `fetch` exposes no upload progress. Body limit
+   * is 50 MB on the server; callers should reject larger files before sending.
+   */
+  putRaw(
+    orgId: string,
+    driveId: string,
+    path: string,
+    body: Blob,
+    opts: PutRawOptions = {},
+  ): Promise<WriteResult> {
+    // Encode the whole path as one segment (slashes become `%2F`), the same
+    // shape `getRawUrl` uses. The route's `:filePath{.+}` param does not span
+    // literal slashes, so `files/a/b.txt/raw` 404s while `files/a%2Fb.txt/raw`
+    // is decoded back to `a/b.txt` by the handler.
+    const encoded = encodeURIComponent(path.replace(/^\/+/, ""))
+    const url = `${this.endpoint}/orgs/${orgId}/drives/${driveId}/files/${encoded}/raw`
+
+    return new Promise<WriteResult>((resolve, reject) => {
+      const xhr = new XMLHttpRequest()
+      xhr.open("PUT", url)
+      xhr.responseType = "text"
+      xhr.setRequestHeader("Authorization", `Bearer ${this.apiKey}`)
+      xhr.setRequestHeader("Content-Type", "application/octet-stream")
+      if (opts.ifNoneMatch) xhr.setRequestHeader("If-None-Match", "*")
+      if (opts.message) {
+        xhr.setRequestHeader("X-Agent-FS-Message", encodeURIComponent(opts.message))
+        xhr.setRequestHeader("X-Agent-FS-Message-Encoding", "percent")
+      }
+
+      const onProgress = opts.onProgress
+      if (onProgress) {
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) onProgress(e.loaded, e.total)
+        }
+      }
+
+      xhr.onload = () => {
+        let parsed: unknown = null
+        try {
+          parsed = JSON.parse(xhr.responseText)
+        } catch {
+          parsed = null
+        }
+        if (xhr.status >= 200 && xhr.status < 300 && parsed) {
+          resolve(parsed as WriteResult)
+          return
+        }
+        const apiError: ApiError =
+          parsed && typeof (parsed as ApiError).message === "string"
+            ? (parsed as ApiError)
+            : { error: "UNKNOWN", message: xhr.statusText || `HTTP ${xhr.status}` }
+        reject(Object.assign(new Error(apiError.message), apiError, { status: xhr.status }))
+      }
+      xhr.onerror = () => {
+        reject(Object.assign(new Error(`Cannot reach ${this.endpoint}`), { error: "NETWORK" }))
+      }
+      xhr.onabort = () => {
+        reject(Object.assign(new Error("Upload cancelled"), { error: "ABORTED" }))
+      }
+
+      if (opts.signal) {
+        if (opts.signal.aborted) {
+          reject(Object.assign(new Error("Upload cancelled"), { error: "ABORTED" }))
+          return
+        }
+        opts.signal.addEventListener("abort", () => xhr.abort(), { once: true })
+      }
+
+      xhr.send(body)
+    })
   }
 
   getRawUrl(orgId: string, driveId: string, path: string): string {

--- a/live/src/api/types.ts
+++ b/live/src/api/types.ts
@@ -294,3 +294,16 @@ export interface Org {
   id: string
   name: string
 }
+
+// File mutation ops (mv / rm)
+
+export interface MvResult {
+  from: string
+  to: string
+  version: number
+}
+
+export interface RmResult {
+  path: string
+  deleted: boolean
+}

--- a/live/src/components/DrivePicker.tsx
+++ b/live/src/components/DrivePicker.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, Check, HardDrive, Building2 } from "lucide-react"
+import { useNavigate } from "react-router"
 import { useAuth } from "@/contexts/auth"
 import {
   DropdownMenu,
@@ -8,8 +9,16 @@ import {
 } from "@/components/ui/dropdown-menu"
 
 export function DrivePicker() {
-  const { drives, driveId, driveName, setDriveId, orgName } = useAuth()
+  const { drives, driveId, driveName, setDriveId, orgId, orgName } = useAuth()
+  const navigate = useNavigate()
   const hasMultiple = drives.length > 1
+
+  // Keep the URL in step with the context so a reload lands on the same drive.
+  const pickDrive = (id: string) => {
+    if (id === driveId) return
+    setDriveId(id)
+    navigate(orgId ? `/file/~/${orgId}/${id}/` : "/files")
+  }
 
   return (
     <div className="border-b border-sidebar-border px-3 py-2 space-y-1">
@@ -31,7 +40,7 @@ export function DrivePicker() {
             {drives.map((drive) => (
               <DropdownMenuItem
                 key={drive.id}
-                onClick={() => setDriveId(drive.id)}
+                onClick={() => pickDrive(drive.id)}
               >
                 <span className="truncate flex-1">{drive.name}</span>
                 {drive.id === driveId && <Check className="size-3 text-primary ml-auto" />}

--- a/live/src/components/file-mutations/DeleteDialog.tsx
+++ b/live/src/components/file-mutations/DeleteDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { useBrowser } from "@/contexts/browser"
+import { useFileMutations } from "@/hooks/use-file-mutations"
+import { parentOf } from "@/lib/paths"
+import { toast } from "@/stores/toast"
+
+interface DeleteDialogProps {
+  /** Drive-relative path of the file to delete. */
+  path: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Confirm-and-delete for a single file via the `rm` op. `rm` writes a delete
+ * marker version, so the history stays available for `revert`.
+ *
+ * Callers mount it only while open, so every opening starts with fresh state.
+ */
+export function DeleteDialog({ path, open, onOpenChange }: DeleteDialogProps) {
+  const { selectedFile, navigateToFolder } = useBrowser()
+  const { deleteFile } = useFileMutations()
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const handleDelete = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await deleteFile(path)
+      toast.success("Deleted", { description: path })
+      onOpenChange(false)
+      if (selectedFile === path) navigateToFolder(parentOf(path))
+    } catch (err) {
+      setError((err as Error).message || "Delete failed.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Delete file</DialogTitle>
+          <DialogDescription>
+            Delete <code className="font-mono text-xs break-all">{path}</code>? It disappears from
+            listings. Its version history is kept, so{" "}
+            <code className="font-mono text-xs">agent-fs revert</code> can restore it.
+          </DialogDescription>
+        </DialogHeader>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={handleDelete}
+            disabled={busy}
+          >
+            {busy ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/live/src/components/file-mutations/FolderActions.tsx
+++ b/live/src/components/file-mutations/FolderActions.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { FilePlus, FolderPlus, FolderUp, Plus, Upload } from "lucide-react"
+import { useAuth } from "@/contexts/auth"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { MAX_UPLOAD_BYTES, toUploadInputs, uploadStore } from "@/stores/upload"
+import { NewEntryDialog, type NewEntryKind } from "./NewEntryDialog"
+
+interface FolderActionsProps {
+  /** Folder the actions target ("" for the drive root). */
+  folder: string
+  size?: "icon-xs" | "icon-sm"
+  className?: string
+}
+
+const UPLOAD_LIMIT_LABEL = `${MAX_UPLOAD_BYTES / 1024 / 1024} MB`
+
+/**
+ * Two icon dropdowns, "New" (file or folder) and "Upload" (files or folder),
+ * bound to one target folder. Used in the folder view header and the sidebar
+ * so creating and uploading stays one click away while a file is open.
+ */
+export function FolderActions({ folder, size = "icon-sm", className }: FolderActionsProps) {
+  const { client, orgId, driveId } = useAuth()
+  const queryClient = useQueryClient()
+  const [dialog, setDialog] = useState<NewEntryKind | null>(null)
+  const filesInputRef = useRef<HTMLInputElement>(null)
+  const dirInputRef = useRef<HTMLInputElement>(null)
+  const enabled = !!orgId && !!driveId
+  const where = folder || "drive root"
+
+  // `webkitdirectory` is not a typed React attribute; set it imperatively.
+  useEffect(() => {
+    dirInputRef.current?.setAttribute("webkitdirectory", "")
+  }, [])
+
+  const enqueue = (files: FileList | null) => {
+    if (!orgId || !driveId || !files || files.length === 0) return
+    uploadStore.enqueue({ client, orgId, driveId, queryClient }, folder, toUploadInputs(Array.from(files)))
+  }
+
+  return (
+    <div className={cn("flex items-center gap-0.5", className)}>
+      <input
+        ref={filesInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        aria-label="Upload files"
+        onChange={(e) => {
+          enqueue(e.target.files)
+          e.target.value = ""
+        }}
+      />
+      <input
+        ref={dirInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        aria-label="Upload folder"
+        onChange={(e) => {
+          enqueue(e.target.files)
+          e.target.value = ""
+        }}
+      />
+
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size={size}
+                    className="text-muted-foreground"
+                    aria-label={`New in ${where}`}
+                    disabled={!enabled}
+                  />
+                }
+              />
+            }
+          >
+            <Plus />
+          </TooltipTrigger>
+          <TooltipContent>New file or folder in {where}</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" className="w-auto min-w-40">
+          <DropdownMenuItem onClick={() => setDialog("file")}>
+            <FilePlus />
+            New file…
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setDialog("folder")}>
+            <FolderPlus />
+            New folder…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size={size}
+                    className="text-muted-foreground"
+                    aria-label={`Upload to ${where}`}
+                    disabled={!enabled}
+                  />
+                }
+              />
+            }
+          >
+            <Upload />
+          </TooltipTrigger>
+          <TooltipContent>Upload to {where} (up to {UPLOAD_LIMIT_LABEL} per file)</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent align="end" className="w-auto min-w-40">
+          <DropdownMenuItem onClick={() => filesInputRef.current?.click()}>
+            <Upload />
+            Files…
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => dirInputRef.current?.click()}>
+            <FolderUp />
+            Folder…
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {dialog && (
+        <NewEntryDialog
+          kind={dialog}
+          basePath={folder}
+          open
+          onOpenChange={(open) => {
+            if (!open) setDialog(null)
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/live/src/components/file-mutations/NewEntryDialog.tsx
+++ b/live/src/components/file-mutations/NewEntryDialog.tsx
@@ -1,0 +1,146 @@
+import { useState, type FormEvent } from "react"
+import { useNavigate } from "react-router"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useAuth } from "@/contexts/auth"
+import { useBrowser } from "@/contexts/browser"
+import { useFileMutations, KEEP_FILE } from "@/hooks/use-file-mutations"
+import { isConflictError } from "@/api/client"
+import { ancestorListings, joinPath, normalizeRelativePath } from "@/lib/paths"
+import { treeExpansionStore } from "@/stores/tree-expansion"
+import { toast } from "@/stores/toast"
+
+export type NewEntryKind = "file" | "folder"
+
+interface NewEntryDialogProps {
+  kind: NewEntryKind
+  /** Folder the new entry is created in ("" for the drive root). */
+  basePath: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * "New file" and "New folder" dialog. Accepts nested relative paths such as
+ * `sub/dir/name.md`. Files are created with `expectedVersion: 0` and opened in
+ * edit mode; folders are materialized through a `.keep` placeholder.
+ *
+ * Callers mount it only while open, so every opening starts with fresh state.
+ */
+export function NewEntryDialog({ kind, basePath, open, onOpenChange }: NewEntryDialogProps) {
+  const { orgId, driveId } = useAuth()
+  const { setSelectedFile, navigateToFolder } = useBrowser()
+  const navigate = useNavigate()
+  const { createFile, createFolder } = useFileMutations()
+  const [value, setValue] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const isFile = kind === "file"
+  const location = basePath || "the drive root"
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    const normalized = normalizeRelativePath(value)
+    if ("error" in normalized) {
+      setError(normalized.error)
+      return
+    }
+    if (!orgId || !driveId) {
+      setError("No drive selected.")
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      if (isFile) {
+        const path = await createFile(basePath, normalized.path)
+        toast.success("File created", { description: path })
+        onOpenChange(false)
+        setSelectedFile(path)
+        navigate(`/file/~/${orgId}/${driveId}/${path}?edit=1`)
+      } else {
+        const folder = await createFolder(basePath, normalized.path)
+        // Reveal the new folder in the tree, then open it.
+        treeExpansionStore.expandMany(
+          ancestorListings(joinPath(folder, KEEP_FILE)).filter((p) => p !== ""),
+        )
+        toast.success("Folder created", { description: folder })
+        onOpenChange(false)
+        navigateToFolder(folder)
+      }
+    } catch (err) {
+      const target = joinPath(basePath, normalized.path)
+      setError(
+        isConflictError(err)
+          ? `Something already exists at ${target}.`
+          : (err as Error).message || "Request failed.",
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>{isFile ? "New file" : "New folder"}</DialogTitle>
+            <DialogDescription>
+              {isFile ? (
+                <>
+                  Created in <code className="font-mono text-xs">{location}</code>. Nested paths
+                  such as <code className="font-mono text-xs">notes/todo.md</code> create the
+                  folders they need.
+                </>
+              ) : (
+                <>
+                  Created in <code className="font-mono text-xs">{location}</code>. An empty{" "}
+                  <code className="font-mono text-xs">.keep</code> file marks the folder so it
+                  shows in listings.
+                </>
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Input
+              autoFocus
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder={isFile ? "notes/todo.md" : "reports/2026"}
+              aria-label={isFile ? "File path" : "Folder path"}
+              aria-invalid={error ? true : undefined}
+              spellCheck={false}
+              autoComplete="off"
+              className="font-mono text-xs"
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={busy || value.trim().length === 0}>
+              {busy ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/live/src/components/file-mutations/RenameDialog.tsx
+++ b/live/src/components/file-mutations/RenameDialog.tsx
@@ -1,0 +1,110 @@
+import { useState, type FormEvent } from "react"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useBrowser } from "@/contexts/browser"
+import { useFileMutations } from "@/hooks/use-file-mutations"
+import { cleanPath, normalizeRelativePath } from "@/lib/paths"
+import { toast } from "@/stores/toast"
+
+interface RenameDialogProps {
+  /** Current drive-relative path of the file. */
+  path: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Rename (or move) a single file with the `mv` op. The input holds the full
+ * drive-relative path so changing a folder segment moves the file. `mv`
+ * overwrites silently, so the dialog refuses a destination that exists.
+ *
+ * Callers mount it only while open, so every opening starts with fresh state.
+ */
+export function RenameDialog({ path, open, onOpenChange }: RenameDialogProps) {
+  const { selectedFile, selectFile } = useBrowser()
+  const { renameFile, exists } = useFileMutations()
+  const [value, setValue] = useState(path)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    const normalized = normalizeRelativePath(value)
+    if ("error" in normalized) {
+      setError(normalized.error)
+      return
+    }
+    const to = normalized.path
+    if (to === cleanPath(path)) {
+      onOpenChange(false)
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      if (await exists(to)) {
+        setError(`A file already exists at ${to}.`)
+        return
+      }
+      await renameFile(path, to)
+      toast.success("Renamed", { description: to })
+      onOpenChange(false)
+      if (selectedFile === path) selectFile(to)
+    } catch (err) {
+      setError((err as Error).message || "Rename failed.")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <form onSubmit={handleSubmit} className="grid gap-4">
+          <DialogHeader>
+            <DialogTitle>Rename file</DialogTitle>
+            <DialogDescription>
+              Edit the full path to rename or move the file. Version history follows it to the
+              new path.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-1.5">
+            <Input
+              autoFocus
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              aria-label="New path"
+              aria-invalid={error ? true : undefined}
+              spellCheck={false}
+              autoComplete="off"
+              className="font-mono text-xs"
+            />
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={busy}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={busy || value.trim().length === 0}>
+              {busy ? "Renaming..." : "Rename"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/live/src/components/file-mutations/UploadPanel.tsx
+++ b/live/src/components/file-mutations/UploadPanel.tsx
@@ -1,0 +1,127 @@
+import { AlertTriangle, Check, X } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Spinner } from "@/components/ui/spinner"
+import { isFinished, uploadStore, useUploads, type UploadItem } from "@/stores/upload"
+import { cn } from "@/lib/utils"
+
+/**
+ * Floating list of queued, running and finished uploads. Renders nothing when
+ * the queue is empty. Conflicts expose Replace / Skip inline.
+ */
+export function UploadPanel({ className }: { className?: string }) {
+  const items = useUploads()
+  if (items.length === 0) return null
+
+  const active = items.filter((i) => i.status === "queued" || i.status === "uploading").length
+  const hasFinished = items.some((i) => isFinished(i.status))
+
+  return (
+    <div
+      className={cn(
+        "flex max-h-72 w-80 flex-col rounded-lg bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/10",
+        className,
+      )}
+      aria-label="Uploads"
+    >
+      <div className="flex items-center justify-between border-b border-border px-3 py-1.5 text-xs">
+        <span className="font-medium">
+          {active > 0 ? `Uploading ${active}...` : "Uploads"}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => uploadStore.clearFinished()}
+          disabled={!hasFinished}
+        >
+          Clear
+        </Button>
+      </div>
+      <ul className="overflow-y-auto p-1">
+        {items.map((item) => (
+          <UploadRow key={item.id} item={item} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function UploadRow({ item }: { item: UploadItem }) {
+  const inFlight = item.status === "queued" || item.status === "uploading"
+  return (
+    <li className="flex flex-col gap-1 rounded-md px-2 py-1.5 text-xs">
+      <div className="flex items-center gap-2">
+        <span className="min-w-0 flex-1 truncate font-mono" title={item.path}>
+          {item.path}
+        </span>
+        <StatusBadge item={item} />
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="text-muted-foreground"
+          aria-label={inFlight ? "Cancel upload" : "Dismiss"}
+          title={inFlight ? "Cancel" : "Dismiss"}
+          onClick={() => (inFlight ? uploadStore.cancel(item.id) : uploadStore.dismiss(item.id))}
+          disabled={item.status === "conflict"}
+        >
+          <X />
+        </Button>
+      </div>
+      {item.status === "uploading" && (
+        <div
+          className="h-1 w-full overflow-hidden rounded bg-muted"
+          role="progressbar"
+          aria-label={`Uploading ${item.path}`}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(item.progress * 100)}
+        >
+          <div
+            className="h-full bg-primary transition-[width] duration-150"
+            style={{ width: `${Math.round(item.progress * 100)}%` }}
+          />
+        </div>
+      )}
+      {item.status === "conflict" && (
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-muted-foreground">Already exists</span>
+          <div className="flex gap-1">
+            <Button type="button" variant="ghost" size="xs" onClick={() => uploadStore.skip(item.id)}>
+              Skip
+            </Button>
+            <Button type="button" variant="outline" size="xs" onClick={() => uploadStore.replace(item.id)}>
+              Replace
+            </Button>
+          </div>
+        </div>
+      )}
+      {(item.status === "error" || item.status === "rejected") && item.error && (
+        <p className="break-words text-destructive">{item.error}</p>
+      )}
+    </li>
+  )
+}
+
+function StatusBadge({ item }: { item: UploadItem }) {
+  switch (item.status) {
+    case "queued":
+      return <span className="shrink-0 text-muted-foreground">Queued</span>
+    case "uploading":
+      return <Spinner size="sm" className="shrink-0" />
+    case "done":
+      return (
+        <span className="flex shrink-0 items-center gap-1 text-muted-foreground">
+          {item.version !== undefined && <span>v{item.version}</span>}
+          <Check className="size-3.5 text-emerald-600 dark:text-emerald-400" />
+        </span>
+      )
+    case "conflict":
+      return <AlertTriangle className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+    case "error":
+    case "rejected":
+      return <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+    case "skipped":
+      return <span className="shrink-0 text-muted-foreground">Skipped</span>
+  }
+}

--- a/live/src/components/file-tree/FileTreeNode.tsx
+++ b/live/src/components/file-tree/FileTreeNode.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { useQuery } from "@tanstack/react-query"
 import {
   Folder,
@@ -8,6 +9,10 @@ import {
   Download,
   Link as LinkIcon,
   FolderOpen as OpenIcon,
+  FilePlus,
+  FolderPlus,
+  Pencil,
+  Trash2,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useAuth } from "@/contexts/auth"
@@ -32,7 +37,12 @@ import {
   ContextMenuItem,
   ContextMenuSeparator,
 } from "@/components/ui/context-menu"
+import { NewEntryDialog, type NewEntryKind } from "@/components/file-mutations/NewEntryDialog"
+import { RenameDialog } from "@/components/file-mutations/RenameDialog"
+import { DeleteDialog } from "@/components/file-mutations/DeleteDialog"
 import type { LsEntry, LsResult } from "@/api/types"
+
+type NodeDialog = NewEntryKind | "rename" | "delete"
 
 interface FileTreeNodeProps {
   entry: LsEntry
@@ -75,6 +85,14 @@ export function FileTreeNode({ entry, path, depth, isDefaultFocus = false }: Fil
   const tabIndex = isFocused || (focusedPath === null && isDefaultFocus) ? 0 : -1
   const isUuidDir = isDir && isUuidLike(entry.name)
   const resolvedUuidName = useUuidName(path, isUuidDir ? entry.name : "")
+  // Mutation dialogs opened from the context menu. Mounted only while open so
+  // a large tree does not carry a dialog per row.
+  const [dialog, setDialog] = useState<NodeDialog | null>(null)
+  const closeDialog = (open: boolean) => {
+    if (!open) setDialog(null)
+  }
+  // "New file" / "New folder" target the folder itself, or a file's parent.
+  const newEntryBase = isDir ? fullPath : path
 
   const { data: children } = useQuery({
     queryKey: ["ls", orgId, driveId, fullPath],
@@ -224,6 +242,29 @@ export function FileTreeNode({ entry, path, depth, isDefaultFocus = false }: Fil
             Download
           </ContextMenuItem>
           <ContextMenuSeparator />
+          <ContextMenuItem onClick={() => setDialog("file")} disabled={!driveId}>
+            <FilePlus className="h-4 w-4" />
+            New file…
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => setDialog("folder")} disabled={!driveId}>
+            <FolderPlus className="h-4 w-4" />
+            New folder…
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          {/* mv and rm are single-file ops; folders stay read-only here. */}
+          <ContextMenuItem onClick={() => setDialog("rename")} disabled={isDir || !driveId}>
+            <Pencil className="h-4 w-4" />
+            Rename…
+          </ContextMenuItem>
+          <ContextMenuItem
+            variant="destructive"
+            onClick={() => setDialog("delete")}
+            disabled={isDir || !driveId}
+          >
+            <Trash2 className="h-4 w-4" />
+            Delete…
+          </ContextMenuItem>
+          <ContextMenuSeparator />
           <ContextMenuItem
             onClick={handleOpenInNewTab}
             disabled={!deepLink}
@@ -233,6 +274,16 @@ export function FileTreeNode({ entry, path, depth, isDefaultFocus = false }: Fil
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+
+      {(dialog === "file" || dialog === "folder") && (
+        <NewEntryDialog kind={dialog} basePath={newEntryBase} open onOpenChange={closeDialog} />
+      )}
+      {dialog === "rename" && (
+        <RenameDialog path={fullPath} open onOpenChange={closeDialog} />
+      )}
+      {dialog === "delete" && (
+        <DeleteDialog path={fullPath} open onOpenChange={closeDialog} />
+      )}
 
       {isDir && expanded && children && (
         <div>

--- a/live/src/components/folder-view/FolderView.tsx
+++ b/live/src/components/folder-view/FolderView.tsx
@@ -1,13 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo } from "react"
 import { useNavigate } from "react-router"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useDropzone } from "react-dropzone"
-import { FolderOpen, FilePlus, FolderPlus, FolderUp, Upload } from "lucide-react"
+import { FolderOpen, FilePlus, Upload } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { useBrowser } from "@/contexts/browser"
-import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
-import { NewEntryDialog, type NewEntryKind } from "@/components/file-mutations/NewEntryDialog"
+import { FolderActions } from "@/components/file-mutations/FolderActions"
 import { MAX_UPLOAD_BYTES, toUploadInputs, uploadStore } from "@/stores/upload"
 import { cleanPath } from "@/lib/paths"
 import { ListView } from "./ListView"
@@ -34,7 +33,7 @@ const UPLOAD_LIMIT_LABEL = `${MAX_UPLOAD_BYTES / 1024 / 1024} MB`
  * `selectFile` flow which navigates the SPA + selects the file.
  *
  * The whole pane is a drop zone: dropped files and folders upload into the
- * current folder. The header offers New file, New folder and Upload actions.
+ * current folder. The header carries the New and Upload dropdowns.
  */
 export function FolderView({ path }: FolderViewProps) {
   const { client, orgId, driveId } = useAuth()
@@ -42,8 +41,6 @@ export function FolderView({ path }: FolderViewProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [mode] = useFolderViewMode()
-  const [dialog, setDialog] = useState<NewEntryKind | null>(null)
-  const dirInputRef = useRef<HTMLInputElement>(null)
   const canMutate = !!orgId && !!driveId
 
   // Normalize: strip trailing/leading slashes so we have a canonical path.
@@ -88,12 +85,12 @@ export function FolderView({ path }: FolderViewProps) {
   )
 
   // react-dropzone traverses dropped folders via `webkitGetAsEntry` and keeps
-  // each file's relative path. Clicks and keyboard are handled by our own
-  // buttons, so the root only reacts to drops (its default
-  // `preventDropOnDocument` also stops a missed drop from navigating away).
-  // Paste-to-upload stays off: the dialogs render inside this React tree and
-  // a pasted image while typing a path should not start an upload.
-  const { getRootProps, getInputProps, open: openFilePicker, isDragActive } = useDropzone({
+  // each file's relative path. The pickers live in `FolderActions`, so the
+  // root only reacts to drops (its default `preventDropOnDocument` also stops
+  // a missed drop from navigating away). Paste-to-upload stays off: the
+  // dialogs render inside this React tree and a pasted image while typing a
+  // path should not start an upload.
+  const { getRootProps, isDragActive } = useDropzone({
     onDrop: enqueueFiles,
     noClick: true,
     noKeyboard: true,
@@ -103,27 +100,14 @@ export function FolderView({ path }: FolderViewProps) {
     disabled: !canMutate,
   })
 
-  // `webkitdirectory` is not a typed React attribute; set it imperatively on
-  // the second hidden input that backs the "Upload folder" button.
-  useEffect(() => {
-    dirInputRef.current?.setAttribute("webkitdirectory", "")
-  }, [])
-
   return (
-    <div {...getRootProps({ className: "relative flex h-full flex-col min-w-0 outline-none" })}>
-      <input {...getInputProps()} />
-      <input
-        ref={dirInputRef}
-        type="file"
-        multiple
-        className="hidden"
-        aria-label="Upload folder"
-        onChange={(e) => {
-          enqueueFiles(Array.from(e.target.files ?? []))
-          e.target.value = ""
-        }}
-      />
-
+    <div
+      {...getRootProps({
+        className: "relative flex h-full flex-col min-w-0 outline-none",
+        role: "region",
+        "aria-label": `Folder ${currentPath || "drive root"}`,
+      })}
+    >
       {/* Header: title (left) + actions and view toggle (right) */}
       <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
         <div className="flex min-w-0 items-center gap-2 text-sm">
@@ -137,51 +121,8 @@ export function FolderView({ path }: FolderViewProps) {
             </span>
           )}
         </div>
-        <div className="flex shrink-0 items-center gap-0.5">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setDialog("file")}
-            disabled={!canMutate}
-            title="New file"
-          >
-            <FilePlus />
-            <span className="hidden lg:inline">New file</span>
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => setDialog("folder")}
-            disabled={!canMutate}
-            title="New folder"
-          >
-            <FolderPlus />
-            <span className="hidden lg:inline">New folder</span>
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={openFilePicker}
-            disabled={!canMutate}
-            title={`Upload files (up to ${UPLOAD_LIMIT_LABEL} each)`}
-          >
-            <Upload />
-            <span className="hidden lg:inline">Upload</span>
-          </Button>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => dirInputRef.current?.click()}
-            disabled={!canMutate}
-            title="Upload a folder"
-          >
-            <FolderUp />
-            <span className="hidden lg:inline">Upload folder</span>
-          </Button>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <FolderActions folder={currentPath} />
           <ViewModeToggle />
         </div>
       </div>
@@ -243,17 +184,6 @@ export function FolderView({ path }: FolderViewProps) {
             </p>
           </div>
         </div>
-      )}
-
-      {dialog && (
-        <NewEntryDialog
-          kind={dialog}
-          basePath={currentPath}
-          open
-          onOpenChange={(open) => {
-            if (!open) setDialog(null)
-          }}
-        />
       )}
     </div>
   )

--- a/live/src/components/folder-view/FolderView.tsx
+++ b/live/src/components/folder-view/FolderView.tsx
@@ -1,10 +1,15 @@
-import { useMemo } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useNavigate } from "react-router"
-import { useQuery } from "@tanstack/react-query"
-import { FolderOpen, FilePlus } from "lucide-react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useDropzone } from "react-dropzone"
+import { FolderOpen, FilePlus, FolderPlus, FolderUp, Upload } from "lucide-react"
 import { useAuth } from "@/contexts/auth"
 import { useBrowser } from "@/contexts/browser"
+import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
+import { NewEntryDialog, type NewEntryKind } from "@/components/file-mutations/NewEntryDialog"
+import { MAX_UPLOAD_BYTES, toUploadInputs, uploadStore } from "@/stores/upload"
+import { cleanPath } from "@/lib/paths"
 import { ListView } from "./ListView"
 import { GridView } from "./GridView"
 import { ViewModeToggle, useFolderViewMode } from "./ViewModeToggle"
@@ -19,26 +24,30 @@ interface FolderViewProps {
   path: string
 }
 
+const UPLOAD_LIMIT_LABEL = `${MAX_UPLOAD_BYTES / 1024 / 1024} MB`
+
 /**
  * Renders the contents of a folder when no file is selected. Toggleable
  * between list and grid views (persisted to `liveui:browser:view`).
  *
  * Folders open by URL navigation (deep-linkable); files open via the existing
  * `selectFile` flow which navigates the SPA + selects the file.
+ *
+ * The whole pane is a drop zone: dropped files and folders upload into the
+ * current folder. The header offers New file, New folder and Upload actions.
  */
 export function FolderView({ path }: FolderViewProps) {
   const { client, orgId, driveId } = useAuth()
   const { selectFile, setSelectedFile } = useBrowser()
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [mode] = useFolderViewMode()
+  const [dialog, setDialog] = useState<NewEntryKind | null>(null)
+  const dirInputRef = useRef<HTMLInputElement>(null)
+  const canMutate = !!orgId && !!driveId
 
   // Normalize: strip trailing/leading slashes so we have a canonical path.
-  const currentPath = useMemo(() => {
-    let p = path ?? ""
-    while (p.endsWith("/")) p = p.slice(0, -1)
-    while (p.startsWith("/")) p = p.slice(1)
-    return p
-  }, [path])
+  const currentPath = useMemo(() => cleanPath(path ?? ""), [path])
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["ls", orgId, driveId, currentPath],
@@ -70,9 +79,52 @@ export function FolderView({ path }: FolderViewProps) {
     }
   }
 
+  const enqueueFiles = useCallback(
+    (files: File[]) => {
+      if (!orgId || !driveId || files.length === 0) return
+      uploadStore.enqueue({ client, orgId, driveId, queryClient }, currentPath, toUploadInputs(files))
+    },
+    [client, orgId, driveId, queryClient, currentPath],
+  )
+
+  // react-dropzone traverses dropped folders via `webkitGetAsEntry` and keeps
+  // each file's relative path. Clicks and keyboard are handled by our own
+  // buttons, so the root only reacts to drops (its default
+  // `preventDropOnDocument` also stops a missed drop from navigating away).
+  // Paste-to-upload stays off: the dialogs render inside this React tree and
+  // a pasted image while typing a path should not start an upload.
+  const { getRootProps, getInputProps, open: openFilePicker, isDragActive } = useDropzone({
+    onDrop: enqueueFiles,
+    noClick: true,
+    noKeyboard: true,
+    noPaste: true,
+    multiple: true,
+    useFsAccessApi: false,
+    disabled: !canMutate,
+  })
+
+  // `webkitdirectory` is not a typed React attribute; set it imperatively on
+  // the second hidden input that backs the "Upload folder" button.
+  useEffect(() => {
+    dirInputRef.current?.setAttribute("webkitdirectory", "")
+  }, [])
+
   return (
-    <div className="flex h-full flex-col min-w-0">
-      {/* Header: title (left) + view toggle (right) */}
+    <div {...getRootProps({ className: "relative flex h-full flex-col min-w-0 outline-none" })}>
+      <input {...getInputProps()} />
+      <input
+        ref={dirInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        aria-label="Upload folder"
+        onChange={(e) => {
+          enqueueFiles(Array.from(e.target.files ?? []))
+          e.target.value = ""
+        }}
+      />
+
+      {/* Header: title (left) + actions and view toggle (right) */}
       <div className="flex items-center justify-between gap-3 border-b border-border px-4 py-2">
         <div className="flex min-w-0 items-center gap-2 text-sm">
           <FolderOpen className="size-4 shrink-0 text-amber-500" />
@@ -85,7 +137,53 @@ export function FolderView({ path }: FolderViewProps) {
             </span>
           )}
         </div>
-        <ViewModeToggle />
+        <div className="flex shrink-0 items-center gap-0.5">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setDialog("file")}
+            disabled={!canMutate}
+            title="New file"
+          >
+            <FilePlus />
+            <span className="hidden lg:inline">New file</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => setDialog("folder")}
+            disabled={!canMutate}
+            title="New folder"
+          >
+            <FolderPlus />
+            <span className="hidden lg:inline">New folder</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={openFilePicker}
+            disabled={!canMutate}
+            title={`Upload files (up to ${UPLOAD_LIMIT_LABEL} each)`}
+          >
+            <Upload />
+            <span className="hidden lg:inline">Upload</span>
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => dirInputRef.current?.click()}
+            disabled={!canMutate}
+            title="Upload a folder"
+          >
+            <FolderUp />
+            <span className="hidden lg:inline">Upload folder</span>
+          </Button>
+          <ViewModeToggle />
+        </div>
       </div>
 
       {/* Body */}
@@ -108,7 +206,7 @@ export function FolderView({ path }: FolderViewProps) {
                 {currentPath ? "This folder is empty" : "This drive is empty"}
               </p>
               <p className="text-xs text-muted-foreground">
-                Files added here will appear automatically.
+                Create a file, or drop files here to upload (up to {UPLOAD_LIMIT_LABEL} each).
               </p>
             </div>
           </div>
@@ -132,6 +230,31 @@ export function FolderView({ path }: FolderViewProps) {
           </>
         )}
       </div>
+
+      {isDragActive && (
+        <div className="pointer-events-none absolute inset-2 z-10 flex items-center justify-center rounded-lg border-2 border-dashed border-primary bg-background/85">
+          <div className="flex flex-col items-center gap-2 text-center">
+            <Upload className="size-6 text-primary" />
+            <p className="text-sm font-medium">
+              Drop to upload into {currentPath || "the drive root"}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Folders keep their structure. Files over {UPLOAD_LIMIT_LABEL} are skipped.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {dialog && (
+        <NewEntryDialog
+          kind={dialog}
+          basePath={currentPath}
+          open
+          onOpenChange={(open) => {
+            if (!open) setDialog(null)
+          }}
+        />
+      )}
     </div>
   )
 }

--- a/live/src/components/layout/DriveSwitcher.tsx
+++ b/live/src/components/layout/DriveSwitcher.tsx
@@ -18,8 +18,8 @@ import { Kbd } from "@/components/ui/kbd"
 import { toast } from "@/stores/toast"
 
 export function DriveSwitcher() {
-  const { drives, driveId, driveName, setDriveId } = useAuth()
-  const { selectFile } = useBrowser()
+  const { drives, driveId, driveName, setDriveId, orgId } = useAuth()
+  const { setSelectedFile } = useBrowser()
   const navigate = useNavigate()
   const displayName = driveName || driveId.slice(0, 8)
 
@@ -68,9 +68,9 @@ export function DriveSwitcher() {
             onClick={() => {
               if (drive.id === driveId) return
               setDriveId(drive.id)
-              selectFile(null)
+              setSelectedFile(null)
               toast(`Switched to ${drive.name}`)
-              navigate("/")
+              navigate(orgId ? `/file/~/${orgId}/${drive.id}/` : "/files")
             }}
           >
             <HardDrive className="size-3 text-muted-foreground" />

--- a/live/src/components/layout/OrgSwitcher.tsx
+++ b/live/src/components/layout/OrgSwitcher.tsx
@@ -19,7 +19,7 @@ import { toast } from "@/stores/toast"
 
 export function OrgSwitcher() {
   const { orgs, orgId, orgName, setOrgId } = useAuth()
-  const { selectFile } = useBrowser()
+  const { setSelectedFile } = useBrowser()
   const navigate = useNavigate()
   const displayName = orgName || orgId?.slice(0, 8) || "..."
 
@@ -68,9 +68,11 @@ export function OrgSwitcher() {
             onClick={() => {
               if (org.id === orgId) return
               setOrgId(org.id)
-              selectFile(null)
+              setSelectedFile(null)
               toast(`Switched to ${org.name}`)
-              navigate("/")
+              // Land on the new org's default (or first) drive root; the
+              // redirect route resolves the drive once it has loaded.
+              navigate(`/orgs/${org.id}/files/`)
             }}
           >
             <Building2 className="size-3 text-muted-foreground" />

--- a/live/src/components/layout/Sidebar.tsx
+++ b/live/src/components/layout/Sidebar.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useId, useState, type KeyboardEvent } from "react"
+import { useEffect, useId, useMemo, useState, type KeyboardEvent } from "react"
 import { FileTree } from "@/components/file-tree/FileTree"
 import { RecentFiles } from "@/components/file-tree/RecentFiles"
+import { FolderActions } from "@/components/file-mutations/FolderActions"
 import { SearchBar } from "@/components/search/SearchBar"
 import { Button } from "@/components/ui/button"
 import { useBrowser } from "@/contexts/browser"
+import { cleanPath, parentOf } from "@/lib/paths"
 import { useFileSearch } from "@/stores/file-search"
 
 type SidebarView = "tree" | "recent"
@@ -24,6 +26,14 @@ export function Sidebar({ children }: { children?: React.ReactNode }) {
   // A user may still switch back to Recent afterward without changing files.
   useEffect(() => {
     if (selectedFile && !selectedFile.endsWith("/")) setView("tree")
+  }, [selectedFile])
+
+  // New / Upload in the sidebar act on the folder the user is looking at:
+  // the open folder, or the open file's parent, else the drive root.
+  const contextFolder = useMemo(() => {
+    if (!selectedFile) return ""
+    if (selectedFile.endsWith("/")) return cleanPath(selectedFile)
+    return parentOf(selectedFile)
   }, [selectedFile])
 
   const selectTab = (next: SidebarView) => {
@@ -57,11 +67,11 @@ export function Sidebar({ children }: { children?: React.ReactNode }) {
     <aside className="flex h-full w-full shrink-0 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground">
       <SearchBar />
       {children}
-      <div className="shrink-0 border-b border-sidebar-border px-3 py-2">
+      <div className="flex shrink-0 items-center gap-1.5 border-b border-sidebar-border px-3 py-2">
         <div
           role="tablist"
           aria-label="File navigation"
-          className="flex rounded-md border border-sidebar-border bg-sidebar-accent/30 p-0.5"
+          className="flex flex-1 rounded-md border border-sidebar-border bg-sidebar-accent/30 p-0.5"
         >
           <Button
             id={treeTabId}
@@ -104,6 +114,7 @@ export function Sidebar({ children }: { children?: React.ReactNode }) {
             Recent
           </Button>
         </div>
+        <FolderActions folder={contextFolder} size="icon-xs" />
       </div>
       <div
         id={activeView === "tree" ? treePanelId : recentPanelId}

--- a/live/src/components/viewers/FileViewer.tsx
+++ b/live/src/components/viewers/FileViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, type MutableRefObject } from "react"
 import { Maximize2, MessageSquare, Code, Eye, Copy, Link, Check, Download, Database, Pencil, Columns2, LayoutGrid } from "lucide-react"
-import { useNavigate } from "react-router"
+import { useNavigate, useSearchParams } from "react-router"
 import { isQueryablePath } from "@/lib/sql-engine/types"
 import { useAuth } from "@/contexts/auth"
 import { useKeyboardShortcuts, type ShortcutMap } from "@/hooks/use-keyboard-shortcuts"
@@ -150,6 +150,20 @@ export function FileViewer({ path, className, showExpandButton = true, showHeade
     setIsEditing(false)
     setMdEditView("source")
   }, [path]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // `?edit=1` (set by the New file dialog) opens the file straight into edit
+  // mode. Runs after the reset above so it wins on the same path change, then
+  // consumes the flag so a reload or Cancel does not re-enter editing.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const wantsEdit = searchParams.get("edit") === "1"
+  useEffect(() => {
+    if (!wantsEdit) return
+    setIsEditing(true)
+    setMdEditView("source")
+    const next = new URLSearchParams(searchParams)
+    next.delete("edit")
+    setSearchParams(next, { replace: true })
+  }, [wantsEdit, path]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleEnterEdit = useCallback(() => {
     setIsEditing(true)

--- a/live/src/hooks/use-file-mutations.ts
+++ b/live/src/hooks/use-file-mutations.ts
@@ -1,0 +1,121 @@
+import { useCallback } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useAuth } from "@/contexts/auth"
+import { isConflictError, type ApiError } from "@/api/client"
+import { invalidateForPath } from "@/lib/listing-cache"
+import { basenameOf, joinPath } from "@/lib/paths"
+
+/** Placeholder written so an empty folder persists and shows up in `ls`. */
+export const KEEP_FILE = ".keep"
+
+function alreadyExists(path: string): Error {
+  return Object.assign(new Error(`Something already exists at ${path}.`), {
+    error: "EDIT_CONFLICT",
+    status: 409,
+  })
+}
+
+/**
+ * Structural file mutations for the UI: create, create folder, rename, delete.
+ * Each call goes through the existing JSON ops (`write`, `mv`, `rm`) and then
+ * invalidates the listings and stat entries the change affects.
+ */
+export function useFileMutations() {
+  const { client, orgId, driveId } = useAuth()
+  const queryClient = useQueryClient()
+
+  /**
+   * True when an object exists at `path`. `stat` heads the stored object, so
+   * it sees files regardless of which route wrote their version rows. Only a
+   * NOT_FOUND answer counts as "free"; any other failure is rethrown so a
+   * network blip cannot be mistaken for a vacant path.
+   */
+  const exists = useCallback(
+    async (path: string): Promise<boolean> => {
+      if (!orgId || !driveId) throw new Error("No org/drive selected")
+      try {
+        await client.callOp(orgId, "stat", { path }, driveId)
+        return true
+      } catch (err) {
+        const e = err as Partial<ApiError>
+        if (e.error === "NOT_FOUND" || e.status === 404) return false
+        throw err
+      }
+    },
+    [client, orgId, driveId],
+  )
+
+  /**
+   * Create-only write. `expectedVersion: 0` is the server's create guard, but
+   * two cases need help from `stat`:
+   * - a file uploaded through `PUT /raw` keeps its version rows under the
+   *   `/path` form, so the JSON op would see version 0 and overwrite it;
+   * - a deleted path keeps its delete-marker rows, so the JSON op rejects a
+   *   legitimate re-creation with a conflict.
+   * So: refuse when the object exists, then write create-only, and on a
+   * conflict re-check the object and write unconditionally only if it is
+   * still absent.
+   */
+  const writeCreateOnly = useCallback(
+    async (path: string, content: string, message: string): Promise<void> => {
+      if (!orgId || !driveId) throw new Error("No org/drive selected")
+      if (await exists(path)) throw alreadyExists(path)
+      try {
+        await client.write(orgId, driveId, { path, content, expectedVersion: 0, message })
+      } catch (err) {
+        if (!isConflictError(err)) throw err
+        if (await exists(path)) throw alreadyExists(path)
+        await client.write(orgId, driveId, { path, content, message })
+      }
+      invalidateForPath(queryClient, orgId, driveId, path)
+    },
+    [client, orgId, driveId, queryClient, exists],
+  )
+
+  /**
+   * Markdown gets a one-line heading so the file is not zero bytes;
+   * everything else starts empty. Returns the full drive-relative path.
+   */
+  const createFile = useCallback(
+    async (base: string, relative: string): Promise<string> => {
+      const path = joinPath(base, relative)
+      const name = basenameOf(path)
+      const mdMatch = /\.(md|mdx)$/i.exec(name)
+      const content = mdMatch ? `# ${name.slice(0, -mdMatch[0].length)}\n` : ""
+      await writeCreateOnly(path, content, "Created in UI")
+      return path
+    },
+    [writeCreateOnly],
+  )
+
+  /** Writes `<folder>/.keep` create-only. Returns the folder path. */
+  const createFolder = useCallback(
+    async (base: string, relative: string): Promise<string> => {
+      const folder = joinPath(base, relative)
+      await writeCreateOnly(joinPath(folder, KEEP_FILE), "", "Created folder in UI")
+      return folder
+    },
+    [writeCreateOnly],
+  )
+
+  const renameFile = useCallback(
+    async (from: string, to: string): Promise<void> => {
+      if (!orgId || !driveId) throw new Error("No org/drive selected")
+      await client.mv(orgId, driveId, { from, to })
+      invalidateForPath(queryClient, orgId, driveId, from)
+      invalidateForPath(queryClient, orgId, driveId, to)
+    },
+    [client, orgId, driveId, queryClient],
+  )
+
+  const deleteFile = useCallback(
+    async (path: string): Promise<void> => {
+      if (!orgId || !driveId) throw new Error("No org/drive selected")
+      await client.rm(orgId, driveId, { path })
+      invalidateForPath(queryClient, orgId, driveId, path)
+    },
+    [client, orgId, driveId, queryClient],
+  )
+
+  return { createFile, createFolder, exists, renameFile, deleteFile }
+}

--- a/live/src/lib/listing-cache.ts
+++ b/live/src/lib/listing-cache.ts
@@ -1,0 +1,40 @@
+import type { QueryClient } from "@tanstack/react-query"
+import { ancestorListings } from "./paths"
+
+/**
+ * Cache invalidation for structural file changes (create, upload, rename,
+ * delete). Folder listings are cached per path under
+ * `["ls", orgId, driveId, folder]`; file metadata under
+ * `["stat", orgId, driveId, path]`. Only mounted queries refetch, so
+ * invalidating the whole root-to-parent chain is cheap and keeps every
+ * expanded tree node and the open folder view consistent.
+ */
+function invalidateListings(
+  queryClient: QueryClient,
+  orgId: string,
+  driveId: string,
+  folders: string[],
+): void {
+  for (const folder of new Set(folders)) {
+    void queryClient.invalidateQueries({
+      queryKey: ["ls", orgId, driveId, folder],
+      exact: true,
+    })
+  }
+}
+
+/** Invalidate every listing that may show `path` plus the file's own stat. */
+export function invalidateForPath(
+  queryClient: QueryClient,
+  orgId: string,
+  driveId: string,
+  path: string,
+): void {
+  invalidateListings(queryClient, orgId, driveId, ancestorListings(path))
+  void queryClient.invalidateQueries({
+    queryKey: ["stat", orgId, driveId, path],
+    exact: true,
+  })
+  // The drive-root "Recent activity" strip lists the latest versions.
+  void queryClient.invalidateQueries({ queryKey: ["recent", orgId, driveId] })
+}

--- a/live/src/lib/paths.ts
+++ b/live/src/lib/paths.ts
@@ -1,0 +1,68 @@
+/**
+ * Drive-relative path helpers shared by the create / upload / rename flows.
+ * Paths are stored without leading or trailing slashes. The drive root is "".
+ */
+
+/** Strip leading and trailing slashes. */
+export function cleanPath(path: string): string {
+  return path.replace(/^\/+|\/+$/g, "")
+}
+
+/** Parent folder of a path ("" for a top-level entry). */
+export function parentOf(path: string): string {
+  const clean = cleanPath(path)
+  const idx = clean.lastIndexOf("/")
+  return idx === -1 ? "" : clean.slice(0, idx)
+}
+
+/** Last path segment. */
+export function basenameOf(path: string): string {
+  const clean = cleanPath(path)
+  const idx = clean.lastIndexOf("/")
+  return idx === -1 ? clean : clean.slice(idx + 1)
+}
+
+/** Join a folder and a relative path, tolerating empty parts and stray slashes. */
+export function joinPath(folder: string, relative: string): string {
+  const a = cleanPath(folder)
+  const b = cleanPath(relative)
+  if (!a) return b
+  if (!b) return a
+  return `${a}/${b}`
+}
+
+/**
+ * Normalize user-typed relative input such as ` sub//dir/name.md `. Returns
+ * an error message instead of a path when the input is empty or escapes the
+ * base folder.
+ */
+export function normalizeRelativePath(input: string): { path: string } | { error: string } {
+  const segments = input
+    .trim()
+    .replace(/\\/g, "/")
+    .split("/")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+  if (segments.length === 0) return { error: "Enter a name." }
+  if (segments.some((s) => s === "." || s === "..")) {
+    return { error: "Paths cannot contain . or .. segments." }
+  }
+  return { path: segments.join("/") }
+}
+
+/**
+ * Every folder listing from the drive root ("") down to the immediate parent
+ * of `path`. Writing `a/b/c.md` returns `["", "a", "a/b"]`: each of those
+ * listings may need to show a folder that did not exist before.
+ */
+export function ancestorListings(path: string): string[] {
+  const parent = parentOf(path)
+  const chain = [""]
+  if (!parent) return chain
+  let acc = ""
+  for (const seg of parent.split("/")) {
+    acc = acc ? `${acc}/${seg}` : seg
+    chain.push(acc)
+  }
+  return chain
+}

--- a/live/src/pages/FileBrowser.tsx
+++ b/live/src/pages/FileBrowser.tsx
@@ -3,6 +3,7 @@ import { useBrowser } from "@/contexts/browser"
 import { FileViewer } from "@/components/viewers/FileViewer"
 import { MainWithComments } from "@/components/layout/MainWithComments"
 import { FolderView } from "@/components/folder-view/FolderView"
+import { UploadPanel } from "@/components/file-mutations/UploadPanel"
 import { useDocumentTitle } from "@/hooks/use-document-title"
 import type { OutlineItem } from "@/lib/outline"
 
@@ -38,24 +39,35 @@ export function FileBrowserPage() {
     return null
   }, [selectedFile])
 
+  // The upload panel floats over both modes so in-flight progress and pending
+  // Replace / Skip prompts stay reachable when the user opens a file mid-upload.
+  // Bottom-left keeps it clear of the comments rail on the right.
+  const uploadPanel = <UploadPanel className="absolute bottom-3 left-3 z-20" />
+
   if (folderPath !== null) {
     // Folder mode — comments rail is hidden by MainWithComments when filePath
     // is null, so we just render the FolderView full-width.
     return (
-      <MainWithComments filePath={null} onCommentClick={handleCommentClick}>
-        <FolderView path={folderPath} />
-      </MainWithComments>
+      <div className="relative h-full">
+        <MainWithComments filePath={null} onCommentClick={handleCommentClick}>
+          <FolderView path={folderPath} />
+        </MainWithComments>
+        {uploadPanel}
+      </div>
     )
   }
 
   return (
-    <MainWithComments filePath={selectedFile} onCommentClick={handleCommentClick} outline={outline}>
-      <FileViewer
-        path={selectedFile!}
-        className="h-full"
-        onScrollToCommentRef={scrollToCommentRef}
-        onOutlineChange={setOutline}
-      />
-    </MainWithComments>
+    <div className="relative h-full">
+      <MainWithComments filePath={selectedFile} onCommentClick={handleCommentClick} outline={outline}>
+        <FileViewer
+          path={selectedFile!}
+          className="h-full"
+          onScrollToCommentRef={scrollToCommentRef}
+          onOutlineChange={setOutline}
+        />
+      </MainWithComments>
+      {uploadPanel}
+    </div>
   )
 }

--- a/live/src/stores/upload.ts
+++ b/live/src/stores/upload.ts
@@ -1,0 +1,233 @@
+import { useSyncExternalStore } from "react"
+import type { QueryClient } from "@tanstack/react-query"
+import { isConflictError, type AgentFsClient } from "@/api/client"
+import { invalidateForPath } from "@/lib/listing-cache"
+import { cleanPath, joinPath } from "@/lib/paths"
+import { toast } from "./toast"
+
+/** Server body limit for `PUT .../raw` (Hono `bodyLimit` and `MAX_RAW_FILE_SIZE`). */
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024
+export const MAX_CONCURRENT_UPLOADS = 3
+
+export type UploadStatus =
+  | "queued"
+  | "uploading"
+  | "done"
+  /** Path already exists; waiting for the user to pick Replace or Skip. */
+  | "conflict"
+  | "error"
+  /** Rejected client-side (over the size cap). Never sent. */
+  | "rejected"
+  | "skipped"
+
+export interface UploadScope {
+  client: AgentFsClient
+  orgId: string
+  driveId: string
+  queryClient: QueryClient
+}
+
+export interface UploadItem {
+  id: number
+  /** Full drive-relative destination path. */
+  path: string
+  file: File
+  /** Org, drive and client the item was dropped into; survives a drive switch. */
+  scope: UploadScope
+  status: UploadStatus
+  /** 0..1 */
+  progress: number
+  error?: string
+  version?: number
+  /** Retry without `If-None-Match: *` after the user confirmed a replace. */
+  overwrite: boolean
+}
+
+export interface UploadInput {
+  file: File
+  /** Path relative to the folder the files were dropped on. */
+  relativePath: string
+}
+
+const FINISHED: ReadonlySet<UploadStatus> = new Set(["done", "error", "rejected", "skipped"])
+export function isFinished(status: UploadStatus): boolean {
+  return FINISHED.has(status)
+}
+
+/**
+ * Destination path relative to the drop folder. react-dropzone (via
+ * file-selector) sets `path` to the entry's full path for folder drops
+ * (`/dir/sub/name.txt`) or `./name.txt` for loose files. A `webkitdirectory`
+ * input sets the native `webkitRelativePath` (`dir/sub/name.txt`).
+ */
+export function toUploadInputs(files: File[]): UploadInput[] {
+  return files.map((file) => {
+    const withPath = file as File & { path?: string }
+    const raw = withPath.path || file.webkitRelativePath || file.name
+    const relativePath = cleanPath(raw.replace(/^\.\//, "")) || file.name
+    return { file, relativePath }
+  })
+}
+
+type Listener = () => void
+
+let nextId = 1
+
+/**
+ * Upload queue. A module-level singleton (same pattern as `stores/toast.ts`)
+ * so in-flight uploads survive navigation inside the app. At most
+ * `MAX_CONCURRENT_UPLOADS` run at once; the first attempt is create-only and
+ * a 409 parks the item in `conflict` until the user chooses Replace or Skip.
+ */
+class UploadStore {
+  private items: UploadItem[] = []
+  private listeners = new Set<Listener>()
+  private controllers = new Map<number, AbortController>()
+  private batch = { done: 0, failed: 0 }
+
+  getItems(): UploadItem[] {
+    return this.items
+  }
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private emit() {
+    this.listeners.forEach((l) => l())
+  }
+
+  private update(id: number, patch: Partial<UploadItem>) {
+    this.items = this.items.map((i) => (i.id === id ? { ...i, ...patch } : i))
+    this.emit()
+  }
+
+  enqueue(scope: UploadScope, folder: string, inputs: UploadInput[]) {
+    const limitMb = MAX_UPLOAD_BYTES / 1024 / 1024
+    const next: UploadItem[] = inputs.map(({ file, relativePath }) => {
+      const tooBig = file.size > MAX_UPLOAD_BYTES
+      return {
+        id: nextId++,
+        path: joinPath(folder, relativePath),
+        file,
+        scope,
+        status: tooBig ? "rejected" : "queued",
+        progress: 0,
+        overwrite: false,
+        error: tooBig ? `Larger than ${limitMb} MB` : undefined,
+      }
+    })
+    this.items = [...this.items, ...next]
+    this.emit()
+    this.pump()
+  }
+
+  replace(id: number) {
+    this.update(id, { status: "queued", overwrite: true, progress: 0, error: undefined })
+    this.pump()
+  }
+
+  skip(id: number) {
+    this.update(id, { status: "skipped" })
+    this.summarizeIfDrained()
+  }
+
+  cancel(id: number) {
+    const item = this.items.find((i) => i.id === id)
+    if (!item) return
+    if (item.status === "uploading") {
+      this.controllers.get(id)?.abort()
+    } else if (item.status === "queued") {
+      this.update(id, { status: "skipped" })
+      this.summarizeIfDrained()
+    }
+  }
+
+  dismiss(id: number) {
+    this.items = this.items.filter((i) => i.id !== id)
+    this.emit()
+  }
+
+  clearFinished() {
+    this.items = this.items.filter((i) => !isFinished(i.status))
+    this.emit()
+  }
+
+  private pump() {
+    let active = this.items.filter((i) => i.status === "uploading").length
+    for (const item of this.items) {
+      if (active >= MAX_CONCURRENT_UPLOADS) break
+      if (item.status !== "queued") continue
+      active++
+      void this.run(item.id)
+    }
+  }
+
+  private async run(id: number) {
+    const item = this.items.find((i) => i.id === id)
+    if (!item) return
+    const { scope } = item
+    const controller = new AbortController()
+    this.controllers.set(id, controller)
+    this.update(id, { status: "uploading", progress: 0 })
+    try {
+      const result = await scope.client.putRaw(scope.orgId, scope.driveId, item.path, item.file, {
+        ifNoneMatch: !item.overwrite,
+        message: "Uploaded from UI",
+        signal: controller.signal,
+        onProgress: (loaded, total) => {
+          this.update(id, { progress: total > 0 ? loaded / total : 0 })
+        },
+      })
+      this.update(id, { status: "done", progress: 1, version: result.version })
+      invalidateForPath(scope.queryClient, scope.orgId, scope.driveId, item.path)
+      this.batch.done++
+    } catch (err) {
+      const code = (err as { error?: string }).error
+      if (isConflictError(err)) {
+        this.update(id, { status: "conflict" })
+      } else if (code === "ABORTED") {
+        this.update(id, { status: "skipped" })
+      } else {
+        this.update(id, { status: "error", error: (err as Error).message || "Upload failed" })
+        this.batch.failed++
+      }
+    } finally {
+      this.controllers.delete(id)
+      this.pump()
+      this.summarizeIfDrained()
+    }
+  }
+
+  /**
+   * One toast per batch instead of one per file, once nothing is in flight
+   * and no conflict is still waiting for a Replace or Skip decision.
+   */
+  private summarizeIfDrained() {
+    const pending = this.items.some(
+      (i) => i.status === "queued" || i.status === "uploading" || i.status === "conflict",
+    )
+    if (pending) return
+    const { done, failed } = this.batch
+    if (done === 0 && failed === 0) return
+    this.batch = { done: 0, failed: 0 }
+    if (failed > 0) {
+      toast.error(`Uploaded ${done}, ${failed} failed`)
+    } else {
+      toast.success(done === 1 ? "Uploaded 1 file" : `Uploaded ${done} files`)
+    }
+  }
+}
+
+export const uploadStore = new UploadStore()
+
+export function useUploads(): UploadItem[] {
+  return useSyncExternalStore(
+    (cb) => uploadStore.subscribe(cb),
+    () => uploadStore.getItems(),
+    () => uploadStore.getItems(),
+  )
+}

--- a/thoughts/taras/plans-yolo/2026-09-03-live-ui-file-mutations.md
+++ b/thoughts/taras/plans-yolo/2026-09-03-live-ui-file-mutations.md
@@ -1,0 +1,96 @@
+---
+date: 2026-09-03T15:30:00Z
+topic: "live/ UI: new file, new folder, upload, rename, delete"
+status: done
+---
+
+# live/ UI: new file, new folder, upload, rename, delete
+
+Source research: `thoughts/taras/research/2026-09-03-ui-file-create-upload-rich-editor.md` (its "Decisions" section is binding).
+
+## Goal
+
+The hosted UI can create files and folders, upload files and folders from the browser, and rename or delete files. All of it uses the existing server routes: the JSON `write`, `mv` and `rm` ops, and `PUT .../files/<path>/raw` for binary upload. Every structural change invalidates the affected `["ls", orgId, driveId, parent]` listings. No changes under `packages/`.
+
+## Decisions
+
+- New file uses `write` with `expectedVersion: 0` so an existing path fails with a conflict instead of a silent overwrite. (given)
+- Before that write the UI runs `stat` on the target and refuses when an object exists. Reason: files uploaded through `PUT /raw` keep their version rows under the `/path` form, so the JSON op alone would see version 0 and overwrite them. After a conflict the UI re-checks `stat`; if the object is absent (only delete-marker rows remain from an earlier `rm`), it writes unconditionally so a deleted path can be created again. (found in review)
+- Nested paths such as `sub/dir/name.md` are accepted in the New file dialog. `.` and `..` segments are rejected. (given)
+- New folder writes `<folder>/.keep` with empty content through the same create-only path. (given)
+- Markdown files get a one-line `# <name>` template so the file is not zero bytes. Other files start empty. (assumed, from the research evaluation)
+- After creating a file the UI navigates to `/file/~/:orgId/:driveId/<path>?edit=1`. `FileViewer` reads `edit=1`, enters the existing edit mode, and strips the param. (assumed: cheapest way to reuse the pencil flow without a new store)
+- Upload transport is `XMLHttpRequest` so each file shows real progress. `putRaw` in `live/src/api/client.ts` mirrors the CLI: Bearer, `Content-Type: application/octet-stream`, `If-None-Match: *` for create-only, percent-encoded `X-Agent-FS-Message`. (given)
+- `putRaw` encodes the whole path with `encodeURIComponent` (slashes become `%2F`), the same shape as the existing `getRawUrl`. Verified against a local daemon: `files/a/b.txt/raw` with literal slashes returns 404, `files/a%2Fb.txt/raw` works. (found during E2E)
+- First attempt sends `If-None-Match: *`. On 409 the upload item shows "Already exists" with Replace and Skip. Replace retries unconditionally because the user confirmed the overwrite. (assumed: avoids a stat round-trip per conflict)
+- Files over 50 MB are rejected client-side before any request. (given)
+- At most 3 uploads run at a time. (given)
+- Upload state lives in a small module-level store (same pattern as `stores/toast.ts`), each item carrying the org, drive and client it was dropped into, so navigating inside the app or switching drives does not lose or misroute in-flight uploads. The panel is mounted in `FileBrowserPage` so it stays visible on both folder and file views. (assumed, refined in review)
+- The batch summary toast waits until no item is queued, uploading, or parked in a conflict. (found in review)
+- `react-dropzone` handles drag-and-drop and folder traversal via `webkitGetAsEntry`. A second hidden `<input webkitdirectory>` covers "Upload folder" from the button. Paste-to-upload is disabled (`noPaste`) so a pasted image while typing a path in a dialog does not start an upload. (given, extended)
+- Rename and Delete apply to files only. `mv` and `rm` are single-file ops, and recursive directory operations are out of scope for this one-shot. Directory rows show the items disabled. (assumed)
+- Rename dialog edits the full drive-relative path, so it doubles as move. Because `mv` overwrites silently, the dialog runs `stat` on the destination first and refuses an existing path. Only a NOT_FOUND answer counts as free; other errors abort the rename. (assumed, hardened in review)
+- Every mutation invalidates the `ls` chain from the drive root down to the immediate parent of each touched path, plus `["stat", ...]` for the path and the drive-root `["recent", ...]` strip. Only mounted queries refetch, so the chain is cheap. (given, extended)
+- Dialogs are mounted only while open (both in `FolderView` and `FileTreeNode`), so every opening starts with fresh state and no reset effects are needed. (review)
+
+## Todo
+
+- [x] `pnpm add react-dropzone` inside `live/`
+- [x] `live/src/api/types.ts`: `MvResult`, `RmResult`
+- [x] `live/src/api/client.ts`: `putRaw` (XHR, progress, abort, conflict detection), `mv`, `rm`, `isConflictError`
+- [x] `live/src/lib/paths.ts`: `cleanPath`, `parentOf`, `basenameOf`, `joinPath`, `normalizeRelativePath`, `ancestorListings`
+- [x] `live/src/lib/listing-cache.ts`: `invalidateForPath`
+- [x] `live/src/hooks/use-file-mutations.ts`: create file, create folder, exists, rename, delete
+- [x] `live/src/stores/upload.ts`: queue, concurrency 3, size cap, conflict state, replace or skip, drain summary toast
+- [x] `live/src/components/file-mutations/NewEntryDialog.tsx` (file and folder kinds)
+- [x] `live/src/components/file-mutations/RenameDialog.tsx`
+- [x] `live/src/components/file-mutations/DeleteDialog.tsx`
+- [x] `live/src/components/file-mutations/UploadPanel.tsx`
+- [x] `live/src/components/folder-view/FolderView.tsx`: header actions, drop zone, hidden inputs, empty-state copy
+- [x] `live/src/pages/FileBrowser.tsx`: mount the upload panel over both modes
+- [x] `live/src/components/file-tree/FileTreeNode.tsx`: New file, New folder, Rename, Delete in the context menu
+- [x] `live/src/components/viewers/FileViewer.tsx`: honor `?edit=1`
+- [x] Verification (`pnpm build`) and browser E2E
+- [x] Code review (Standards + Spec) and fixes
+
+## Verification
+
+- `cd live && pnpm build` passes.
+- Browser E2E: Playwright script at `/tmp/pw/ui-e2e.mjs` (not committed; it borrows `playwright-core` from the qa-use checkout) against an isolated MinIO-backed daemon on port 4898 (`/tmp/agent-fs-ui-e2e-minio-setup.sh`) and `vite` on port 5199. Final run: 39 of 40 checks pass. The one failing check is the deliberate probe of the server path-form finding below. Covered: nested create opens edit mode, create conflict, new folder `.keep`, tree reveal, PUT headers (`octet-stream`, `If-None-Match: *`, Bearer, `%2F` path), picker upload, synthetic drop into a subfolder with overlay, folder upload via `webkitdirectory` keeping structure, conflict prompt surviving navigation to a file, Replace without `If-None-Match` creating v2, concurrency cap of 3 measured on the daemon log, 51 MB rejected without a request, create refused over an uploaded file, rename (prefill, move, source and destination listings, viewer follows), rename onto an existing file refused, rename disabled for folders, delete (listing, delete marker, navigate to parent, tree row gone), re-create after delete, create from the tree context menu.
+- Not covered by automation: a real folder drag-and-drop (Playwright cannot build a `DataTransfer` whose items return `webkitGetAsEntry()` entries; the `webkitdirectory` input path exercises the same relative-path handling), and the visual progress bar under a slow network.
+
+## Manual E2E
+
+1. `bun run packages/cli/src/index.ts daemon start` (or an already running local daemon) and `cd live && pnpm dev`.
+2. Connect the UI to the local daemon on `/credentials`.
+3. Folder view: New file `notes/sub/hello.md`, confirm it opens in edit mode and `agent-fs cat notes/sub/hello.md` prints `# hello`.
+4. Folder view: New folder `empty-dir`, confirm `agent-fs ls empty-dir` shows `.keep`.
+5. Drag a file and a folder onto the folder view, confirm progress, then `agent-fs ls` shows them. Drop the same file again and confirm the Replace prompt, then `agent-fs log /<path>` shows two versions (note the leading slash, see findings).
+6. Tree context menu: Rename `notes/sub/hello.md` to `notes/hello-renamed.md`, confirm `agent-fs ls notes`.
+7. Tree context menu: Delete `notes/hello-renamed.md`, confirm `agent-fs ls notes` no longer lists it and `agent-fs log notes/hello-renamed.md` shows the delete entry.
+8. Pick a file over 50 MB and confirm the UI rejects it without a request.
+
+## Findings outside this change (server, not fixed here)
+
+- **Path form mismatch between the raw route and the JSON ops route.** `PUT .../files/<path>/raw` runs `normalizePath` and stores version rows under `/drop.txt`; the JSON `write`, `mv`, `rm`, `stat`, `log` ops store and look up the path verbatim (`drop.txt`). After an upload from the UI, `stat drop.txt` reports `author: "unknown"` and `log drop.txt` is empty, while `log /drop.txt` shows the version. The UI's version history and author for uploaded files are therefore empty until the server normalizes both routes the same way (`packages/server/src/routes/files.ts:139` vs `packages/core/src/ops/versioning.ts:166-176`). The same divergence already exists between CLI calls with and without a leading slash (`docs/api-reference.md` uses `/hello.md`, `skills/agent-fs/SKILL.md` uses `docs/readme.txt`). The UI's `stat` pre-check keeps New file from overwriting such uploads, but the underlying split needs a server fix.
+- **Nested paths with literal slashes 404 on the raw route.** `PUT .../files/a/b.txt/raw` returns Hono's 404; only `files/a%2Fb.txt/raw` works. The CLI's `putRaw` uses `encodeURI`, which keeps slashes literal, so `agent-fs write sub/file.bin --file ...` may hit the same 404. Not verified for the CLI in this session.
+- **Text preview on local-storage daemons.** `useFileContent` fetches the `signed-url` result without an Authorization header. On the local adapter that URL is an authenticated app link and returns 401, so text files show "Content preview not available" and the pencil never appears. Pre-existing; the E2E above therefore ran against MinIO.
+
+## Review notes
+
+Two-axis review (Standards and Spec, both Opus sub-agents) on the staged diff.
+
+Fixed:
+- Upload store held one global scope; queued items now carry their own org, drive and client (Standards, Important).
+- `exists()` swallowed every error as "path is free"; now only NOT_FOUND counts (Standards, Important).
+- New file blocked forever after deleting the same path (delete-marker rows make `expectedVersion: 0` fail); handled by the stat re-check and unconditional retry (Spec, Important).
+- New file silently overwrote a file uploaded through the raw route; handled by the stat pre-check (Spec, Important).
+- Upload panel lived only in `FolderView`; moved to `FileBrowserPage` so progress and Replace/Skip stay reachable on a file view (Spec, Important).
+- Batch summary toast fired while conflicts were still parked (both axes, Minor).
+- Dead parameters (`ifMatch`, `expectedVersion` on `mv`/`rm`, `ready`), the duplicated `useMemo` scope helper, hand-rolled slash stripping in `FolderView`, the exported-but-internal `invalidateListings`, the permanently mounted dialog whose title flipped during the close animation, and the progress bar without `role="progressbar"` (Standards, Minor).
+
+Accepted as is:
+- Directories cannot be renamed or deleted (single-file `mv`/`rm`; documented above).
+- `# <name>` template for new Markdown files (from the research evaluation).
+- "Upload folder" button in addition to drag-and-drop (the research listed `webkitdirectory` as the input-side option).
+- Paths are not URL-encoded in the edit redirect, matching the existing `selectFile` behavior for names with `#` or `?`.

--- a/thoughts/taras/plans-yolo/2026-09-03-live-ui-file-mutations.md
+++ b/thoughts/taras/plans-yolo/2026-09-03-live-ui-file-mutations.md
@@ -94,3 +94,12 @@ Accepted as is:
 - `# <name>` template for new Markdown files (from the research evaluation).
 - "Upload folder" button in addition to drag-and-drop (the research listed `webkitdirectory` as the input-side option).
 - Paths are not URL-encoded in the edit redirect, matching the existing `selectFile` behavior for names with `#` or `?`.
+
+## Addendum (2026-09-03, follow-up in the same session)
+
+Taras asked for two icon dropdowns instead of four text buttons, tooltips, the same actions outside the folder view, and a look at org switching.
+
+- `live/src/components/file-mutations/FolderActions.tsx`: two icon buttons with tooltips. Plus opens New file / New folder; Upload opens Files / Folder. It owns the hidden pickers and the New dialog and takes a target folder. Used in the `FolderView` header (drop zone stays in `FolderView`) and in the sidebar tab row (`live/src/components/layout/Sidebar.tsx`), where it targets the open folder, or the open file's parent, else the drive root. The folder pane is now a labelled `region` ("Folder <path>") so tests and screen readers can address it.
+- **Org switch bug (root cause and fix).** `BrowserRouter` applies navigations inside `React.startTransition`, so a switcher click commits the context update first while the old file route is still mounted. `RouteParamsSync` had `orgId`/`driveId` in its effect deps, so that commit re-ran the URL sync and the stale URL params reverted the switch. The second click worked only because `/files` mounts no `RouteParamsSync`. Fix in `live/src/App.tsx`: the sync effects read the current context through a ref and run only when the URL params change. Companion changes: `OrgSwitcher` navigates to `/orgs/<id>/files/` so the redirect lands on the new org's drive root; `DriveSwitcher` and `DrivePicker` navigate to the picked drive's root so the URL matches the context (the picker used to change context without touching the URL).
+- Verification: `pnpm build` passes. E2E extended to 46 checks (dropdown items, tooltip, sidebar New from a file view, one-click org switch landing on `/file/~/<orgB>/<driveB>/`); 45 pass, the one failure remains the server path-form probe.
+- Pre-existing and untouched: the design hook flags two side-tab accent borders in `live/src/index.css` (lines 156 and 165). Not part of this change.

--- a/thoughts/taras/research/2026-09-03-ui-file-create-upload-rich-editor.md
+++ b/thoughts/taras/research/2026-09-03-ui-file-create-upload-rich-editor.md
@@ -1,0 +1,235 @@
+---
+date: 2026-09-03T14:50:47+0200
+researcher: Claude
+git_commit: 7e7360c20f8933cc7969aae5d140add3ac34150f
+branch: main
+repository: agent-fs
+topic: "Manual file creation, browser upload, and a rich editor in the live/ web UI"
+tags: [research, codebase, live-ui, upload, editor, monaco, markdown, raw-put]
+status: complete
+autonomy: critical
+last_updated: 2026-09-03
+last_updated_by: Claude
+---
+
+# Research: Manual file creation, browser upload, and a rich editor in the live/ web UI
+
+**Date**: 2026-09-03 14:50 CEST
+**Researcher**: Claude
+**Git Commit**: 7e7360c20f8933cc7969aae5d140add3ac34150f
+**Branch**: main
+
+## Research Question
+
+Taras asked: "I would like to have a way to create files manually in agent-fs ui + potentially an editor (rich one). Do some research on the easiest way we could achieve this, and the best solutions out there for it. Essentially would be nice to upload files to the ui directly, then be able to edit, etc."
+
+Two parts: (1) what the codebase already offers for writing files from a browser, and (2) which external editor and upload solutions fit. Because the question explicitly asks for "easiest way" and "best solutions", this document ends with an evaluation and a recommendation. Sections 1 to 4 are purely descriptive.
+
+## Summary
+
+The live UI already edits files. `TextViewer` wraps Monaco and has a working save path: `FileViewer` → `useFileSave` → `client.write` → `POST /orgs/:orgId/ops` with `op: "write"`. Markdown files get a source / split / preview edit view backed by the same Monaco editor and `MarkdownViewer`. What is missing is purely the "create" side: there is no new-file dialog, no upload input, no drag-and-drop, and no rename or delete in the tree context menu. Directories are implicit key prefixes, so there is no `mkdir` op either.
+
+The server already exposes everything a browser needs for creation and upload, with no server changes. The JSON `write` op accepts `expectedVersion: 0` as create-only. The binary route `PUT /orgs/:orgId/drives/:driveId/files/:path/raw` takes raw bytes up to 50 MB with a Bearer token, `If-None-Match: *` for create-only, and `X-Agent-FS-Message` for the version message. This is the exact wire format the CLI uses for `agent-fs write --file`. CORS defaults to `*`, and the hosted UI at live.agent-fs.dev already calls the daemon cross-origin, so uploads work from the browser today. Presigned upload URLs do not exist (only presigned GET), so files above 50 MB need new server work.
+
+For the rich editor, the constraint that matters is that Markdown on disk is the shared contract with agents writing through CLI and MCP. That rules out block-JSON editors (BlockNote, Notion-style) and favors markdown-native ones. Verified against npm on 2026-09-03: MDXEditor 4.2.3 (Lexical + MDAST, frontmatter plugin, source-mode fallback), Milkdown Crepe 7.22.1 (ProseMirror + remark), and TipTap 3.31.2 with the new official `@tiptap/markdown` extension are the three credible options. All are MIT and declare React 19 support. The recommendation below is a two-phase approach: ship create + upload + rename/delete on the existing write paths first, then add MDXEditor as a fourth edit mode for `.md` files while keeping Monaco as the source fallback. Taras confirmed these choices in review; see "Decisions" near the end.
+
+## Detailed Findings
+
+### 1. The live/ UI today
+
+**Stack and deploy.** Vite 8 + React 19 + Tailwind v4 + shadcn (`base-nova` style, `@base-ui/react`), react-router v7, react-query v5. Managed with pnpm, deployed to Vercel as a pure SPA (`live/vercel.json` rewrites everything to `index.html`, no API proxy). Hosted at live.agent-fs.dev (`README.md:170`). The API endpoint is per-credential, entered by the user on `/credentials`, stored in `localStorage` (`live/src/stores/credentials.ts:8-9`). There is no `VITE_API_URL`.
+
+**Auth from the browser.** Bearer token on every request (`live/src/api/client.ts:53,136`). No cookies or sessions. The server accepts `Authorization: Bearer <api_key>` only (`packages/server/src/middleware/auth.ts:8-45`).
+
+**Routes** (`live/src/App.tsx:172-197`):
+
+| Route | Page |
+|---|---|
+| `/credentials` | Connect or register |
+| `/file/~/:orgId/:driveId/*` | `FileBrowserPage`: folder listing (`FolderView`) when the path ends in `/`, else `FileViewer` |
+| `/detail/~/:orgId/:driveId/*` | `FileDetailPage`: full-page file view with version history |
+| `/sql/~/:orgId/:driveId` | SQL workbench |
+
+**API client** (`live/src/api/client.ts`). One generic RPC: `callOp(orgId, op, params, driveId)` → `POST /orgs/:orgId/ops` (`client.ts:82-86`). Ops used by the UI: `ls`, `stat`, `log`, `diff`, `recent`, `glob`, `fts`, `search`, `vec-search`, `sql`, `signed-url`, `read`, comment ops, and exactly one mutating file op: `write` (`client.ts:125-127`). `getRawUrl` / `fetchRaw` exist for `GET .../raw` (`client.ts:129-140`). There is no `putRaw`, no `mv`, `rm`, `cp` call anywhere in `live/src`.
+
+**Editing already exists.** `TextViewer` (`live/src/components/viewers/TextViewer.tsx:310`) renders `@monaco-editor/react`. With `editable` it shows a Save / Cancel toolbar (`TextViewer.tsx:257-294`), binds Cmd/Ctrl+S (`TextViewer.tsx:140-149`), and guards `beforeunload` when dirty (`TextViewer.tsx:81-88`). The trace:
+
+1. Pencil button in `ViewerHeader` → `setIsEditing(true)` (`FileViewer.tsx:154-157,769-786`).
+2. Markdown files render `MarkdownEditView` (`FileViewer.tsx:453-516`): Monaco source pane plus live `MarkdownViewer` preview, with `source` / `split` / `preview` modes and a draggable `SplitPane`. Other text files render `TextViewer` directly (`FileViewer.tsx:415-427`).
+3. `handleSave` (`FileViewer.tsx:165-174`) calls `save(content, stat?.currentVersion)` from `useFileSave` (`live/src/hooks/use-file-save.ts:13-58`), which calls `client.write(orgId, driveId, { path, content, expectedVersion })`.
+4. On success: toast `Saved (vN)`, `refetchStat()` on `["stat", orgId, driveId, path]`. Nothing invalidates `["ls", ...]` because no current write changes directory structure.
+
+**No create or upload surface.** Verified by search of `live/src`: no `<input type="file">`, no `onDrop` / `dragover`, no `FormData`. `new Blob` appears only for CSV and SVG export. The `FilePlus` icon in `FolderView.tsx:105` is decorative. The tree context menu (`live/src/components/file-tree/FileTreeNode.tsx:214-233`) has Open, Copy link, Download, Open in new tab. No Rename, Delete, New file, New folder.
+
+**Viewer dispatch** (`FileViewer.tsx:38-112`): extension sets pick `ImageViewer`, `VideoViewer`, `PdfViewer` (signed URL), `TablePreviewViewer` (csv/tsv/ndjson/parquet/xlsx via DuckDB-WASM or server `sql`), `DatabasePreviewViewer`, `FallbackViewer` for binaries, `TextViewer` for text, and `MarkdownViewer` for `md`, `mdx`, `txt`. `MarkdownViewer` uses react-markdown + remark-gfm + rehype-highlight, hand-parses YAML frontmatter (`MarkdownViewer.tsx:58-161`), and routes ```mermaid fences to `MermaidDiagram`. `shiki` is a dependency but is not imported anywhere.
+
+**State and cache keys.** `AuthProvider` owns `client`, `orgId`, `driveId` (`live/src/contexts/auth.tsx:32-168`). Folder listings are cached per path under `["ls", orgId, driveId, path]` (`FileTree.tsx:30`, `FileTreeNode.tsx:82`, `FolderView.tsx:46`). `["stat", orgId, driveId, path]` in `use-file-stat.ts:11`. File content is not in react-query (`use-file-content.ts` uses local state over a signed-URL fetch). Tree expansion is a `useSyncExternalStore` singleton (`live/src/stores/tree-expansion.ts`).
+
+**UI primitives available** (`live/src/components/ui/`): button, input, textarea, popover, tooltip, badge, spinner, dialog, resizable, sheet, toggle-group, kbd, dropdown-menu, context-menu, toaster. `CredentialDetailsDialog` is the existing dialog pattern to copy.
+
+### 2. Server write paths
+
+**JSON op route.** `POST /orgs/:orgId/ops` (`packages/server/src/routes/ops.ts:9`). `write` schema: `{ path, content: string, message?, expectedVersion? }` (`packages/core/src/ops/index.ts:48-56`). Content is a string, capped at 10 MB (`packages/core/src/ops/write.ts:15,65-71`). Other write ops on the same route: `edit`, `append`, `mv`, `cp`, `rm`, `revert`. All require the `editor` drive role (`packages/core/src/identity/rbac.ts:31-37`).
+
+**Create-only semantics.** `assertExpectedVersion` computes `currentVersion = nextVersion - 1`, so a file with no versions is at version 0 (`packages/core/src/ops/versioning.ts:92-109`). Passing `expectedVersion: 0` therefore means "must not exist" and throws `EditConflictError` otherwise. The raw route maps `If-None-Match: *` to the same `expectedVersion: 0` (`packages/server/src/routes/files.ts:141-149`).
+
+**Raw binary route.** `PUT /orgs/:orgId/drives/:driveId/files/:filePath{.+}/raw` (`files.ts:107`):
+
+- Body: raw bytes via `c.req.arrayBuffer()` (`files.ts:189`). Rejects `application/json` bodies with 415 (`files.ts:114-124`).
+- Headers: `Authorization: Bearer`, any non-JSON `Content-Type`, `If-Match: <version>` or `If-None-Match: *`, `X-Agent-FS-Message` plus `X-Agent-FS-Message-Encoding: percent` for non-Latin-1 messages (`files.ts:166-186`).
+- Response: `WriteResult` JSON `{ version, path, size, contentHash, deduped }` plus `ETag`, `X-Agent-FS-Version` headers (`files.ts:209-220`).
+- Limits: Hono `bodyLimit` 50 MB (`packages/server/src/app.ts:32`) and `MAX_RAW_FILE_SIZE` 50 MB (`write.ts:18`). Buffered, not streamed (`files.ts:106`).
+
+**Core write pipeline** (`write.ts:55-128`): compute S3 key, enforce cap, SHA-256, optional version check plus dedup short-circuit, `detectMimeType(path)` by extension only (`packages/core/src/ops/mime.ts:56-59`; browser-supplied `Content-Type` is not stored), `putObject`, `createVersion` in one SQLite transaction (`versioning.ts:152-258`), then synchronous FTS indexing and embedding scheduling for indexable text (`packages/core/src/ops/search-index.ts:52-79`). Every successful write creates a new `file_versions` row.
+
+**Directories are implicit.** No `mkdir` op exists in `opRegistry` (`ops/index.ts:47-323`). `ls` derives folders from `listObjects` common prefixes (`packages/core/src/ops/ls.ts:7-68`).
+
+**Presigned URLs.** Only presigned GET exists: `signed-url` op (`packages/core/src/ops/signed-url.ts:27-84`) → `getPresignedUrl` on the adapter (`packages/core/src/storage/adapter.ts:114-119`) → `GetObjectCommand` in `packages/core/src/s3/client.ts:215-229`. The local adapter throws `UnsupportedOperation` (`local-adapter.ts:240-247`). There is no `PutObjectCommand` presign anywhere.
+
+**CORS.** `config.server.cors.origins` defaults to `["*"]` (`packages/core/src/config.ts:112-114`), applied as Hono `cors()` before auth (`app.ts:23-29`). The hosted UI already relies on this for cross-origin `POST /ops` calls.
+
+**Rate limit.** 1200 requests per minute per API key by default (`packages/server/src/middleware/rate-limit.ts`, `config.ts:115-117`).
+
+**CLI wire format for binary upload** (`packages/cli/src/api-client.ts:91-161`, `packages/cli/src/commands/ops.ts:104-118`): `PUT .../raw` with `Content-Type: application/octet-stream`, Bearer, optional `If-Match`, `X-Agent-FS-Content-Hash`, percent-encoded `X-Agent-FS-Message`. A browser `fetch` with a `File` body reproduces this exactly. MCP exposes only the JSON ops (`packages/mcp/src/tools.ts:8-63`), so MCP clients cannot write binary today.
+
+**Docs.** `docs/api-reference.md:94-111` documents both raw routes with curl examples. `docs/openapi.json` carries per-op schemas.
+
+### 3. Prior thoughts on this topic
+
+- `thoughts/taras/plans/2026-03-19-signed-urls-fe-and-mime-types.md` moved viewers to signed GET URLs and listed "binary upload" as out of scope because `write` only accepts a string. The raw PUT route landed later and closes that gap.
+- `thoughts/taras/research/2026-08-21-sync-write-audit-raw-put.md` documents the synchronous cost of `PUT /raw` (FTS, hashing, WAL) and names presigned uploads as the future path for large binaries. Not implemented.
+- `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md` notes `files-sdk` offers `signedUploadUrl()` and that non-S3 adapters have no presign concept. Still an open decision.
+- `thoughts/taras/research/2026-04-27-live-ui-improvements.md` said "no Monaco or rich editor for text viewing yet". That is stale: Monaco editing shipped since.
+- `thoughts/taras/research/2026-03-15-document-comments.md`: comments are plain text and out of scope for rich text.
+- `~/.agentic-learnings.json` has no entries about the UI, upload, or editors.
+
+### 4. External options (verified against npm on 2026-09-03)
+
+| Package | Version | React peer | License | Last publish |
+|---|---|---|---|---|
+| `@tiptap/react` / `@tiptap/markdown` | 3.31.2 | `^17 \|\| ^18 \|\| ^19` | MIT | 2026-09-03 |
+| `@mdxeditor/editor` | 4.2.3 | `>= 18 \|\| >= 19` | MIT | 2026-08-27 |
+| `@milkdown/kit` / `@milkdown/crepe` / `@milkdown/react` | 7.22.1 | `*` | MIT | 2026-08-12 |
+| `@blocknote/shadcn` | 0.54.0 | `^18 \|\| ^19` | MPL-2.0 (XL packages GPL or commercial) | 2026-08-13 |
+| `platejs` / `@platejs/markdown` | 53.3.9 / 53.3.3 | `>=18` | MIT | 2026-08-24 |
+| `@lexical/markdown` | 0.50.0 | n/a | MIT | 2026-09-03 |
+| `react-dropzone` | 20.1.1 | `>= 18` | MIT | 2026-08-20 |
+| `@uppy/react` / `@uppy/aws-s3` | 6.0.0 | `^18 \|\| ^19` | MIT | 2026-08-26 |
+| `@codemirror/lang-markdown` | 6.5.2 | n/a | MIT | 2026-08-04 |
+
+**Rich Markdown editors, by markdown fidelity.**
+
+- **MDXEditor** (Lexical + MDAST via remark). Purpose-built for editing `.md` and `.mdx` files. Plugins for GFM tables, frontmatter (dedicated `frontmatterPlugin`), code blocks (CodeMirror inside), images, links. `onError({ error, source })` fires when MDAST cannot parse the input, and `diffSourcePlugin` gives a source-mode escape hatch so users can fix unsupported content. `onChange(markdown, initialMarkdownNormalize)` flags the first normalization pass. `suppressHtmlProcessing` exists for raw HTML. Ships its own CSS, not shadcn. Sources: mdxeditor.dev docs (overview, error-handling, diff-source).
+- **Milkdown Crepe** (ProseMirror with remark as the document model). Typora-like. `@milkdown/crepe` is the batteries-included editor: toolbar, slash menu, tables, CodeMirror code blocks, LaTeX, placeholder, several themes. `getMarkdown()` and `markdownUpdated` listener. React binding is `MilkdownProvider` + `useEditor`. Frontmatter is not a Crepe feature; it would need a remark-frontmatter plugin or strip-and-reattach around the editor. No shadcn integration. Sources: milkdown.dev docs (api/crepe, recipes/react).
+- **TipTap 3 + `@tiptap/markdown`** (ProseMirror, HTML/JSON schema, markdown as a converter). The official markdown extension is weeks old and supersedes the community `tiptap-markdown` (0.9.0, about a year stale). Load with `setContent(md, { contentType: "markdown" })`, save with `editor.getMarkdown()`. Parses embedded HTML through extension `parseHTML` rules. GFM tables need the Table extensions and have an open serialization bug (ueberdosis/tiptap#5750). No frontmatter support. Best shadcn story via community registries: Aslam97/minimal-tiptap (installable with `npx shadcn add`), shadcn-labs/editorcn. Sources: tiptap.dev markdown docs, release notes.
+- **Plate 53** (Slate, remark pipeline with `remark-gfm` and `remark-frontmatter` opt-in). Most shadcn-native UI, heaviest bundle, largest surface area.
+- **BlockNote 0.54** (TipTap-based, block JSON schema). Markdown is import/export only, documented as a CommonMark+GFM subset with no frontmatter and a known table export bug (TypeCellOS/BlockNote#1377).
+- **Lexical alone** (22 KB core). A framework, not an editor. MDXEditor is the packaged answer on top of it.
+- **Novel**: a Next.js template around TipTap with AI autocomplete, not a library.
+
+**Code editor.** Monaco 0.55 is already installed and working. CodeMirror 6 is roughly 50 to 300 KB gzip depending on languages, needs no worker setup, and is what Obsidian and HedgeDoc 2 use for markdown "live preview" over raw text. Switching is not needed for this feature.
+
+**Upload libraries.** `react-dropzone` 20.1.1 is small, MIT, React 19 ready, and handles the drop zone, click-to-open, and multiple files. Folder drops require `DataTransferItem.webkitGetAsEntry()` traversal (implemented in all major browsers despite the prefix) or `webkitdirectory` on the input. The File System Access API remains Chromium-only. Uppy 6 adds a dashboard, progress, retry, and presigned or multipart S3 uploads; it is more than the daemon can use today because there is no presigned PUT. FilePond's React adapter has not been published in about two years.
+
+**Direct-to-S3 patterns.** Presigned PUT is the simplest, presigned POST enforces size and type policies at the bucket, multipart is required above 5 GB and recommended above about 100 MB. Bucket CORS must allow `PUT` from the UI origin and expose `ETag` for multipart. MinIO supports the same API surface but has a history of CORS preflight bugs on presigned flows (minio/minio#10002, #11111, #15693), so test explicitly. Proxying through the API is the right default when writes must go through the same hash, version, and index pipeline as CLI and MCP writes, which is the agent-fs case.
+
+**Prior art.** Nextcloud Text uses TipTap over plain Markdown files on disk. Obsidian uses CodeMirror 6 live preview over raw Markdown. github.dev is Monaco. Outline and Notion store their own JSON and only export Markdown, which is the model to avoid here. FileBrowser (filebrowser/filebrowser) was archived on 2026-09-01; Filestash remains active and delegates office docs to Collabora.
+
+## Evaluation and recommendation
+
+The question asks for the easiest path and the best solutions, so this section goes beyond documentation.
+
+### Easiest path: creation and upload need zero server changes
+
+**New file.** A dialog (reuse `dialog.tsx` + `input.tsx`, copy `CredentialDetailsDialog`) that takes a path relative to the current folder and calls `client.write({ path, content: template, expectedVersion: 0, message: "Created in UI" })`. `expectedVersion: 0` makes it create-only, so an existing file returns a conflict instead of a silent overwrite. Then invalidate `["ls", orgId, driveId, parentPath]`, navigate to the file route, and enter edit mode. For `.md` a one-line `# <name>` template avoids a zero-byte file.
+
+**New folder.** Because directories are implicit, two mechanisms cover it (decided below). The new-file dialog accepts nested paths like `sub/dir/name.md`, GitHub-style, so a folder appears as soon as its first file is written. A separate "New folder" action writes `<folder>/.keep` through the same `write` op so empty folders persist and show up in `ls`. Agents see the `.keep` placeholder in listings; that trade-off is accepted.
+
+**Upload.** Add `putRaw(orgId, driveId, path, file, { ifNoneMatch, message })` to `live/src/api/client.ts`, mirroring the CLI's `putRaw`. A browser `fetch` with `method: "PUT"`, `body: file`, `Content-Type: application/octet-stream` (the server ignores it for storage and detects MIME by extension), and the Bearer header is the whole transport. Use `react-dropzone` on `FolderView` and the tree for drag-and-drop plus a hidden `<input type="file" multiple>`, and traverse `webkitGetAsEntry()` for dropped folders so relative paths land under the current folder. Send `If-None-Match: *` first; on a conflict, prompt "Replace existing file?" and retry with `If-Match: <version>`. Limit concurrency to 3 or 4 uploads to stay under the 1200 requests per minute rate limit on bulk drops. Progress bars need `XMLHttpRequest` because `fetch` has no upload progress; per-file spinners are enough for a first cut. Files above 50 MB fail with the server's body limit, so show that limit in the UI.
+
+**Rename, move, delete.** `mv` and `rm` already exist server-side with the editor role and the UI does not call them. Adding Rename and Delete to the existing context menu (`FileTreeNode.tsx:214-233`) is cheap, and `rm` is a soft delete with a delete-marker version, so `revert` still works. This is adjacent to the ask, not part of it, but "create files manually" implies being able to clean them up.
+
+**Cache invalidation.** Every create, upload, rename, and delete must invalidate `["ls", orgId, driveId, <parent>]` for both source and destination parents. Nothing does this today because no existing write touches structure.
+
+### Rich editor: keep Monaco, add one markdown-native WYSIWYG for `.md`
+
+The existing source / split / preview mode is already a good markdown editing experience and costs nothing. A WYSIWYG mode is an upgrade, not a blocker. If it is added:
+
+1. **First pick: MDXEditor 4.2.3.** It is the only option designed around `.md` files as the source of truth with frontmatter as a first-class plugin, and it has a documented failure mode (`onError` plus source mode) for markdown it cannot parse. That matters because agents write arbitrary Markdown and an editor that throws on unknown syntax would block editing those files. Cost: its CSS needs theming to match the shadcn dark and light themes, and Lexical plus CodeMirror add a few hundred KB gzip to the `.md` edit route (lazy-load it).
+2. **Runner-up: Milkdown Crepe 7.22.1** if a Typora feel is preferred. Remark is the document model, so round-trips are clean, but frontmatter needs custom handling and there is no shadcn kit.
+3. **If shadcn-native look wins: TipTap 3.31 + `@tiptap/markdown` via minimal-tiptap.** Best ecosystem and styling fit, but the markdown extension is brand new, tables have an open serialization bug, and frontmatter must be stripped before load and re-attached on save.
+4. **Avoid BlockNote and Plate for this use case.** BlockNote's block JSON is lossy for frontmatter and raw HTML. Plate is the heaviest option and its strengths (collaborative rich docs) are not the requirement.
+
+Two rules apply to any WYSIWYG here. Keep Monaco source mode one click away as the escape hatch, exactly as MDXEditor's diff-source plugin does. And guard against normalization noise: every save creates a version, so compare the serialized markdown with the original and skip the write when they are byte-equal, and warn the user the first time the editor reformats an agent-written file (MDXEditor's `initialMarkdownNormalize` flag exposes this directly).
+
+### Large uploads later, only if needed
+
+Anything above 50 MB requires server work: a `signed-upload-url` op that presigns `PutObjectCommand`, a `finalize` op that hashes, creates the version row, and indexes, bucket CORS for the UI origin, and a fallback to `PUT /raw` on the local adapter. Uppy's `@uppy/aws-s3` would then be the client. This is the path the 2026-08-21 audit already anticipated. It is a separate feature and should not gate phase 1.
+
+### Suggested phasing
+
+| Phase | Scope | Server changes | New deps |
+|---|---|---|---|
+| 1 | New file dialog (nested paths allowed), "New folder" via `.keep`, upload via raw PUT with drag-and-drop and a 50 MB cap, rename and delete in context menu, `ls` invalidation | none | `react-dropzone` |
+| 2 | MDXEditor as an opt-in `rich` mode in `MarkdownEditView` behind the existing pencil button, lazy-loaded, themed to shadcn, with normalization guard | none | `@mdxeditor/editor` |
+| 3 | Presigned upload for files above 50 MB | presign PUT + finalize op + CORS | `@uppy/*` optional |
+
+Per the project's release checklist, phase 1 touches no core ops, CLI, or MCP, so the skill and E2E updates are not required. A version bump through `./scripts/release.sh` is still needed if the UI ships with the daemon release train.
+
+## Code References
+
+| File | Line | Description |
+|------|------|-------------|
+| `live/src/api/client.ts` | 82-86 | `callOp` → `POST /orgs/:orgId/ops` |
+| `live/src/api/client.ts` | 125-127 | `write()`, the only mutating file call in the UI |
+| `live/src/api/client.ts` | 129-140 | `getRawUrl` / `fetchRaw` for `GET .../raw` |
+| `live/src/hooks/use-file-save.ts` | 13-58 | Save hook with abort and error state |
+| `live/src/components/viewers/FileViewer.tsx` | 154-174 | Enter edit, `handleSave`, `refetchStat` |
+| `live/src/components/viewers/FileViewer.tsx` | 397-430 | Edit-mode dispatch: `MarkdownEditView` vs `TextViewer` |
+| `live/src/components/viewers/FileViewer.tsx` | 453-516 | `MarkdownEditView` source / split / preview |
+| `live/src/components/viewers/TextViewer.tsx` | 310-318 | Monaco `Editor`, `readOnly = !editable \|\| isSaving` |
+| `live/src/components/viewers/MarkdownViewer.tsx` | 58-161 | Hand-parsed YAML frontmatter |
+| `live/src/components/file-tree/FileTreeNode.tsx` | 214-233 | Context menu items (no rename or delete) |
+| `live/src/components/folder-view/FolderView.tsx` | 46, 105 | `["ls", ...]` query, decorative `FilePlus` empty state |
+| `live/src/contexts/auth.tsx` | 92-94, 107-108 | Existing `["ls"]` invalidation on org or drive switch |
+| `live/src/stores/credentials.ts` | 8-9 | localStorage keys for endpoint and API key |
+| `packages/server/src/routes/files.ts` | 107-220 | `PUT .../raw` handler, headers, response |
+| `packages/server/src/routes/files.ts` | 141-149 | `If-None-Match: *` → `expectedVersion: 0` |
+| `packages/server/src/routes/ops.ts` | 9 | `POST /orgs/:orgId/ops` dispatch |
+| `packages/server/src/app.ts` | 23-32 | CORS (`*` default) and 50 MB body limit |
+| `packages/server/src/middleware/auth.ts` | 8-45 | Bearer-only auth |
+| `packages/core/src/ops/index.ts` | 48-56 | `write` op schema |
+| `packages/core/src/ops/write.ts` | 15, 18, 55-128 | Size caps and `writeInternal` pipeline |
+| `packages/core/src/ops/versioning.ts` | 92-109 | `assertExpectedVersion` (version 0 = does not exist) |
+| `packages/core/src/ops/mime.ts` | 56-59 | Extension-only MIME detection |
+| `packages/core/src/ops/signed-url.ts` | 27-84 | Presigned GET only |
+| `packages/core/src/s3/client.ts` | 215-229 | `GetObjectCommand` presign, no PUT presign |
+| `packages/cli/src/api-client.ts` | 91-161 | CLI `putRaw` wire format to replicate in the browser |
+| `docs/api-reference.md` | 94-111 | Raw route documentation |
+
+## Decisions (Taras, 2026-09-03)
+
+Resolved in review so a yolo plan can be written in a new session from this document.
+
+- **Rich editor: MDXEditor.** Target `@mdxeditor/editor` 4.2.3 for `.md` files. Monaco stays for every other text type and as the source escape hatch.
+- **New folder: both approaches.** The new-file dialog accepts nested paths like `sub/dir/name.md`, and a separate "New folder" action writes `<folder>/.keep` so empty folders persist and show in `ls`. Agents will see the `.keep` placeholder; that is accepted.
+- **WYSIWYG is opt-in.** The existing pencil edit button stays the single entry point into edit mode. The rich editor is a fourth mode next to source / split / preview inside `MarkdownEditView`, remembered per user in localStorage. Monaco source remains the default.
+- **Upload size: 50 MB cap via raw PUT.** No server changes for the first release. The UI shows the cap and rejects larger files up front. Presigned upload stays a later phase.
+
+## Open Questions
+
+Items that are tasks for the plan rather than decisions:
+
+- MDXEditor ships its own CSS variables rather than Tailwind classes. The plan needs a theming step to match the shadcn dark and light themes.
+- Bundle sizes for MDXEditor were not measured in this session. Measure with a Vite build and keep the `.md` rich-edit route lazy-loaded.
+
+## Appendix
+
+- **Architecture notes**: The UI is stateless and talks to any daemon cross-origin with a Bearer key, so every create and upload path must work with the default `cors.origins: ["*"]` and no cookies. All writes converge on `writeInternal`, which is why proxying uploads through the daemon (rather than presigned PUT) keeps versions, hashes, and search consistent with CLI and MCP writes.
+- **Historical context (from thoughts/)**: the 2026-03-19 signed-URL plan deferred binary upload; the raw PUT route later removed that blocker. The 2026-08-21 audit is the reference for the synchronous cost of large raw writes and for the presigned-upload follow-up.
+- **Related research**:
+  - `thoughts/taras/research/2026-08-21-sync-write-audit-raw-put.md`: raw PUT performance and presigned upload as a future path.
+  - `thoughts/taras/research/2026-04-27-live-ui-improvements.md`: UI primitives and keyboard infrastructure (partially stale on editing).
+  - `thoughts/taras/research/2026-06-25-files-sdk-storage-adapters.md`: `signedUploadUrl` in files-sdk and non-S3 adapter limits.
+  - `thoughts/taras/plans/2026-03-19-signed-urls-fe-and-mime-types.md`: signed GET migration for viewers.
+- **External sources**: tiptap.dev markdown docs and release notes; mdxeditor.dev docs (overview, error-handling, diff-source); milkdown.dev docs (api/crepe, recipes/react); npm registry metadata queried 2026-09-03; ueberdosis/tiptap#5750; TypeCellOS/BlockNote#1377; minio/minio#10002, #11111, #15693; MDN `DataTransferItem.webkitGetAsEntry`; filebrowser/filebrowser archive notice (2026-09-01).


### PR DESCRIPTION
## Summary

The live UI can now create, upload, rename and delete files. Everything runs on existing server routes; nothing under `packages/` changed.

- **New file / New folder.** Icon dropdown (Plus) in the folder view header and in the sidebar tab row, plus items in the tree context menu. Accepts nested paths like `sub/dir/name.md`, writes create-only (`expectedVersion: 0`), then opens the file straight into the existing edit mode via `?edit=1`. New folder writes `<folder>/.keep`.
- **Upload.** The folder pane is a react-dropzone drop zone (folders keep their structure via `webkitGetAsEntry`). The Upload dropdown offers Files / Folder pickers. Each file goes to `PUT .../files/<path>/raw` over `XMLHttpRequest` with Bearer, `application/octet-stream` and `If-None-Match: *` first; a 409 shows Replace / Skip inline. Files over 50 MB are rejected client-side, at most 3 uploads run at once, and a floating panel shows per-file progress and survives navigation.
- **Rename / Delete.** Tree context menu items for files, using `mv` and `rm`. Rename edits the full path (so it doubles as move) and refuses an existing destination.
- **Cache.** Every mutation invalidates the `ls` chain from the drive root to the parent, the file's stat, and the recent strip.
- **Guards.** New file runs `stat` before writing so it never overwrites a file uploaded through the raw route (whose version rows live under the `/path` form), and can re-create a path after `rm` (delete-marker rows would otherwise make `expectedVersion: 0` fail).

Also fixes a pre-existing bug: **switching org or drive from a file view needed two clicks.** `BrowserRouter` applies navigations inside a transition, so a switcher click committed the new org while the old file route was still mounted; `RouteParamsSync` had the context org in its effect deps, re-ran, and the stale URL params reverted the switch. The sync now runs only when URL params change, and the org / drive switchers land on the picked drive root.

## Testing

- `cd live && pnpm build`, plus the root `typecheck`, `build`, `test` and OpenAPI freshness checks pass locally.
- Playwright browser E2E (kept out of the repo; it borrows `playwright-core` from another checkout) against an isolated MinIO-backed daemon: 45 of 46 checks pass. Covered: nested create opening edit mode, create conflict, `.keep`, tree reveal, exact PUT headers and path encoding, picker and drop uploads, folder upload keeping structure, Replace creating v2 without `If-None-Match`, concurrency cap of 3 measured on the daemon log, 51 MB rejected with no request, rename and delete in listings and the viewer, re-create after delete, dropdown items and tooltips, sidebar New from a file view, one-click org switch.
- The single failing check is a deliberate probe of a server inconsistency (below).
- Not automatable: a real folder drag (Playwright cannot fake `webkitGetAsEntry` entries). Worth one manual drag.

## Server findings (not fixed here)

1. **Path form mismatch.** The raw PUT route normalizes to `/path` while the JSON ops store paths verbatim, so `log drop.txt` is empty after a UI upload and `log /drop.txt` shows the version. Uploaded files show no history or author in the UI until both routes agree (`packages/server/src/routes/files.ts:139` vs `packages/core/src/ops/versioning.ts`).
2. **Nested paths 404 on the raw route** unless the whole path is one encoded segment (`a%2Fb.txt`). The CLI's `putRaw` uses `encodeURI`, so `agent-fs write sub/file.bin --file` may hit the same 404.
3. **Local-storage daemons cannot preview text in the UI** (signed-url app link returns 401 without a Bearer header), so the pencil never appears there.

Plan, decisions and review notes: `thoughts/taras/plans-yolo/2026-09-03-live-ui-file-mutations.md`.
